### PR TITLE
feat(image): make edit usable for img2img — paths/URLs, multi-image fusion, inpaint mask

### DIFF
--- a/src/tools/image.ts
+++ b/src/tools/image.ts
@@ -34,6 +34,14 @@ const EDIT_MODELS = new Set([
   "google/nano-banana-pro",
 ]);
 
+// Mirrors the gateway's MAX_IMAGES_BY_PREFIX. Multi-image edit fuses several
+// source images (e.g. a subject + a layout guide, or a reference + a brand logo)
+// into one render. openai/* accepts up to 4 source images, google/* up to 3.
+const MAX_EDIT_IMAGES_BY_PREFIX: Record<string, number> = {
+  "openai/": 4,
+  "google/": 3,
+};
+
 const IMAGE_MODELS = [
   "zai/cogview-4",
   "google/nano-banana",
@@ -71,12 +79,16 @@ Generation models (1024x1024 base price; larger sizes cost more on gpt-image-*):
 - xai/grok-imagine-image-pro ($0.07) — higher quality Grok Imagine
 - zai/cogview-4 ($0.015) — cheapest, photorealistic detailed scenes
 
-Edit (img2img) models: openai/gpt-image-2 (default), openai/gpt-image-1, google/nano-banana, google/nano-banana-pro`,
+Edit (img2img) models: openai/gpt-image-2 (default), openai/gpt-image-1, google/nano-banana, google/nano-banana-pro
+Multi-image edit: pass an array of 2–4 source images to "image" to fuse them in one render (openai/* up to 4, google/* up to 3) — e.g. a subject plus a sprite layout guide, or a reference plus a brand logo.`,
       inputSchema: {
         prompt: z.string().describe("Image description or edit instructions"),
         action: z.enum(["generate", "edit"]).optional().default("generate").describe("generate: create from text; edit: transform existing image"),
         model: z.enum(IMAGE_MODELS).optional().describe("Model to use (default: openai/gpt-image-2 for both generate and edit). gpt-image-2 renders on-image text best; nano-banana-pro for 4K photorealism; cogview-4 / grok-imagine-image for cheap drafts."),
-        image: z.string().optional().describe("Source image for edit action: base64-encoded image or URL"),
+        image: z
+          .union([z.string(), z.array(z.string()).min(1).max(4)])
+          .optional()
+          .describe("Source image(s) for edit action: a base64 data URI or URL, or an array of 2–4 to fuse into one render (e.g. subject + layout guide, or reference + brand logo). openai/* accepts up to 4, google/* up to 3; a mask cannot be combined with multiple images."),
         size: z.string().optional().default("1024x1024").describe("Image size. Common values: 1024x1024 (all models), 1536x1024 / 1024x1536 (gpt-image-*), 2048x2048 / 4096x4096 (nano-banana-pro)"),
         quality: z.enum(["standard", "hd"]).optional().default("standard"),
         agent_id: z.string().optional().describe("Agent identifier for budget tracking and enforcement."),
@@ -104,6 +116,14 @@ Edit (img2img) models: openai/gpt-image-2 (default), openai/gpt-image-1, google/
           if (!EDIT_MODELS.has(selectedModel)) {
             return {
               content: [{ type: "text", text: formatError("Image edits support openai/gpt-image-1, openai/gpt-image-2, google/nano-banana, or google/nano-banana-pro") }],
+              isError: true,
+            };
+          }
+          const sourceImages = Array.isArray(image) ? image : [image];
+          const maxImages = MAX_EDIT_IMAGES_BY_PREFIX[`${selectedModel.split("/")[0]}/`] ?? 1;
+          if (sourceImages.length > maxImages) {
+            return {
+              content: [{ type: "text", text: formatError(`${selectedModel} accepts at most ${maxImages} source image${maxImages > 1 ? "s" : ""} per edit (got ${sourceImages.length}).`) }],
               isError: true,
             };
           }

--- a/src/tools/image.ts
+++ b/src/tools/image.ts
@@ -6,6 +6,54 @@ import { checkBudget, recordSpending } from "../utils/budget.js";
 import { formatError } from "../utils/errors.js";
 import type { BudgetState } from "../types.js";
 import { getChain, getImageClient } from "../utils/wallet.js";
+import { readFile } from "node:fs/promises";
+
+// The gateway's /v1/images/image2image only accepts base64 data URIs for the
+// source image(s). Callers naturally have local file paths or http(s) URLs, so
+// normalize those into data URIs here instead of forcing them to pre-encode.
+// Mirrors Franklin's resolveReferenceImage (src/tools/imagegen.ts): same data
+// URI / http / local-path handling, with a size cap, fetch timeout, and
+// content-type / extension validation.
+const REFERENCE_IMAGE_MAX_BYTES = 4_000_000;
+const IMAGE_EXT_MIME: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+};
+
+export async function toImageDataUri(ref: string): Promise<string> {
+  if (ref.startsWith("data:image/")) return ref;
+
+  if (/^https?:\/\//i.test(ref)) {
+    const ctrl = new AbortController();
+    const timeout = setTimeout(() => ctrl.abort(), 30_000);
+    try {
+      const res = await fetch(ref, { signal: ctrl.signal });
+      if (!res.ok) throw new Error(`fetch failed: ${res.status} ${res.statusText}`);
+      const mime = (res.headers.get("content-type") || "").toLowerCase().split(";")[0].trim();
+      if (!mime.startsWith("image/")) throw new Error(`URL returned non-image content-type: ${mime || "(none)"}`);
+      const buffer = Buffer.from(await res.arrayBuffer());
+      if (buffer.byteLength > REFERENCE_IMAGE_MAX_BYTES) {
+        throw new Error(`image too large: ${(buffer.byteLength / 1e6).toFixed(1)}MB > ${REFERENCE_IMAGE_MAX_BYTES / 1e6}MB cap`);
+      }
+      return `data:${mime};base64,${buffer.toString("base64")}`;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  // Treat as a local file path.
+  const ext = ref.split(".").pop()?.toLowerCase() ?? "";
+  const mime = IMAGE_EXT_MIME[ext];
+  if (!mime) throw new Error(`unsupported image extension ".${ext}"; use png/jpg/jpeg/gif/webp`);
+  const buffer = await readFile(ref);
+  if (buffer.byteLength > REFERENCE_IMAGE_MAX_BYTES) {
+    throw new Error(`image too large: ${(buffer.byteLength / 1e6).toFixed(1)}MB > ${REFERENCE_IMAGE_MAX_BYTES / 1e6}MB cap; resize or crop first`);
+  }
+  return `data:${mime};base64,${buffer.toString("base64")}`;
+}
 
 // Base (1024x1024) prices, mirroring the live /v1/images/models catalog.
 // dall-e-3 and flux-schnell were delisted upstream — do not re-add them.
@@ -41,6 +89,9 @@ const MAX_EDIT_IMAGES_BY_PREFIX: Record<string, number> = {
   "openai/": 4,
   "google/": 3,
 };
+
+// Mirrors the gateway's MASK_SUPPORTED_MODELS — only OpenAI image models inpaint.
+const MASK_MODELS = new Set(["openai/gpt-image-1", "openai/gpt-image-2"]);
 
 const IMAGE_MODELS = [
   "zai/cogview-4",
@@ -80,7 +131,8 @@ Generation models (1024x1024 base price; larger sizes cost more on gpt-image-*):
 - zai/cogview-4 ($0.015) — cheapest, photorealistic detailed scenes
 
 Edit (img2img) models: openai/gpt-image-2 (default), openai/gpt-image-1, google/nano-banana, google/nano-banana-pro
-Multi-image edit: pass an array of 2–4 source images to "image" to fuse them in one render (openai/* up to 4, google/* up to 3) — e.g. a subject plus a sprite layout guide, or a reference plus a brand logo.`,
+Multi-image edit: pass an array of 2–4 source images to "image" to fuse them in one render (openai/* up to 4, google/* up to 3) — e.g. a subject plus a sprite layout guide, or a reference plus a brand logo.
+Source images and masks accept a base64 data URI, an http(s) URL, or a local file path (auto-encoded). Inpaint mask (openai/gpt-image-* only) via "mask"; not combinable with multiple source images.`,
       inputSchema: {
         prompt: z.string().describe("Image description or edit instructions"),
         action: z.enum(["generate", "edit"]).optional().default("generate").describe("generate: create from text; edit: transform existing image"),
@@ -88,13 +140,14 @@ Multi-image edit: pass an array of 2–4 source images to "image" to fuse them i
         image: z
           .union([z.string(), z.array(z.string()).min(1).max(4)])
           .optional()
-          .describe("Source image(s) for edit action: a base64 data URI or URL, or an array of 2–4 to fuse into one render (e.g. subject + layout guide, or reference + brand logo). openai/* accepts up to 4, google/* up to 3; a mask cannot be combined with multiple images."),
+          .describe("Source image(s) for edit action: a base64 data URI, an http(s) URL, or a local file path (auto-encoded to a data URI) — or an array of 2–4 to fuse into one render (e.g. subject + layout guide, or reference + brand logo). openai/* accepts up to 4, google/* up to 3; a mask cannot be combined with multiple images."),
+        mask: z.string().optional().describe("Inpaint mask for edit action (openai/gpt-image-* only): a base64 data URI, http(s) URL, or local file path. Transparent areas of the mask are regenerated. Cannot be combined with multiple source images."),
         size: z.string().optional().default("1024x1024").describe("Image size. Common values: 1024x1024 (all models), 1536x1024 / 1024x1536 (gpt-image-*), 2048x2048 / 4096x4096 (nano-banana-pro)"),
         quality: z.enum(["standard", "hd"]).optional().default("standard"),
         agent_id: z.string().optional().describe("Agent identifier for budget tracking and enforcement."),
       },
     },
-    async ({ prompt, action, model, image, size, quality, agent_id }) => {
+    async ({ prompt, action, model, image, mask, size, quality, agent_id }) => {
       try {
         if (getChain() !== "base") {
           return {
@@ -127,6 +180,32 @@ Multi-image edit: pass an array of 2–4 source images to "image" to fuse them i
               isError: true,
             };
           }
+          if (mask) {
+            if (!MASK_MODELS.has(selectedModel)) {
+              return {
+                content: [{ type: "text", text: formatError("mask (inpaint) is supported only by openai/gpt-image-1 and openai/gpt-image-2") }],
+                isError: true,
+              };
+            }
+            if (sourceImages.length > 1) {
+              return {
+                content: [{ type: "text", text: formatError("mask cannot be combined with multiple source images; send a single image with a mask, or multiple images without a mask") }],
+                isError: true,
+              };
+            }
+          }
+          let normalizedImage: string | string[];
+          let normalizedMask: string | undefined;
+          try {
+            const dataUris = await Promise.all(sourceImages.map(toImageDataUri));
+            normalizedImage = dataUris.length === 1 ? dataUris[0] : dataUris;
+            if (mask) normalizedMask = await toImageDataUri(mask);
+          } catch (e) {
+            return {
+              content: [{ type: "text", text: formatError(`Could not load source image: ${e instanceof Error ? e.message : String(e)}`) }],
+              isError: true,
+            };
+          }
           const estimatedCost = estimateCost(selectedModel, size);
           const budgetCheck = checkBudget(budget, agent_id, estimatedCost);
           if (!budgetCheck.allowed) {
@@ -135,9 +214,10 @@ Multi-image edit: pass an array of 2–4 source images to "image" to fuse them i
               isError: true,
             };
           }
-          response = await getImageClient().edit(prompt, image, {
+          response = await getImageClient().edit(prompt, normalizedImage, {
             model: selectedModel,
             size,
+            ...(normalizedMask ? { mask: normalizedMask } : {}),
           });
           recordSpending(budget, estimatedCost, agent_id);
         } else {

--- a/test/image.test.ts
+++ b/test/image.test.ts
@@ -1,0 +1,47 @@
+// Run with: npm test  (tsx --test)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { toImageDataUri } from "../src/tools/image.js";
+
+const tmp = mkdtempSync(join(tmpdir(), "blockrun-img-"));
+
+// 1x1 transparent PNG
+const PNG_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
+  "base64",
+);
+
+test("toImageDataUri passes through an existing data URI unchanged", async () => {
+  const uri = "data:image/png;base64,iVBORw0KGgo=";
+  assert.equal(await toImageDataUri(uri), uri);
+});
+
+test("toImageDataUri encodes a local .png into a data:image/png URI", async () => {
+  const p = join(tmp, "pic.png");
+  writeFileSync(p, PNG_BYTES);
+  const out = await toImageDataUri(p);
+  assert.match(out, /^data:image\/png;base64,/);
+  assert.equal(out, `data:image/png;base64,${PNG_BYTES.toString("base64")}`);
+});
+
+test("toImageDataUri maps .jpg/.jpeg to image/jpeg", async () => {
+  const p = join(tmp, "pic.jpeg");
+  writeFileSync(p, PNG_BYTES); // bytes irrelevant to mime mapping
+  const out = await toImageDataUri(p);
+  assert.match(out, /^data:image\/jpeg;base64,/);
+});
+
+test("toImageDataUri rejects an unsupported extension", async () => {
+  const p = join(tmp, "notes.txt");
+  writeFileSync(p, "hello");
+  await assert.rejects(() => toImageDataUri(p), /unsupported image extension/);
+});
+
+test("toImageDataUri rejects a file over the 4MB cap", async () => {
+  const p = join(tmp, "huge.png");
+  writeFileSync(p, Buffer.alloc(4_000_001, 0));
+  await assert.rejects(() => toImageDataUri(p), /too large/);
+});


### PR DESCRIPTION
## Summary

The `edit` (img2img) action of `blockrun_image` was effectively unusable: the gateway `/v1/images/image2image` only accepts **base64 data URIs**, but the MCP exposed `image` as a single string and passed it through verbatim — so a path or URL hit the gateway's `/^data:image\//` validation and failed, and callers had no way to inline an image. This PR brings the MCP to parity with Franklin's `resolveReferenceImage` (`Franklin/src/tools/imagegen.ts`).

## Changes

1. **Accept file paths / http(s) URLs / data URIs** for `image` (and `mask`). The MCP normalizes each to a data URI: passthrough for data URIs, `fetch` for URLs (30s timeout + content-type check), `readFile` for local paths (extension→mime). 4MB cap per image. Mirrors Franklin's safeguards.
2. **Multi-image fusion**: `image` accepts an array of 2–4 sources to fuse in one render, with per-provider caps mirroring the gateway (`openai/*` → 4, `google/*` → 3).
3. **Inpaint mask**: expose `mask` for `openai/gpt-image-*`, with the gateway's guards (mask only on OpenAI models; mask not combinable with multiple source images).
4. **Tests**: `test/image.test.ts` covers the normalization paths (data-URI passthrough, local png/jpeg → data URI, unsupported extension, >4MB rejection).

## Why

`edit` is the img2img entry point — its natural inputs are file paths and URLs, not pre-encoded base64. Without this, identity-locked workflows (e.g. generating a sprite/pet from a reference image, fusing a subject + a layout guide, or inpainting with a mask) were impossible through the MCP even though the gateway and `@blockrun/llm` SDK already supported them.

## Compatibility

Backward compatible: a single data-URI `image` behaves exactly as before. Paths/URLs, arrays, and `mask` are opt-in.

## Test

- `npm run typecheck` ✓
- `npm test` ✓ (13 tests, 5 new)
- `npm run build` ✓