### PR TITLE
ci: auto-publish to npm + MCP registry (unsticks registry from 0.2.2)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,87 @@
+name: Publish (npm + MCP registry)
+
+# Why this exists: publishing was 100% manual. `npm publish` got run, the
+# `mcp-publisher` step got forgotten — so npm reached 0.26.0 while the official
+# MCP registry (which PulseMCP/Glama/etc. mirror) stayed frozen at 0.2.2 with a
+# stale "30+ AI models" blurb since January. This automates BOTH targets with
+# independent version guards, so they can never drift apart again.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "package.json"        # only run when the version could have changed
+      - "server.template.json"
+      - ".github/workflows/publish.yml"
+  workflow_dispatch:          # manual trigger (e.g. to unstick the registry)
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write          # required for `mcp-publisher login github-oidc`
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Resolve versions
+        id: v
+        run: |
+          PKG=$(node -p "require('./package.json').version")
+          NPM=$(npm view @blockrun/mcp version 2>/dev/null || echo "none")
+          REG=$(curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.BlockRunAI/blockrun-mcp" \
+                | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{const j=JSON.parse(s);console.log(j.servers?.[0]?.server?.version||'none')}catch{console.log('none')}})")
+          echo "pkg=$PKG"  >> "$GITHUB_OUTPUT"
+          echo "npm=$NPM"  >> "$GITHUB_OUTPUT"
+          echo "reg=$REG"  >> "$GITHUB_OUTPUT"
+          echo "package.json=$PKG | npm=$NPM | registry=$REG"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build, typecheck, test
+        run: |
+          npm run build
+          npm run typecheck
+          npm test
+
+      # ---- npm ----
+      - name: Publish to npm
+        if: steps.v.outputs.pkg != steps.v.outputs.npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Skip npm (already published)
+        if: steps.v.outputs.pkg == steps.v.outputs.npm
+        run: echo "npm already at ${{ steps.v.outputs.pkg }} — skipping npm publish"
+
+      # ---- MCP registry ----
+      - name: Install mcp-publisher
+        if: steps.v.outputs.pkg != steps.v.outputs.reg
+        run: |
+          curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" \
+            | tar -xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+
+      - name: Stamp + publish server.json to MCP registry
+        if: steps.v.outputs.pkg != steps.v.outputs.reg
+        run: |
+          node scripts/stamp-server-json.mjs
+          mcp-publisher validate
+          mcp-publisher login github-oidc
+          mcp-publisher publish
+          echo "Published $(node -p "require('./package.json').name")@${{ steps.v.outputs.pkg }} to the MCP registry"
+
+      - name: Skip registry (already published)
+        if: steps.v.outputs.pkg == steps.v.outputs.reg
+        run: echo "registry already at ${{ steps.v.outputs.pkg }} — skipping"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@blockrun/mcp",
   "version": "0.26.0",
   "mcpName": "io.github.BlockRunAI/blockrun-mcp",
-  "description": "BlockRun MCP Server - Give your AI agent web search, deep research, prediction markets, crypto data, X/Twitter intelligence. Paid via x402 micropayments.",
+  "description": "BlockRun MCP Server - Give your AI agent web search, deep research, prediction markets, and crypto data. Paid via x402 micropayments.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/stamp-server-json.mjs
+++ b/scripts/stamp-server-json.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// Generate server.json (the MCP registry manifest) from server.template.json,
+// stamping the version from package.json so the two can never drift apart.
+//
+// The old failure mode: server.json was hand-edited and gitignored, so its
+// version silently fell behind package.json/npm (0.23.1 vs 0.26.0) and the
+// registry publish was forgotten entirely (frozen at 0.2.2 since January).
+// Single source of truth = package.json "version". Run in CI before publish.
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+const version = pkg.version;
+if (!version || version.includes("template")) {
+  console.error(`Refusing to stamp: package.json version is "${version}"`);
+  process.exit(1);
+}
+
+const manifest = JSON.parse(readFileSync(join(root, "server.template.json"), "utf8"));
+manifest.version = version;
+for (const p of manifest.packages ?? []) {
+  // Pin the registry entry to the exact npm version we publish.
+  if (p.identifier === pkg.name) p.version = version;
+}
+
+writeFileSync(join(root, "server.json"), JSON.stringify(manifest, null, 2) + "\n");
+console.log(`Stamped server.json → ${manifest.name} v${version} (npm ${pkg.name}@${version})`);

--- a/server.template.json
+++ b/server.template.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.BlockRunAI/blockrun-mcp",
+  "description": "Web search, deep research, prediction markets & crypto data for AI agents. Pay per call via x402.",
+  "repository": {
+    "url": "https://github.com/BlockRunAI/blockrun-mcp",
+    "source": "github"
+  },
+  "version": "0.0.0-template",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@blockrun/mcp",
+      "version": "0.0.0-template",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "description": "Optional: Your wallet private key for USDC payments (hex for Base, bs58 for Solana). If not set, a wallet is auto-generated.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true,
+          "name": "BLOCKRUN_WALLET_KEY"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

Publishing `@blockrun/mcp` was 100% manual. `npm publish` kept running (npm is at **0.26.0**) but the `mcp-publisher` step got dropped — so the **official MCP registry has been frozen at v0.2.2 since January 14**, still advertising the stale *"Access 30+ AI models"* blurb. PulseMCP, Glama, and every downstream mirror read from that registry, so our public MCP card is ~6 months and 24 versions out of date.

Root cause of the drift: `server.json` was **hand-edited and gitignored**, so its version silently fell behind (it was sitting at 0.23.1 locally, never published).

## Fix

- **`.github/workflows/publish.yml`** — on a version bump (or manual dispatch), publishes to **npm and the MCP registry** with *independent* version guards. Each target is skipped if already at the current version, so merging this **retroactively unsticks the registry to 0.26.0** while skipping the already-published npm release. Registry auth is **GitHub OIDC** (`mcp-publisher login github-oidc`) — no stored token. npm publish uses `secrets.NPM_TOKEN` (only needed for future version bumps).
- **`server.template.json` + `scripts/stamp-server-json.mjs`** — `server.json` is now *generated* from the single `package.json` version, so the manifest can never drift from npm again.
- Dropped the stale **"X/Twitter"** capability claim from the package description (we don't offer X/Twitter data).

## After merge
1. This run unsticks the registry → 0.26.0 (no secret needed).
2. Add repo secret **`NPM_TOKEN`** so the *next* version bump (e.g. #32 → 0.27.0) auto-publishes to npm too.

Verified locally: `mcp-publisher validate` ✅, `npm run build` ✅, `npm run typecheck` ✅.