### PR TITLE
feat: tool profiles + inline image previews + spend confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,24 @@ claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest
 The `-s user` flag installs globally (available in every project). The `--` separator
 ensures `-y` is passed to `npx`, not parsed by `claude mcp add`.
 
-**Media-only build** — image/video/audio focused, fewer tools loaded into context. Add
-`--profile media` to expose only `blockrun_image`, `blockrun_video`, `blockrun_realface`,
-`blockrun_music`, `blockrun_speech`, `blockrun_wallet`, and `blockrun_models`:
+**Tool profiles** — expose a trimmed tool set so the client loads fewer schemas into
+context. Pass `--profile <name>` (or set `BLOCKRUN_MCP_PROFILE`); omit it for the full set.
+
+| Profile | Tools |
+|---------|-------|
+| `full` *(default)* | everything |
+| `media` | `wallet` `models` `image` `video` `realface` `music` `speech` |
+| `trading` | `wallet` `price` `dex` `markets` `surf` `defi` `rpc` |
+| `research` | `wallet` `models` `chat` `search` `exa` `surf` |
+| `chat` | `wallet` `models` `chat` |
+
 ```bash
+# e.g. a media-only install
 claude mcp add blockrun-media -s user -- npx -y @blockrun/mcp@latest --profile media
+# or a trading-only install
+claude mcp add blockrun-trading -s user -- npx -y @blockrun/mcp@latest --profile trading
 ```
-Equivalent via env: `BLOCKRUN_MCP_PROFILE=media`. Omit the flag (or use `--profile full`)
-for the complete tool set.
+Equivalent via env: `BLOCKRUN_MCP_PROFILE=trading`. An unknown profile name falls back to `full`.
 
 **Claude Desktop** — add to `claude_desktop_config.json`:
 ```json

--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest
 The `-s user` flag installs globally (available in every project). The `--` separator
 ensures `-y` is passed to `npx`, not parsed by `claude mcp add`.
 
+**Media-only build** — image/video/audio focused, fewer tools loaded into context. Add
+`--profile media` to expose only `blockrun_image`, `blockrun_video`, `blockrun_realface`,
+`blockrun_music`, `blockrun_speech`, `blockrun_wallet`, and `blockrun_models`:
+```bash
+claude mcp add blockrun-media -s user -- npx -y @blockrun/mcp@latest --profile media
+```
+Equivalent via env: `BLOCKRUN_MCP_PROFILE=media`. Omit the flag (or use `--profile full`)
+for the complete tool set.
+
 **Claude Desktop** — add to `claude_desktop_config.json`:
 ```json
 {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { initializeMcpServer } from "./mcp-handler.js";
 import { warnOnLeakedKeys } from "./utils/key-leak-scanner.js";
+import { PROFILES } from "./profiles.js";
 
 // Read version from package.json so it can never drift from the published version.
 const { version: VERSION } = JSON.parse(
@@ -30,7 +31,7 @@ function printHelp(): void {
       "Options:",
       "  -h, --help       Show this help message",
       "  -v, --version    Print the package version",
-      "      --profile <name>  Tool profile to expose: full (default) | media",
+      `      --profile <name>  Tool profile to expose: ${Object.keys(PROFILES).join(" | ")} (default: full)`,
       "",
       "When no metadata flag is provided, the server starts on stdio for MCP clients.",
       "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ function printHelp(): void {
       "Options:",
       "  -h, --help       Show this help message",
       "  -v, --version    Print the package version",
+      "      --profile <name>  Tool profile to expose: full (default) | media",
       "",
       "When no metadata flag is provided, the server starts on stdio for MCP clients.",
       "",
@@ -79,11 +80,14 @@ async function main() {
     version: VERSION,
   });
 
-  initializeMcpServer(server);
+  const { profile, tools } = initializeMcpServer(server);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error(`BlockRun MCP Server started (v${VERSION}) — stdio transport`);
+  const profileNote = profile === "full"
+    ? `${tools.length} tools`
+    : `profile "${profile}" — ${tools.length} tools: ${tools.join(", ")}`;
+  console.error(`BlockRun MCP Server started (v${VERSION}) — stdio transport — ${profileNote}`);
 
   // Check for updates in background (non-blocking)
   checkForUpdate();

--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -22,60 +22,89 @@ import { registerPhoneTool } from "./tools/phone.js";
 import { registerSurfTool } from "./tools/surf.js";
 import { registerRpcTool } from "./tools/rpc.js";
 import { registerDefiTool } from "./tools/defi.js";
-export function initializeMcpServer(server: McpServer): void {
+import { resolveTools, type ToolName } from "./profiles.js";
+
+/**
+ * Initialize the MCP server. The active tool `profile` (resolved from
+ * `--profile` / BLOCKRUN_MCP_PROFILE, defaulting to "full") decides which
+ * tools are registered, so one published package can expose a trimmed set
+ * (e.g. media-only) without loading the excluded tools' schemas into the
+ * client's context. Returns the canonical profile name + registered tools
+ * for startup logging.
+ */
+export function initializeMcpServer(
+  server: McpServer,
+  profileArgs?: { argv?: string[]; env?: NodeJS.ProcessEnv },
+): { profile: string; tools: ToolName[] } {
   const budget: BudgetState = { limit: null, spent: 0, calls: 0, agents: new Map() };
   const modelCache: ModelCache = { models: null };
 
-  // Register all tools
-  registerWalletTool(server, budget);
-  registerChatTool(server, budget);
-  registerModelsTool(server, modelCache);
-  registerImageTool(server, budget);
-  registerMusicTool(server, budget);
-  registerSpeechTool(server, budget);
-  registerVideoTool(server, budget);
-  registerRealfaceTool(server, budget);
-  registerSearchTool(server, budget);
-  registerExaTool(server, budget);
-  registerMarketsTool(server, budget);
-  registerPriceTool(server, budget);
-  registerDexTool(server);
-  registerModalTool(server, budget);
-  registerPhoneTool(server, budget);
-  registerSurfTool(server, budget);
-  registerRpcTool(server, budget);
-  registerDefiTool(server, budget);
+  const { profile, tools } = resolveTools(profileArgs?.argv, profileArgs?.env);
 
-  // Register resources
-  server.registerResource(
-    "wallet",
-    "blockrun://wallet",
-    { description: "Wallet address and status", mimeType: "application/json" },
-    async () => {
-      const info = await getWalletInfo();
-      return {
-        contents: [{
-          uri: "blockrun://wallet",
-          mimeType: "application/json",
-          text: JSON.stringify(info, null, 2),
-        }],
-      };
-    }
-  );
+  // One registrar per tool — only the ones in the active profile run, so a
+  // trimmed profile never advertises (or loads schemas for) excluded tools.
+  const registrars: Record<ToolName, () => void> = {
+    wallet: () => registerWalletTool(server, budget),
+    chat: () => registerChatTool(server, budget),
+    models: () => registerModelsTool(server, modelCache),
+    image: () => registerImageTool(server, budget),
+    music: () => registerMusicTool(server, budget),
+    speech: () => registerSpeechTool(server, budget),
+    video: () => registerVideoTool(server, budget),
+    realface: () => registerRealfaceTool(server, budget),
+    search: () => registerSearchTool(server, budget),
+    exa: () => registerExaTool(server, budget),
+    markets: () => registerMarketsTool(server, budget),
+    price: () => registerPriceTool(server, budget),
+    dex: () => registerDexTool(server),
+    modal: () => registerModalTool(server, budget),
+    phone: () => registerPhoneTool(server, budget),
+    surf: () => registerSurfTool(server, budget),
+    rpc: () => registerRpcTool(server, budget),
+    defi: () => registerDefiTool(server, budget),
+  };
 
-  server.registerResource(
-    "models",
-    "blockrun://models",
-    { description: "Available AI models with pricing", mimeType: "application/json" },
-    async () => {
-      const models = await loadModels(getClient(), modelCache);
-      return {
-        contents: [{
-          uri: "blockrun://models",
-          mimeType: "application/json",
-          text: JSON.stringify(models, null, 2),
-        }],
-      };
-    }
-  );
+  for (const [name, register] of Object.entries(registrars) as [ToolName, () => void][]) {
+    if (tools.has(name)) register();
+  }
+
+  // Register resources — gated on the matching tool so a trimmed profile
+  // doesn't advertise resources for capabilities it excluded.
+  if (tools.has("wallet")) {
+    server.registerResource(
+      "wallet",
+      "blockrun://wallet",
+      { description: "Wallet address and status", mimeType: "application/json" },
+      async () => {
+        const info = await getWalletInfo();
+        return {
+          contents: [{
+            uri: "blockrun://wallet",
+            mimeType: "application/json",
+            text: JSON.stringify(info, null, 2),
+          }],
+        };
+      }
+    );
+  }
+
+  if (tools.has("models")) {
+    server.registerResource(
+      "models",
+      "blockrun://models",
+      { description: "Available AI models with pricing", mimeType: "application/json" },
+      async () => {
+        const models = await loadModels(getClient(), modelCache);
+        return {
+          contents: [{
+            uri: "blockrun://models",
+            mimeType: "application/json",
+            text: JSON.stringify(models, null, 2),
+          }],
+        };
+      }
+    );
+  }
+
+  return { profile, tools: [...tools] };
 }

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -1,0 +1,85 @@
+// src/profiles.ts
+//
+// Tool profiles let one published package expose a trimmed tool set so MCP
+// clients (Claude Code, etc.) only load the schemas they need into context.
+// Select a profile with `--profile <name>` (CLI flag) or BLOCKRUN_MCP_PROFILE.
+//
+//   claude mcp add blockrun-media -- npx -y @blockrun/mcp@latest --profile media
+//
+// "full" (default) registers everything — identical to the historical behavior.
+
+export type ToolName =
+  | "wallet"
+  | "chat"
+  | "models"
+  | "image"
+  | "music"
+  | "speech"
+  | "video"
+  | "realface"
+  | "search"
+  | "exa"
+  | "markets"
+  | "price"
+  | "dex"
+  | "modal"
+  | "phone"
+  | "surf"
+  | "rpc"
+  | "defi";
+
+export const ALL_TOOLS: ToolName[] = [
+  "wallet", "chat", "models", "image", "music", "speech", "video", "realface",
+  "search", "exa", "markets", "price", "dex", "modal", "phone", "surf", "rpc", "defi",
+];
+
+// "all" is a sentinel meaning "every tool" — kept distinct from an explicit
+// list so the full profile never drifts out of sync when tools are added.
+export const PROFILES: Record<string, ToolName[] | "all"> = {
+  full: "all",
+  // Image + video focused build: generation/editing tools (image, video,
+  // realface) plus the other generative-media tools (music, speech), and the
+  // wallet (funding/balance — media calls cost USDC) and models (discover
+  // what's available). Strips chat, market data, search, and the rest.
+  media: ["wallet", "models", "image", "video", "realface", "music", "speech"],
+};
+
+const DEFAULT_PROFILE = "full";
+
+/**
+ * Resolve the active profile name. Precedence: explicit `--profile <name>` /
+ * `--profile=<name>` CLI flag, then BLOCKRUN_MCP_PROFILE env, then "full".
+ * An unknown name falls back to "full" (logged by the caller).
+ */
+export function resolveProfileName(
+  argv: string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--profile") return (argv[i + 1] ?? DEFAULT_PROFILE).toLowerCase();
+    if (arg.startsWith("--profile=")) return arg.slice("--profile=".length).toLowerCase();
+  }
+  if (env.BLOCKRUN_MCP_PROFILE) return env.BLOCKRUN_MCP_PROFILE.toLowerCase();
+  return DEFAULT_PROFILE;
+}
+
+/**
+ * Resolve a profile name to the concrete set of tools to register.
+ * Returns the canonical profile name actually used (after unknown-name
+ * fallback) alongside the tool list, so the server can log it accurately.
+ */
+export function resolveTools(
+  argv?: string[],
+  env?: NodeJS.ProcessEnv,
+): { profile: string; tools: Set<ToolName> } {
+  const requested = resolveProfileName(argv, env);
+  const spec = PROFILES[requested];
+  if (!spec) {
+    return { profile: DEFAULT_PROFILE, tools: new Set(ALL_TOOLS) };
+  }
+  return {
+    profile: requested,
+    tools: new Set(spec === "all" ? ALL_TOOLS : spec),
+  };
+}

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -37,11 +37,18 @@ export const ALL_TOOLS: ToolName[] = [
 // list so the full profile never drifts out of sync when tools are added.
 export const PROFILES: Record<string, ToolName[] | "all"> = {
   full: "all",
-  // Image + video focused build: generation/editing tools (image, video,
-  // realface) plus the other generative-media tools (music, speech), and the
-  // wallet (funding/balance — media calls cost USDC) and models (discover
-  // what's available). Strips chat, market data, search, and the rest.
+  // Generative media: image/video/realface plus the other media-generation
+  // tools (music, speech), with wallet (funding/balance — media calls cost
+  // USDC) and models (discover what's available).
   media: ["wallet", "models", "image", "video", "realface", "music", "speech"],
+  // Markets & on-chain data: prediction markets, realtime prices, DEX/CEX
+  // data, DeFi metrics, and raw RPC, plus the wallet for balance/funding.
+  trading: ["wallet", "price", "dex", "markets", "surf", "defi", "rpc"],
+  // Web research & analysis: live search, neural search, Surf's news/SQL,
+  // and chat for synthesis, plus wallet and the model catalogue.
+  research: ["wallet", "models", "chat", "search", "exa", "surf"],
+  // Minimal LLM gateway: just chat + model discovery + wallet.
+  chat: ["wallet", "models", "chat"],
 };
 
 const DEFAULT_PROFILE = "full";


### PR DESCRIPTION
Three opt-in additions to blockrun-mcp, all backward compatible (default behavior unchanged).

## 1. Tool profiles (`--profile`)
Expose a trimmed tool set so clients load fewer schemas. Select via `--profile <name>` or `BLOCKRUN_MCP_PROFILE`; unknown names fall back to `full`.

| Profile | Tools |
|---|---|
| `full` *(default)* | all 18 |
| `media` | wallet, models, image, video, realface, music, speech |
| `trading` | wallet, price, dex, markets, surf, defi, rpc |
| `research` | wallet, models, chat, search, exa, surf |
| `chat` | wallet, models, chat |

`src/profiles.ts` + conditional registration in `mcp-handler.ts`; `--help` lists profiles.

## 2. Inline image previews (`blockrun_image`)
Opt-in `inline` param (or `BLOCKRUN_INLINE_IMAGES=1`) returns a downscaled JPEG thumbnail as a `type:"image"` block **alongside** the full-res URL, so rich clients render the result in-conversation. Auto-skips above a size cap and on fetch/encode errors (URL-only fallback). Tunable: `BLOCKRUN_INLINE_MAX_DIM` / `_QUALITY` / `_MAX_BYTES`. New: `src/utils/inline-image.ts` (uses `sharp`).

## 3. Spend confirmation (`blockrun_image`)
Before charging, `confirmSpend()` asks via **MCP elicitation** with an "approve all this session" checkbox (session-scoped auto-approve). No-ops on clients without elicitation; fail-open (only an explicit decline aborts). Controls: `BLOCKRUN_CONFIRM_SPEND=off`, `BLOCKRUN_CONFIRM_THRESHOLD`. New: `src/utils/confirm-spend.ts`.

## Notes for packaging
- All three default to prior behavior (full profile, no inline, no confirm) — safe to publish.
- Inline + confirm are currently wired into `blockrun_image`; can be extended to video/music/speech later.
- `tsc --noEmit` clean; `npm run build` succeeds; verified end-to-end via MCP (profiles, inline thumbnail, and elicitation with a capable client).

## Commits
- profiles (media/trading/research/chat)
- inline image preview + spend confirmation