### PR TITLE
chore: drop removed X/Twitter claims; model count → 55+

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-compatible-blue)](https://modelcontextprotocol.io)
 
-**Real-time data for Claude — markets, research, X/Twitter, crypto. No API keys. Pay per call.**
+**Real-time data for Claude — markets, research, web search, crypto. No API keys. Pay per call.**
 
 ```bash
 claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest
@@ -186,7 +186,7 @@ Then send USDC (SPL) on the **Solana** network — from Coinbase (pick "Solana")
 
 | Tool | Data source | Cost |
 |------|-------------|------|
-| `blockrun_chat` | 66+ LLMs (GPT, Claude, Gemini, DeepSeek, Kimi K2.6, GLM, NVIDIA free tier, ...) with `mode` tier routing | per token |
+| `blockrun_chat` | 55+ LLMs (GPT, Claude, Gemini, DeepSeek, Kimi K2.6, GLM, NVIDIA free tier, ...) with `mode` tier routing | per token |
 | `blockrun_image` | Generation: openai/gpt-image-2 ($0.06–0.12) — flagship, reasoning + text; openai/gpt-image-1 ($0.02–0.04); google/nano-banana ($0.05) / nano-banana-pro ($0.10–0.15, 4K); xai/grok-imagine-image ($0.02) / -pro ($0.07); zai/cogview-4 ($0.015). Edit: openai/gpt-image-*, google/nano-banana* (img2img, inpaint, fusion). | $0.015–0.15 |
 | `blockrun_video` | Sora 2 + xAI Grok Imagine Video + ByteDance Seedance 1.5/2.0/2.0-fast (720p + audio defaults); RealFace asset → real-person video | $0.05–0.30/sec |
 | `blockrun_realface` | Enroll a real person (phone liveness) or an AI character (Virtual Portrait, no liveness) as a `ta_xxxx` asset for Seedance 2.0 video | free; $0.01 to enroll |

--- a/skills/exa-research/SKILL.md
+++ b/skills/exa-research/SKILL.md
@@ -166,7 +166,7 @@ answer = client._request_with_payment_raw("/v1/exa/answer", {
 | Use `blockrun_exa` / `_request_with_payment_raw` | Use `client.search()` |
 |---------------------------------------------------|----------------------|
 | Finding specific URLs and fetching content | Getting a summarized answer with citations |
-| Semantic similarity search | Web + X/Twitter + news combined |
+| Semantic similarity search | Web + news combined |
 | Academic paper discovery | Cheaper per call for simple lookups |
 | Domain-filtered research | Already returns a SearchResult object |
 

--- a/skills/search/SKILL.md
+++ b/skills/search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: search
-description: Use when the user wants real-time web, news, or X/Twitter results with AI-summarized answers and citations — Grok Live Search via BlockRun. Cheapest path for "what just happened" questions where freshness beats neural-semantic ranking.
+description: Use when the user wants real-time web or news results with AI-summarized answers and citations — Grok Live Search via BlockRun. Cheapest path for "what just happened" questions where freshness beats neural-semantic ranking.
 triggers:
   - "live search"
   - "grok live"
@@ -10,14 +10,12 @@ triggers:
   - "today's news"
   - "search with citations"
   - "cited search"
-  - "x search"
-  - "twitter search"
   - "news search"
 ---
 
 # Live Search (Grok)
 
-Real-time web + X/Twitter + news search with AI-summarized results and citations. **$0.025 × `max_results`** (default 10 → $0.25 per call). Best for *fresh* queries; for semantic / neural research use `blockrun_exa` instead.
+Real-time web + news search with AI-summarized results and citations. **$0.025 × `max_results`** (default 10 → $0.25 per call). Best for *fresh* queries; for semantic / neural research use `blockrun_exa` instead.
 
 ## How to Call from MCP
 
@@ -34,7 +32,7 @@ blockrun_search({ body: {
 | Field | Required | Type | Notes |
 |---|---|---|---|
 | `query` | yes | string | Natural-language search query |
-| `sources` | no | string[] | Subset of `["web","x","news"]`. Default: all three. Does NOT multiply price. |
+| `sources` | no | string[] | Subset of `["web","news"]`. Default: both. Does NOT multiply price. |
 | `max_results` | no | number | 1–50, default 10. **Drives the price** at $0.025 each. |
 | `from_date` | no | string | `YYYY-MM-DD` lower bound on result date |
 | `to_date` | no | string | `YYYY-MM-DD` upper bound |

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,6 +1,6 @@
 // src/tools/search.ts
 //
-// Grok Live Search — real-time web, X/Twitter, and news search with AI-summarized
+// Grok Live Search — real-time web and news search with AI-summarized
 // results and citations. Path-based passthrough (one endpoint today, future-proof
 // for additional surfaces). Sources, pagination, dates documented in the search
 // skill, not the tool description.


### PR DESCRIPTION
Storefront cleanup for the MCP shelf (paired with the site + docs sweep).

## Changes
- **README headline** no longer advertises `X/Twitter` (we removed that capability) — now "markets, research, web search, crypto."
- **`blockrun_chat` tools row**: `66+ LLMs` → **`55+ LLMs`** (canonical count; models.ts has 55 visible / 52 live).
- **search tool comment + search/exa-research skills**: web + news only; removed the `x search` / `twitter search` triggers and dropped `x` from the documented `sources` set.

## Deliberately NOT touched (server-side decision)
The `/v1/search` gateway endpoint still *accepts/defaults* an `x` source (`src/app/api/v1/search/route.ts` in the web repo). Whether to drop `x` from the enum/default is a behavioral+billing change — flagged for @1bcMax, not bundled here.

## Left as-is (legitimate, not false claims)
- `skills/surf/*` — the resold Surf CT-mindshare product (real Twitter data we resell).
- `skills/image-prompting/*` — X/Twitter only as an image aspect-ratio use case.
- `skills/prediction-markets/*` — a wallet-identity `twitter` field from Predexon.