### PR TITLE
fix(errors): accurate upstream model-unavailable guidance (drop misleading gpt-4o fallback)

### DIFF
--- a/src/tools/image.ts
+++ b/src/tools/image.ts
@@ -259,7 +259,7 @@ Source images and masks accept a base64 data URI, an http(s) URL, or a local fil
           };
         }
         return {
-          content: [{ type: "text", text: formatError(`Image generation failed: ${errMsg}`) }],
+          content: [{ type: "text", text: formatError(`Image generation failed: ${errMsg}`, { altModels: "google/nano-banana, zai/cogview-4" }) }],
           isError: true,
         };
       }

--- a/src/tools/video.ts
+++ b/src/tools/video.ts
@@ -334,7 +334,7 @@ Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GC
           };
         }
         return {
-          content: [{ type: "text", text: formatError(`Video generation failed: ${errMsg}`, { altModels: "bytedance/seedance-2.0" }) }],
+          content: [{ type: "text", text: formatError(`Video generation failed: ${errMsg}`, { altModels: "bytedance/seedance-2.0, azure/sora-2" }) }],
           isError: true,
         };
       }

--- a/src/tools/video.ts
+++ b/src/tools/video.ts
@@ -334,7 +334,7 @@ Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GC
           };
         }
         return {
-          content: [{ type: "text", text: formatError(`Video generation failed: ${errMsg}`) }],
+          content: [{ type: "text", text: formatError(`Video generation failed: ${errMsg}`, { altModels: "bytedance/seedance-2.0" }) }],
           isError: true,
         };
       }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -33,7 +33,14 @@ export function extractErrorMessage(err: unknown): string {
   return base;
 }
 
-export function formatError(message: string): string {
+/**
+ * Format an error for return to the caller, appending actionable guidance for
+ * the three common failure classes (upstream model unavailable, server blip,
+ * payment/balance). `opts.altModels` lets a tool suggest a SAME-DOMAIN fallback
+ * (e.g. video → "bytedance/seedance-2.0") instead of a generic, often-wrong
+ * cross-domain one — omit it and no specific model is named.
+ */
+export function formatError(message: string, opts?: { altModels?: string }): string {
   const msgLower = message.toLowerCase();
 
   // Match HTTP status codes as standalone tokens, not substrings — "max 5000
@@ -45,14 +52,29 @@ export function formatError(message: string): string {
     msgLower.includes("insufficient") ||
     (msgLower.includes("payment") && !hasStatus("500"));
 
+  // Upstream model/provider availability, e.g. token360 returns
+  // "Model '…' not found or not active for requested provider" (the gateway
+  // surfaces it as a 500). This is the SPECIFIC model being down upstream, not
+  // a generic blip — so steer the user to a sibling model, not "try again".
+  const isModelUnavailable =
+    msgLower.includes("not active for requested provider") ||
+    msgLower.includes("not found or not active");
+
   const isServerError = hasStatus("500") ||
     msgLower.includes("api error after payment");
 
+  const altHint = opts?.altModels ? ` (e.g. ${opts.altModels})` : "";
   let errorText = `Error: ${message}`;
 
-  if (isServerError) {
+  if (isModelUnavailable) {
+    errorText += `\n\nThis model is temporarily unavailable upstream` +
+      (opts?.altModels
+        ? `. Try a different model${altHint} — it should work right away.`
+        : `. Try a different model, or retry shortly.`);
+  } else if (isServerError) {
     errorText += `\n\nThis is a temporary API issue. The API may be experiencing problems.` +
-      `\nTry again in a few minutes, or use a different model (e.g., openai/gpt-4o).`;
+      `\nTry again in a few minutes` +
+      (opts?.altModels ? `, or use a different model${altHint}.` : `.`);
   } else if (isPaymentError) {
     const chain = getChain();
     const network = chain === "solana" ? "Solana" : "Base";

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,0 +1,46 @@
+// Run with: npm test  (tsx --test)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { formatError } from "../src/utils/errors.js";
+
+test("model-unavailable (token360) → steers to a sibling model, not a generic blip", () => {
+  const msg = "Video generation failed: API error 500: token360 video submit failed: Model 'seedance-2.0-fast' not found or not active for requested provider";
+  const out = formatError(msg, { altModels: "bytedance/seedance-2.0" });
+  assert.match(out, /temporarily unavailable upstream/);
+  assert.match(out, /bytedance\/seedance-2\.0/);
+  assert.doesNotMatch(out, /temporary API issue/); // not misclassified as a generic 500
+});
+
+test("model-unavailable without altModels → neutral guidance, no model named", () => {
+  const out = formatError("token360 video submit failed: Model 'x' not active for requested provider");
+  assert.match(out, /temporarily unavailable upstream/);
+  assert.doesNotMatch(out, /e\.g\./);
+});
+
+test("generic 500 no longer suggests openai/gpt-4o", () => {
+  const out = formatError("Image generation failed: API error 500: Internal server error");
+  assert.match(out, /temporary API issue/);
+  assert.doesNotMatch(out, /gpt-4o/);
+});
+
+test("generic 500 with altModels names same-domain alternatives", () => {
+  const out = formatError("Image generation failed: API error 500: boom", { altModels: "google/nano-banana, zai/cogview-4" });
+  assert.match(out, /temporary API issue/);
+  assert.match(out, /google\/nano-banana/);
+});
+
+test("payment/402 → funding guidance, not server text", () => {
+  const out = formatError("API error 402: insufficient balance");
+  assert.match(out, /needs funding/);
+  assert.doesNotMatch(out, /temporary API issue/);
+});
+
+test("plain validation message gets no canned guidance appended", () => {
+  const out = formatError("mask cannot be combined with multiple source images");
+  assert.equal(out, "Error: mask cannot be combined with multiple source images");
+});
+
+test("a dollar amount like $1.4020 is not misread as a 402", () => {
+  const out = formatError("charged $1.4020 for the call");
+  assert.equal(out, "Error: charged $1.4020 for the call"); // no funding/server text
+});


### PR DESCRIPTION
## Problem

`formatError()` (shared by all 17 tools) had a single 500-error branch that appended:

> Try again in a few minutes, or use a different model (e.g., **openai/gpt-4o**).

Two issues, both surfaced during a real Seedance incident today:

1. **Wrong, cross-domain suggestion.** `openai/gpt-4o` is a *chat* model — useless advice on a **video / image / music / speech** error. Every non-chat tool inherited it.
2. **Misclassifies upstream model outages as a blip.** When token360 dropped supply for `seedance-2.0-fast` / `seedance-1.5-pro`, the gateway surfaced `Model '…' not found or not active for requested provider` as a 500, so users saw *"temporary API issue, try openai/gpt-4o"* — wrong cause, wrong fix. (`seedance-2.0` stayed up the whole time.)

## Change

- New **`isModelUnavailable`** branch detecting `not active for requested provider` / `not found or not active` → *"This model is temporarily unavailable upstream"* instead of a generic blip.
- Optional **`opts.altModels`** so a tool can name a **same-domain** fallback; removed the hardcoded `gpt-4o`.
- Wired **video → `bytedance/seedance-2.0`**, **image → `google/nano-banana, zai/cogview-4`** (different providers than each default, so a single-provider outage is dodged).
- Music/speech/other tools simply stop emitting the wrong model name (strict improvement).

## Audit

Swept all tools for canned/misleading error text — this `formatError` line was the **only** cross-domain model suggestion. The other model names in error strings (image edit-model list, video RealFace requirement) are accurate same-domain validation messages and were left as-is.

## Testing

- `tsc --noEmit` clean, `npm run build` succeeds, `npm test` green (**20 tests**, 7 new for `formatError` branches incl. the `$1.4020`-isn't-a-402 guard).