### PR TITLE
fix(polymarket): fund reports pending pUSD credit, not 'funded' (#226)

### DIFF
--- a/src/utils/polymarket/fund.ts
+++ b/src/utils/polymarket/fund.ts
@@ -121,6 +121,8 @@ export async function fundVault(input: { amount_usd?: number; confirm?: boolean 
       depositAuthorization,
     })) as {
       success?: boolean;
+      funded?: boolean;
+      creditPending?: boolean;
       deposit?: { txHash?: string; amountUsd?: number };
       fee?: { txHash?: string };
       error?: string;
@@ -130,15 +132,31 @@ export async function fundVault(input: { amount_usd?: number; confirm?: boolean 
       return { text: `Funding failed: ${result?.error ?? JSON.stringify(result)}`, isError: true };
     }
 
+    // success:true = the deposit was SUBMITTED to the bridge + fee charged on
+    // Base. It does NOT mean the vault is funded: the Polymarket bridge credits
+    // pUSD on Polygon asynchronously (usually minutes, occasionally 30+),
+    // off-chain and un-pollable here — don't claim "Funded" (issue #226).
     return {
       text: [
-        `✅ Funded $${amountUsd.toFixed(2)} USDC → your Polymarket vault (gasless).`,
+        `✅ Deposit of $${amountUsd.toFixed(2)} USDC submitted to the Polymarket bridge (gasless).`,
         `  from Base wallet: ${agent}`,
         ...(result.deposit?.txHash ? [`  deposit tx: https://basescan.org/tx/${result.deposit.txHash}`] : []),
-        `  It bridges + wraps to pUSD in ${vault} shortly — re-run action:"setup" to see the balance.`,
+        `  ⏳ pUSD credit to your vault ${vault} is PENDING — the bridge settles on Polygon`,
+        `     asynchronously (usually minutes, occasionally 30+). Re-run action:"setup"`,
+        `     and watch for the pUSD balance; it is not instant.`,
         `  Fee charged: $${FUND_FEE_USD}.`,
       ].join("\n"),
-      structured: { success: true, amountUsd, agent, bridge, vault, deposit: result.deposit, fee: result.fee },
+      structured: {
+        success: true,
+        funded: false,
+        creditPending: true,
+        amountUsd,
+        agent,
+        bridge,
+        vault,
+        deposit: result.deposit,
+        fee: result.fee,
+      },
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Rebased replacement for #37 onto current main (which added the $2 bridge minimum + vault-deployed guards). Remaining gap: the success text still claimed '✅ Funded ... shortly'. The gateway (blockrun #227, merged) now returns funded:false/creditPending:true — this surfaces it: reports the deposit as SUBMITTED with the pUSD credit PENDING (Polygon settle is async, minutes/occasionally 30+, un-pollable). See BlockRunAI/blockrun#226.