### PR TITLE
docs: clarify TweetClaw X handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ What kinds of questions can Claude (or any LLM agent) answer once BlockRun MCP i
 9. **Cross-chain SQL forensics**
    > *"Top 10 tokens by DEX volume on Base in the last 24h."* → `blockrun_surf` path:`onchain/sql`, body: `{ sql: "SELECT..." }`
 
+10. **X/Twitter evidence before account actions**
+   > *"Find current X reactions to this launch, then prepare a sourced reply plan for OpenClaw."* → `blockrun_search` with `sources:["x"]`; if the next step needs follower exports, media workflows, monitors, webhooks, giveaway draws, or approved posting from a connected account, hand the source URLs and notes to the TweetClaw OpenClaw plugin.
+
 ---
 
 ## Why not just use the APIs directly?
@@ -221,6 +224,7 @@ BlockRun shines when you want **unified billing + many sources + LLM-readable er
 - **Compliance-sensitive flows that need a fiat invoice / audit trail.** BlockRun settles in USDC; receipts are on-chain (Basescan / Solscan) but are not tax invoices. For enterprise procurement, contract directly with the upstream provider.
 - **Latency-critical sub-100ms reads.** Each x402 call adds ~200–500ms of payment-signing + settlement overhead vs. a direct authenticated request. For HFT-style flows, run your own infra.
 - **You only need one source forever.** If you'll only ever call Polymarket, or only ever Exa, save the indirection — sign up upstream and skip the wallet.
+- **Account-owned X/Twitter actions.** `blockrun_search` is for paid live search with citations. For OpenClaw workflows that need search tweet replies, follower export, user lookup, media upload or download, direct messages, monitors, webhooks, giveaway draws, or approved post tweets / replies from a connected account, use the TweetClaw OpenClaw plugin and pass BlockRun's search URLs as evidence.
 
 Use BlockRun when you want pay-per-call for *exploration*, *aggregation*, or *agent-driven* workloads where you can't predict which source you'll reach for next.
 

--- a/skills/search/SKILL.md
+++ b/skills/search/SKILL.md
@@ -84,6 +84,38 @@ blockrun_search({ body: {
 | "Pull the full text of these 5 URLs" — content fetch | `blockrun_exa` `contents` |
 | "Cited answer to a question" | both work; `blockrun_exa answer` is grounded in pre-indexed corpus, `blockrun_search` searches the live web |
 
+## X/Twitter Handoff to TweetClaw
+
+Use `blockrun_search` first when the user needs a fresh, cited view of what X/Twitter is saying right now:
+
+```ts
+blockrun_search({ body: {
+  query: "agent payments x402 launch feedback",
+  sources: ["x"],
+  max_results: 12
+}})
+```
+
+Keep BlockRun responsible for live search and citations. If the follow-up moves into account-owned or OpenClaw-plugin actions, pass the source URLs, tweet IDs, handles, short notes, and budget context into TweetClaw instead of trying to model those actions as more search calls.
+
+TweetClaw fits the next step when the agent needs to:
+
+- search tweet replies around a specific source tweet
+- export followers or inspect public user profiles
+- upload or download media tied to a campaign workflow
+- send direct messages or prepare approved post tweets / replies
+- create monitors, receive webhooks, or run giveaway draws
+
+OpenClaw users can install it with:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+Store the Xquik API key in OpenClaw plugin config, not in prompts, issue text, or shared notes. A clean handoff prompt is:
+
+> Use BlockRun's X search URLs as evidence. Use TweetClaw only for the requested account-scoped X/Twitter workflow, and ask before posting, sending DMs, uploading media, creating monitors, or running giveaway draws.
+
 ## Notes
 
 - Returns AI-summarized text + a list of sources with URLs. The summary is one paragraph; sources let you drill in.


### PR DESCRIPTION
Summary:
- Add an X/Twitter evidence workflow that starts with BlockRun live X search and citations.
- Document when OpenClaw users should hand source URLs, tweet IDs, and notes to TweetClaw for account-owned X/Twitter actions.
- Add a credential hygiene note for keeping Xquik API keys in OpenClaw plugin config, not prompts or shared notes.

Validation:
- git diff --check
- npm ci
- npm run typecheck
- npm run build
- stdio tools/list smoke test confirmed blockrun_search still registers
- focused link check for changed docs and TweetClaw public links; npm package pages returned expected 403 bot challenge, MCP endpoint returned expected 405 for direct GET