### PR TITLE
fix: handle CLI metadata flags before startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,40 @@ const { version: VERSION } = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
 ) as { version: string };
 
+function printHelp(): void {
+  process.stdout.write(
+    [
+      "BlockRun MCP Server",
+      "",
+      "Usage:",
+      "  blockrun-mcp [options]",
+      "",
+      "Options:",
+      "  -h, --help       Show this help message",
+      "  -v, --version    Print the package version",
+      "",
+      "When no metadata flag is provided, the server starts on stdio for MCP clients.",
+      "",
+    ].join("\n"),
+  );
+}
+
+function handleCliMetadataFlags(argv: string[]): void {
+  const args = argv.slice(2);
+
+  if (args.includes("--version") || args.includes("-v")) {
+    process.stdout.write(`${VERSION}\n`);
+    process.exit(0);
+  }
+
+  if (args.includes("--help") || args.includes("-h")) {
+    printHelp();
+    process.exit(0);
+  }
+}
+
+handleCliMetadataFlags(process.argv);
+
 async function checkForUpdate() {
   try {
     const resp = await fetch("https://registry.npmjs.org/@blockrun/mcp/latest", {


### PR DESCRIPTION
## Summary
- handle --version/-v and --help/-h before starting the stdio MCP server
- print metadata to stdout and exit cleanly for CLI/package inspection workflows
- keep normal MCP stdio startup unchanged when no metadata flag is provided

## Reproduction
The published package starts the MCP server when metadata flags are requested:

npm exec --yes --package=@blockrun/mcp -- blockrun-mcp --version
npm exec --yes --package=@blockrun/mcp -- blockrun-mcp --help

Actual behavior: stderr includes BlockRun MCP Server started (v0.21.1) and the command enters server mode.
Expected behavior: --version prints the package version, --help prints usage, and both exit without starting the server.

## Verification
- npm ci
- npm run build
- npm run typecheck
- node dist/index.js --version
- node dist/index.js -v
- node dist/index.js --help
