### PR TITLE
feat(image): blockrun_image now pays on Solana too

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Then send USDC (SPL) on the **Solana** network — from Coinbase (pick "Solana")
 
 **Base-only — these fall back to Base regardless of active chain:**
 
-- Tools: `blockrun_image`, `blockrun_music`, `blockrun_speech`, `blockrun_video`, paid `blockrun_realface` (enroll/portrait), paid stock `blockrun_price`. In Solana mode they return a "switch to Base" message instead of charging.
+- Tools: `blockrun_music`, `blockrun_speech`, `blockrun_video`, paid `blockrun_realface` (enroll/portrait), paid stock `blockrun_price`. In Solana mode they return a "switch to Base" message instead of charging. (`blockrun_image` pays on either chain.)
 - `blockrun_chat routing:"smart"` (ClawRouter) and native Anthropic (`claude-*`) passthrough — on Solana, pass `model:` or `mode:` explicitly.
 
 > Advanced: chain selection can also be forced before startup via files/env (`~/.blockrun/.chain`, `SOLANA_WALLET_KEY`) — see [Environment Variables](#environment-variables). The `action:"chain"` command above is the recommended path.
@@ -330,7 +330,7 @@ blockrun_wallet action:"setup"                  # funding instructions for the a
 
 *Advanced (force a chain before startup, e.g. in CI):* `echo solana > ~/.blockrun/.chain` then set `SOLANA_WALLET_KEY` or create `~/.blockrun/.solana-session`; `echo base > ~/.blockrun/.chain` reuses the existing `.session` (same Base wallet). These edit the same preference file that `action:"chain"` writes — prefer the tool unless you need pre-startup control.
 
-Some media and paid market-data tools still settle on Base only: `blockrun_image`, `blockrun_music`, `blockrun_speech`, `blockrun_video`, paid `blockrun_realface` (enroll/portrait), and paid stock `blockrun_price` calls — plus `blockrun_chat routing:"smart"` and native Anthropic (`claude-*`) passthrough. In Solana mode these return a "switch to Base" message instead of charging.
+Some media and paid market-data tools still settle on Base only: `blockrun_music`, `blockrun_speech`, `blockrun_video`, paid `blockrun_realface` (enroll/portrait), and paid stock `blockrun_price` calls — plus `blockrun_chat routing:"smart"` and native Anthropic (`claude-*`) passthrough. In Solana mode these return a "switch to Base" message instead of charging. `blockrun_image` (generate + edit) settles on whichever chain is active.
 
 The server also runs a non-blocking npm registry check at startup and prints an `Update available` notice to stderr when a newer `@blockrun/mcp` version exists. Upgrade by re-running the install command — no manual `npm update` needed.
 

--- a/src/tools/image.ts
+++ b/src/tools/image.ts
@@ -2,14 +2,18 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { PaymentError } from "@blockrun/llm";
-import { reserveBudget, recordSpending } from "../utils/budget.js";
+import { reserveBudget, recordSpending, recordActualSpend } from "../utils/budget.js";
 import { formatError } from "../utils/errors.js";
 import type { BudgetState } from "../types.js";
 import { getChain, getImageClient } from "../utils/wallet.js";
+import { solanaPaidPost } from "../utils/solana-402.js";
 import { isBlockedFetchHost } from "../utils/ssrf.js";
 import { shouldInline, buildInlineImageBlock } from "../utils/inline-image.js";
 import { confirmSpend } from "../utils/confirm-spend.js";
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
 
 // The gateway's /v1/images/image2image only accepts base64 data URIs for the
 // source image(s). Callers naturally have local file paths or http(s) URLs, so
@@ -149,11 +153,67 @@ function estimateCost(model: string, size: string): number {
   return base;
 }
 
+// The Solana gateway routes render synchronously (generation runs 10-180s,
+// then the result is mirrored to GCS before the response returns), so the
+// paid request's timeout must cover the whole render — not just a round-trip.
+const SOLANA_IMAGE_TIMEOUT_MS = 300_000;
+
+/**
+ * The image2image routes (both gateways) ship the provider's output verbatim —
+ * google/nano-banana returns a multi-megabyte base64 data URI, not a hosted
+ * URL. Returning that inline would flood the MCP client's context, so persist
+ * it to a temp file and hand back the path. Non-data URLs pass through.
+ */
+export async function materializeImageUrl(imageUrl: string): Promise<string> {
+  if (!imageUrl.startsWith("data:image/")) return imageUrl;
+  const m = /^data:image\/([a-z0-9.+-]+);base64,(.+)$/is.exec(imageUrl);
+  if (!m) return imageUrl; // undecodable — better to return the paid result verbatim than drop it
+  const ext = m[1].toLowerCase() === "jpeg" ? "jpg" : m[1].toLowerCase();
+  const file = join(tmpdir(), `blockrun-image-${Date.now()}-${randomBytes(4).toString("hex")}.${ext}`);
+  await writeFile(file, Buffer.from(m[2], "base64"));
+  return file;
+}
+
+/**
+ * Endpoint + body for a Solana-gateway image call. The gateway's zod schema
+ * takes quality as low|medium|high|auto (the OpenAI latency knob), not this
+ * tool's standard|hd — map hd→high and drop standard (the gateway default)
+ * so the request isn't rejected with a 400.
+ */
+export function buildSolanaImageRequest(
+  action: "generate" | "edit",
+  params: { model: string; prompt: string; size: string; quality?: string; image?: string | string[]; mask?: string },
+): { endpoint: string; body: Record<string, unknown> } {
+  if (action === "edit") {
+    return {
+      endpoint: "/v1/images/image2image",
+      body: {
+        model: params.model,
+        prompt: params.prompt,
+        image: params.image,
+        size: params.size,
+        n: 1,
+        ...(params.mask ? { mask: params.mask } : {}),
+      },
+    };
+  }
+  return {
+    endpoint: "/v1/images/generations",
+    body: {
+      model: params.model,
+      prompt: params.prompt,
+      size: params.size,
+      n: 1,
+      ...(params.quality === "hd" ? { quality: "high" } : {}),
+    },
+  };
+}
+
 export function registerImageTool(server: McpServer, budget: BudgetState): void {
   server.registerTool(
     "blockrun_image",
     {
-      description: `Generate or edit images via BlockRun. Pays with USDC — no separate API keys needed.
+      description: `Generate or edit images via BlockRun. Pays with USDC on the ACTIVE chain — Base or Solana (see blockrun_wallet) — no separate API keys needed.
 
 Actions:
 - generate (default): Create image from text prompt
@@ -188,13 +248,6 @@ Source images and masks accept a base64 data URI, an http(s) URL, or a local fil
     },
     async ({ prompt, action, model, image, mask, size, quality, inline, agent_id }) => {
       try {
-        if (getChain() !== "base") {
-          return {
-            content: [{ type: "text", text: formatError("blockrun_image currently settles on Base only. Switch BlockRun to Base (for example: run blockrun_wallet with action:chain chain:base) and fund the Base wallet with USDC.") }],
-            isError: true,
-          };
-        }
-
         const selectedModel = model || "openai/gpt-image-2";
 
         // Edit-mode inputs, normalized to data URIs in the branch below and
@@ -273,16 +326,35 @@ Source images and masks accept a base64 data URI, an http(s) URL, or a local fil
             return { content: [{ type: "text", text: confirm.reason || "Charge cancelled." }] };
           }
 
-          const response = action === "edit"
-            ? await getImageClient().edit(prompt, normalizedImage!, {
-                model: selectedModel,
-                size,
-                ...(normalizedMask ? { mask: normalizedMask } : {}),
-              })
-            : await getImageClient().generate(prompt, { model: selectedModel, size, quality: quality as "standard" | "hd" });
-          recordSpending(budget, estimatedCost, agent_id);
+          let imageUrl: string | undefined;
+          if (getChain() === "solana") {
+            // Solana: manual x402 against the sol.blockrun.ai gateway (the SDK's
+            // ImageClient signs Base/EVM payments only). Record the ACTUAL cost
+            // from the 402 quote — the Solana gateway prices carry a markup over
+            // the Base table above.
+            const { endpoint, body } = buildSolanaImageRequest(action, {
+              model: selectedModel,
+              prompt,
+              size,
+              quality,
+              image: normalizedImage,
+              mask: normalizedMask,
+            });
+            const { data, paidUsd } = await solanaPaidPost(endpoint, body, SOLANA_IMAGE_TIMEOUT_MS);
+            recordActualSpend(budget, paidUsd, estimatedCost, agent_id);
+            imageUrl = (data as { data?: Array<{ url?: string }> }).data?.[0]?.url;
+          } else {
+            const response = action === "edit"
+              ? await getImageClient().edit(prompt, normalizedImage!, {
+                  model: selectedModel,
+                  size,
+                  ...(normalizedMask ? { mask: normalizedMask } : {}),
+                })
+              : await getImageClient().generate(prompt, { model: selectedModel, size, quality: quality as "standard" | "hd" });
+            recordSpending(budget, estimatedCost, agent_id);
+            imageUrl = response.data?.[0]?.url;
+          }
 
-          const imageUrl = response.data?.[0]?.url;
           if (!imageUrl) {
             return {
               content: [{ type: "text", text: formatError("No image URL in response") }],
@@ -290,14 +362,19 @@ Source images and masks accept a base64 data URI, an http(s) URL, or a local fil
             };
           }
 
-          const textBlock = { type: "text" as const, text: `Image: ${imageUrl}\nPrompt: ${prompt}\nModel: ${selectedModel}` };
+          const delivered = await materializeImageUrl(imageUrl);
+          const savedLocally = delivered !== imageUrl;
+          const textBlock = {
+            type: "text" as const,
+            text: `Image: ${delivered}${savedLocally ? " (saved locally — the gateway returned inline image data)" : ""}\nPrompt: ${prompt}\nModel: ${selectedModel}`,
+          };
           // Optional inline preview (thumbnail) for rich clients. Best-effort:
           // on failure or if disabled, fall back to the URL-only text block.
           const previewBlock = shouldInline(inline) ? await buildInlineImageBlock(imageUrl) : null;
 
           return {
             content: previewBlock ? [previewBlock, textBlock] : [textBlock],
-            structuredContent: { url: imageUrl, prompt, model: selectedModel, inlined: Boolean(previewBlock) },
+            structuredContent: { url: delivered, prompt, model: selectedModel, inlined: Boolean(previewBlock) },
           };
         } finally {
           gate.release();

--- a/src/tools/wallet.ts
+++ b/src/tools/wallet.ts
@@ -24,9 +24,9 @@ To pay on Solana (no env vars, no file editing, no restart):
   1. action:"chain" chain:"solana"   → provisions + activates the Solana wallet
   2. action:"setup"                   → Solana address + funding QR (send USDC SPL on Solana)
 Switch back with action:"chain" chain:"base". Base-only — these ignore Solana and
-need Base: blockrun_image, blockrun_music, blockrun_speech, blockrun_video,
-blockrun_realface, paid blockrun_price, blockrun_chat routing:"smart", and native
-Anthropic (claude-*).
+need Base: blockrun_music, blockrun_speech, blockrun_video, blockrun_realface,
+paid blockrun_price, blockrun_chat routing:"smart", and native Anthropic
+(claude-*). blockrun_image pays on either chain.
 
 Actions:
 - status (default): Both wallet addresses + USDC balances, active chain, session spending
@@ -162,8 +162,8 @@ Do NOT call this for actual AI queries — use blockrun_chat for that.`,
   Base:   ${both.base.address}
   Solana: ${both.solana.address}
 
-All blockrun_* calls now pay on ${active}. Note: image generation, price, video,
-music and RealFace are Base-only — switch back with chain:"base" for those.`;
+All blockrun_* calls now pay on ${active}. Note: price, video, music, speech
+and RealFace are Base-only — switch back with chain:"base" for those.`;
         return {
           content: [{ type: "text", text }],
           structuredContent: {

--- a/src/utils/solana-402.ts
+++ b/src/utils/solana-402.ts
@@ -1,0 +1,124 @@
+// src/utils/solana-402.ts
+// Manual x402 payment flow against the Solana gateway (sol.blockrun.ai) for
+// paid endpoints the SolanaLLMClient doesn't expose as public methods yet
+// (image generation today; music/speech/video are candidates once their
+// Solana routes ship). Mirrors the music.ts manual-402 pattern on Base, but
+// signs an SPL transfer via createSolanaPaymentPayload instead of an
+// EIP-3009 authorization.
+import {
+  SolanaLLMClient,
+  PaymentError,
+  parsePaymentRequired,
+  extractPaymentDetails,
+  createSolanaPaymentPayload,
+  solanaKeyToBytes,
+  solanaPublicKey,
+  loadSolanaWallet,
+  SOLANA_NETWORK,
+} from "@blockrun/llm";
+import { fetchWithTimeout } from "./http.js";
+import { amountToUsd } from "./budget.js";
+
+const QUOTE_TIMEOUT_MS = 15_000;
+
+export interface SolanaPaidPostResult {
+  data: Record<string, unknown>;
+  /** Actual USD charged, from the 402 quote. Null when unparseable — callers fall back to their estimate. */
+  paidUsd: number | null;
+}
+
+/**
+ * POST `body` to a paid Solana-gateway endpoint, handling the 402 → sign →
+ * retry x402 dance. The Solana image/media routes settle OPTIMISTICALLY and
+ * respond synchronously (generation can take 10–180s), so `paidTimeoutMs`
+ * must cover the full generation, not just the HTTP round-trip.
+ */
+export async function solanaPaidPost(
+  endpoint: string,
+  body: Record<string, unknown>,
+  paidTimeoutMs: number,
+): Promise<SolanaPaidPostResult> {
+  const privateKey = process.env.SOLANA_WALLET_KEY || loadSolanaWallet();
+  if (!privateKey) {
+    throw new PaymentError('No Solana wallet found. Run blockrun_wallet with action:"setup" to provision one.');
+  }
+
+  const apiUrl = SolanaLLMClient.SOLANA_API_URL;
+  const url = `${apiUrl}${endpoint}`;
+
+  // Step 1: unpaid request → 402 quote.
+  const quoteResp = await fetchWithTimeout(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }, QUOTE_TIMEOUT_MS);
+
+  if (quoteResp.status !== 402) {
+    const data = await quoteResp.json().catch(() => ({})) as Record<string, unknown>;
+    throw new Error(`Unexpected status ${quoteResp.status} (the endpoint did not return a quote): ${JSON.stringify(data)}`);
+  }
+
+  // The gateway sends the requirements both as a PAYMENT-REQUIRED header and
+  // as the JSON body — fall back to the body (base64-wrapped, the shape
+  // parsePaymentRequired expects) when a proxy strips the header.
+  let prHeader = quoteResp.headers.get("payment-required") || quoteResp.headers.get("PAYMENT-REQUIRED");
+  if (!prHeader) {
+    const respBody = await quoteResp.json().catch(() => null) as Record<string, unknown> | null;
+    if (respBody && (respBody.accepts || respBody.x402Version)) {
+      prHeader = Buffer.from(JSON.stringify(respBody)).toString("base64");
+    }
+  }
+  if (!prHeader) throw new PaymentError("402 response but no payment requirements found");
+
+  const paymentRequired = parsePaymentRequired(prHeader);
+  const details = extractPaymentDetails(paymentRequired, SOLANA_NETWORK);
+  if (!details.network?.startsWith("solana:")) {
+    throw new PaymentError(`Expected a Solana payment quote, got network: ${details.network}. The endpoint may not support Solana settlement yet.`);
+  }
+  const feePayer = (details.extra as { feePayer?: string } | undefined)?.feePayer;
+  if (!feePayer) throw new PaymentError("Missing feePayer in the 402 quote's extra field");
+
+  // Only sign for a resource on the gateway's own origin — a spoofed quote must
+  // not relabel the payment as authorizing some other resource.
+  const quotedResource = details.resource?.url;
+  const resourceUrl = quotedResource && quotedResource.startsWith(apiUrl) ? quotedResource : url;
+
+  const fromAddress = await solanaPublicKey(privateKey);
+  const secretKey = await solanaKeyToBytes(privateKey);
+  const extensions = (paymentRequired as unknown as Record<string, unknown>).extensions as Record<string, unknown> | undefined;
+
+  const paymentPayload = await createSolanaPaymentPayload(
+    secretKey,
+    fromAddress,
+    details.recipient,
+    details.amount,
+    feePayer,
+    {
+      resourceUrl,
+      resourceDescription: details.resource?.description || "BlockRun Solana API call",
+      maxTimeoutSeconds: details.maxTimeoutSeconds || 300,
+      extra: details.extra as Record<string, unknown>,
+      ...(extensions ? { extensions } : {}),
+    },
+  );
+
+  // Step 2: paid request. The signed SPL transaction embeds a recent blockhash
+  // (~60-90s validity); the gateway settles optimistically in parallel with
+  // generation, so submitting right after signing keeps it inside the window.
+  const resp = await fetchWithTimeout(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "PAYMENT-SIGNATURE": paymentPayload },
+    body: JSON.stringify(body),
+  }, paidTimeoutMs);
+
+  if (resp.status === 402) {
+    throw new PaymentError("Payment was rejected. Check your Solana USDC balance.");
+  }
+  if (!resp.ok) {
+    const errBody = await resp.json().catch(() => ({ error: "Request failed" })) as Record<string, unknown>;
+    throw new Error(`API error ${resp.status}: ${JSON.stringify(errBody)}`);
+  }
+
+  const data = await resp.json() as Record<string, unknown>;
+  return { data, paidUsd: amountToUsd(details.amount) };
+}

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -120,11 +120,12 @@ export async function ensureBothWallets(): Promise<{
 }
 
 /**
- * Guard for capabilities the Solana SDK path doesn't cover yet (image
- * generation, price data, video, music, RealFace). Returns an actionable
- * message when the active chain is Solana, otherwise null. Tools call this
- * before paying so they never silently drain the Base wallet while the user
- * believes they're on Solana.
+ * Guard for capabilities the Solana SDK path doesn't cover yet (price data,
+ * video, music, speech, RealFace). Returns an actionable message when the
+ * active chain is Solana, otherwise null. Tools call this before paying so
+ * they never silently drain the Base wallet while the user believes they're
+ * on Solana. Image generation is NOT on this list — it pays on either chain
+ * via utils/solana-402.ts.
  */
 export function baseOnlyMessage(capability: string): string | null {
   if (getChain() === "solana") {

--- a/test/image.test.ts
+++ b/test/image.test.ts
@@ -4,7 +4,8 @@ import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { toImageDataUri } from "../src/tools/image.js";
+import { readFileSync } from "node:fs";
+import { toImageDataUri, buildSolanaImageRequest, materializeImageUrl } from "../src/tools/image.js";
 
 const tmp = mkdtempSync(join(tmpdir(), "blockrun-img-"));
 
@@ -52,4 +53,73 @@ test("toImageDataUri refuses to fetch a loopback/link-local URL (SSRF guard)", a
   await assert.rejects(() => toImageDataUri("http://127.0.0.1:1/x.png"), /refusing to fetch/i);
   await assert.rejects(() => toImageDataUri("http://169.254.169.254/latest/meta-data/"), /refusing to fetch/i);
   await assert.rejects(() => toImageDataUri("http://10.0.0.5/internal.png"), /refusing to fetch/i);
+});
+
+test("buildSolanaImageRequest generate targets /v1/images/generations with quality omitted for standard", () => {
+  const { endpoint, body } = buildSolanaImageRequest("generate", {
+    model: "openai/gpt-image-2",
+    prompt: "a fox",
+    size: "1024x1024",
+    quality: "standard",
+  });
+  assert.equal(endpoint, "/v1/images/generations");
+  assert.deepEqual(body, { model: "openai/gpt-image-2", prompt: "a fox", size: "1024x1024", n: 1 });
+});
+
+test("buildSolanaImageRequest maps quality hd → high (the gateway's zod enum has no 'hd')", () => {
+  const { body } = buildSolanaImageRequest("generate", {
+    model: "openai/gpt-image-2",
+    prompt: "a fox",
+    size: "1024x1024",
+    quality: "hd",
+  });
+  assert.equal(body.quality, "high");
+});
+
+test("buildSolanaImageRequest edit targets /v1/images/image2image with image and optional mask", () => {
+  const withMask = buildSolanaImageRequest("edit", {
+    model: "openai/gpt-image-1",
+    prompt: "add a hat",
+    size: "1024x1024",
+    image: "data:image/png;base64,AAAA",
+    mask: "data:image/png;base64,BBBB",
+  });
+  assert.equal(withMask.endpoint, "/v1/images/image2image");
+  assert.deepEqual(withMask.body, {
+    model: "openai/gpt-image-1",
+    prompt: "add a hat",
+    image: "data:image/png;base64,AAAA",
+    size: "1024x1024",
+    n: 1,
+    mask: "data:image/png;base64,BBBB",
+  });
+
+  const noMask = buildSolanaImageRequest("edit", {
+    model: "google/nano-banana",
+    prompt: "fuse these",
+    size: "1024x1024",
+    image: ["data:image/png;base64,AAAA", "data:image/png;base64,BBBB"],
+  });
+  assert.equal("mask" in noMask.body, false);
+  assert.deepEqual(noMask.body.image, ["data:image/png;base64,AAAA", "data:image/png;base64,BBBB"]);
+});
+
+test("materializeImageUrl passes hosted URLs and local paths through unchanged", async () => {
+  const url = "https://sol.blockrun.ai/api/media/images/x.png";
+  assert.equal(await materializeImageUrl(url), url);
+  assert.equal(await materializeImageUrl("/tmp/pic.png"), "/tmp/pic.png");
+});
+
+test("materializeImageUrl saves a data: URI to a temp file with the right bytes", async () => {
+  // image2image ships the provider output verbatim — nano-banana returns a
+  // multi-MB data URI. The tool must hand back a file path, never the base64.
+  const out = await materializeImageUrl(`data:image/png;base64,${PNG_BYTES.toString("base64")}`);
+  assert.doesNotMatch(out, /^data:/);
+  assert.match(out, /blockrun-image-.*\.png$/);
+  assert.deepEqual(readFileSync(out), PNG_BYTES);
+});
+
+test("materializeImageUrl maps image/jpeg data URIs to a .jpg file", async () => {
+  const out = await materializeImageUrl(`data:image/jpeg;base64,${PNG_BYTES.toString("base64")}`);
+  assert.match(out, /\.jpg$/);
 });


### PR DESCRIPTION
## What

`blockrun_image` rejected Solana payment with a hard "settles on Base only" error, forcing users with a funded Solana wallet to bridge/fund Base just to generate an image. The Solana gateway (`sol.blockrun.ai`) already serves both image routes with Solana x402 settlement — the gap was purely client-side: the SDK's `ImageClient` signs Base/EVM payments only, and `SolanaLLMClient` has no public generate method.

## How

- **New `src/utils/solana-402.ts`** — manual 402 → sign (SPL transfer via the SDK's `createSolanaPaymentPayload`) → retry flow against the Solana gateway. Mirrors the established `music.ts` manual-402 pattern on Base. Reusable for music/speech/video once their Solana routes ship.
- **`src/tools/image.ts`** — Base-only guard removed; the charge site branches on the active chain. The Solana path records the **actual** 402-quoted cost (Solana gateway prices carry a markup over the Base estimate table). Quality is mapped `hd→high` / `standard→omitted` because the gateway's zod enum is `low|medium|high|auto`.
- **`materializeImageUrl`** — image2image (both gateways) ships provider output verbatim; `google/nano-banana` edits return a multi-MB base64 data URI. That's now persisted to a temp file and returned as a path, so a paid result never floods the MCP client's context.
- Tool descriptions (`blockrun_image`, `blockrun_wallet`) and README updated to reflect the new chain support.

## Verification

- `npm run typecheck`, `npm test` (90/90), `npm run build` — all green.
- **Mainnet e2e** through the new code path, paid from the Solana wallet:
  - generate `zai/cogview-4` → $0.01575, 14.0s, GCS-hosted URL returned, payment status `settling` on `solana:5eykt4…`
  - edit `google/nano-banana` → $0.052501, 8.4s, data-URI result persisted locally