### PR TITLE
docs(readme): link back to blockrun.ai/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ Wallet auto-created. Fund with $5 USDC. Ask Claude anything.
 
 ---
 
+## Documentation
+
+Full docs: **https://blockrun.ai/docs**
+
+- MCP tools & setup: https://blockrun.ai/docs/mcp/blockrun-mcp
+- All BlockRun SDKs & APIs: https://blockrun.ai/docs
+
+---
+
 ## What changes
 
 Before BlockRun, Claude can't answer:


### PR DESCRIPTION
Adds a **Documentation** section to the README linking back to the docs site.

The README previously linked only to the homepage (blockrun.ai) and to npm/X — there was no link to the docs site. This adds a short section near the top (after the intro, before "What changes"):

- Full docs: https://blockrun.ai/docs
- MCP tools & setup: https://blockrun.ai/docs/mcp/blockrun-mcp
- All BlockRun SDKs & APIs: https://blockrun.ai/docs

No code, install commands, or other content changed.