### PR TITLE
feat(video): expose Seedance passthrough params (generate_audio, resolution, aspect_ratio, last_frame_url)

### DIFF
--- a/src/tools/video.ts
+++ b/src/tools/video.ts
@@ -76,11 +76,12 @@ Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GC
         image_url: z.string().url().optional().describe("Optional seed image URL for image-to-video generation"),
         real_face_asset_id: z.string().regex(/^ta_[A-Za-z0-9]+$/, "token360 asset id like 'ta_xxxx'").optional().describe("BytePlus RealFace asset id (from blockrun_realface enroll/list) to generate video of a specific real person. Seedance 2.0 / 2.0-fast only. Mutually exclusive with image_url."),
         duration_seconds: z.number().int().min(1).max(60).optional().describe("Duration to bill for (defaults to the model's default — 8s for xAI, 5s for Seedance; Seedance supports up to 10s)."),
+        generate_audio: z.boolean().optional().describe("Seedance only: whether to generate a synced audio track. Defaults ON for text-to-video and OFF for image/RealFace-conditioned. The auto-generated audio is occasionally rejected by upstream moderation ('output audio may contain sensitive information') even for benign prompts — pass false to skip audio and avoid that failure. Ignored by xAI/Sora."),
         model: z.enum(["azure/sora-2", "xai/grok-imagine-video", "bytedance/seedance-1.5-pro", "bytedance/seedance-2.0-fast", "bytedance/seedance-2.0"]).optional().default("xai/grok-imagine-video").describe("Video model to use"),
         agent_id: z.string().optional().describe("Agent identifier for budget tracking and enforcement."),
       },
     },
-    async ({ prompt, image_url, real_face_asset_id, duration_seconds, model, agent_id }) => {
+    async ({ prompt, image_url, real_face_asset_id, duration_seconds, generate_audio, model, agent_id }) => {
       try {
         if (getChain() !== "base") {
           return {
@@ -130,6 +131,7 @@ Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GC
         if (image_url) body.image_url = image_url;
         if (real_face_asset_id) body.real_face_asset_id = real_face_asset_id;
         if (duration_seconds !== undefined) body.duration_seconds = duration_seconds;
+        if (generate_audio !== undefined) body.generate_audio = generate_audio;
 
         // Step 1: get 402 with price + requirements
         const resp402 = await fetchWithTimeout(submitUrl, {

--- a/src/tools/video.ts
+++ b/src/tools/video.ts
@@ -77,11 +77,14 @@ Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GC
         real_face_asset_id: z.string().regex(/^ta_[A-Za-z0-9]+$/, "token360 asset id like 'ta_xxxx'").optional().describe("BytePlus RealFace asset id (from blockrun_realface enroll/list) to generate video of a specific real person. Seedance 2.0 / 2.0-fast only. Mutually exclusive with image_url."),
         duration_seconds: z.number().int().min(1).max(60).optional().describe("Duration to bill for (defaults to the model's default — 8s for xAI, 5s for Seedance; Seedance supports up to 10s)."),
         generate_audio: z.boolean().optional().describe("Seedance only: whether to generate a synced audio track. Defaults ON for text-to-video and OFF for image/RealFace-conditioned. The auto-generated audio is occasionally rejected by upstream moderation ('output audio may contain sensitive information') even for benign prompts — pass false to skip audio and avoid that failure. Ignored by xAI/Sora."),
+        resolution: z.enum(["360p", "480p", "540p", "720p", "1080p", "1K", "2K", "4K"]).optional().describe("Seedance only: output resolution. Defaults to 720p. Higher resolutions cost more (token-priced upstream) — the final price is set by the 402 challenge, so the up-front estimate may understate 1080p/4K. Ignored by xAI/Sora."),
+        aspect_ratio: z.enum(["adaptive", "16:9", "9:16", "1:1", "4:3", "3:4", "21:9", "9:21"]).optional().describe("Seedance only: output aspect ratio, e.g. '9:16' for vertical/mobile, '16:9' for landscape. Defaults to the model's own default. Ignored by xAI/Sora."),
+        last_frame_url: z.string().url().optional().describe("Seedance only: first-and-last-frame interpolation. A second image URL that seeds the FINAL frame so the model tweens from image_url (first frame) → last_frame_url (last frame). Requires image_url; mutually exclusive with real_face_asset_id. Priced as image-to-video."),
         model: z.enum(["azure/sora-2", "xai/grok-imagine-video", "bytedance/seedance-1.5-pro", "bytedance/seedance-2.0-fast", "bytedance/seedance-2.0"]).optional().default("xai/grok-imagine-video").describe("Video model to use"),
         agent_id: z.string().optional().describe("Agent identifier for budget tracking and enforcement."),
       },
     },
-    async ({ prompt, image_url, real_face_asset_id, duration_seconds, generate_audio, model, agent_id }) => {
+    async ({ prompt, image_url, real_face_asset_id, duration_seconds, generate_audio, resolution, aspect_ratio, last_frame_url, model, agent_id }) => {
       try {
         if (getChain() !== "base") {
           return {
@@ -103,6 +106,23 @@ Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GC
           if (image_url) {
             return {
               content: [{ type: "text", text: formatError("Pass exactly one of real_face_asset_id or image_url — both seed the first frame.") }],
+              isError: true,
+            };
+          }
+        }
+
+        // first-and-last-frame interpolation needs a first frame (image_url) and
+        // can't be combined with a RealFace seed.
+        if (last_frame_url) {
+          if (!image_url) {
+            return {
+              content: [{ type: "text", text: formatError("last_frame_url (first-and-last-frame interpolation) requires image_url as the first frame.") }],
+              isError: true,
+            };
+          }
+          if (real_face_asset_id) {
+            return {
+              content: [{ type: "text", text: formatError("last_frame_url cannot be combined with real_face_asset_id.") }],
               isError: true,
             };
           }
@@ -132,6 +152,9 @@ Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GC
         if (real_face_asset_id) body.real_face_asset_id = real_face_asset_id;
         if (duration_seconds !== undefined) body.duration_seconds = duration_seconds;
         if (generate_audio !== undefined) body.generate_audio = generate_audio;
+        if (resolution !== undefined) body.resolution = resolution;
+        if (aspect_ratio !== undefined) body.aspect_ratio = aspect_ratio;
+        if (last_frame_url) body.last_frame_url = last_frame_url;
 
         // Step 1: get 402 with price + requirements
         const resp402 = await fetchWithTimeout(submitUrl, {


### PR DESCRIPTION
## Problem

The gateway videos route accepts several Seedance (token360) parameters that the `blockrun_video` MCP tool never surfaced, so MCP callers were locked to gateway defaults with no escape hatch.

**generate_audio** is the one that bit a user: Seedance text-to-video defaults `generate_audio=true`, and the auto-generated audio track is occasionally rejected by upstream (ByteDance/Volcengine) moderation with *"output audio may contain sensitive information"* — even for benign prompts. Reproduced:

| Prompt | Audio | Result |
|--------|-------|--------|
| `A cat walking slowly on a table` | on (default) | ❌ failed — "output audio … sensitive information" |
| `A cat walking slowly on a table` | **off** | ✅ success |
| `A fluffy cat slowly walking across a wooden kitchen table` | on | ✅ success |

It's a non-deterministic false positive on the model's hallucinated audio track, not real sensitive content — but the tool gave callers no way to disable audio and recover.

## Change

Expose these optional Seedance passthroughs in the tool's input schema, forwarded to the gateway only when set (the gateway already honors explicit values over its defaults):

- **`generate_audio`** — pass `false` to skip the audio track and avoid the moderation failure
- **`resolution`** — `360p…4K` (default 720p); pick 1080p/4K for quality or 480p to save cost
- **`aspect_ratio`** — `9:16` vertical for mobile/social, `16:9` landscape, etc.
- **`last_frame_url`** — first-and-last-frame interpolation (tweens `image_url` → `last_frame_url`); requires `image_url`, mutually exclusive with RealFace, priced as image-to-video. Fail-fast guards added.

## Notes

- All optional; omitting any param preserves existing gateway behavior. xAI/Sora ignore these (Seedance-only).
- `reference_videos` / `reference_audios` (r2v) intentionally **not** exposed — the gateway gates them behind `R2V_ENABLED` (currently off, pending a reference-media pricing fix), so they'd only 503 today.
- The per-second cost estimate doesn't vary by resolution, so the up-front estimate may understate 1080p/4K — the real price is set by the 402 challenge, so no overcharge risk. Called out in the `resolution` description.
- `npm run typecheck` passes.