### PR TITLE
chore: enable Renovate (shared org preset)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>blockrunai/renovate-config"]
+}


### PR DESCRIPTION
Onboards this repo to the shared org Renovate preset by adding a root `renovate.json` that extends `github>blockrunai/renovate-config` — giving us weekly grouped minor/patch updates, auto-merged dev-dependency updates and security PRs, and manually-reviewed major upgrades; this config is inert until the Mend Renovate app is installed on the org, so merging it now is safe.