### PR TITLE
feat(polymarket): default Tokyo egress (zero-config trading) + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,19 +268,6 @@ One wallet. All sources. No dashboards.
 
 ---
 
-## When NOT to use BlockRun MCP
-
-BlockRun shines when you want **unified billing + many sources + LLM-readable errors**. It is not the right fit for:
-
-- **High-volume single-API workloads (≥10k calls/day to one source).** Direct subscriptions amortize better past the break-even point — Polymarket's free public API plus your own caching beats $0.001 × 10k/day if you don't need cross-source aggregation.
-- **Compliance-sensitive flows that need a fiat invoice / audit trail.** BlockRun settles in USDC; receipts are on-chain (Basescan / Solscan) but are not tax invoices. For enterprise procurement, contract directly with the upstream provider.
-- **Latency-critical sub-100ms reads.** Each x402 call adds ~200–500ms of payment-signing + settlement overhead vs. a direct authenticated request. For HFT-style flows, run your own infra.
-- **You only need one source forever.** If you'll only ever call Polymarket, or only ever Exa, save the indirection — sign up upstream and skip the wallet.
-
-Use BlockRun when you want pay-per-call for *exploration*, *aggregation*, or *agent-driven* workloads where you can't predict which source you'll reach for next.
-
----
-
 ## Multi-agent budget delegation
 
 Delegate a spending budget to a child agent with `agent_id`. The child is auto-blocked when the budget runs out — useful for autonomous agents that shouldn't run up unbounded costs.
@@ -323,7 +310,7 @@ Delegate a spending budget to a child agent with `agent_id`. The child is auto-b
 
 **Safety rails** (server-side; an agent cannot bypass them): `confirm:true` required for every order/approval/redeem, `POLYMARKET_MAX_BET_USD` per-order cap (default $25), optional `POLYMARKET_MAX_SESSION_USD` session cap, and bets never draw from the x402 API budget.
 
-**Regions:** Polymarket geoblocks *opening* positions from ~35 countries (US/UK/EU are close-only — cancel/sell/redeem still work). `setup` reports your status (the check runs through the same egress your orders will).
+**Regions:** Polymarket geoblocks order placement by IP (US/UK/EU + many regions). **Handled by default** — the MCP routes CLOB traffic through BlockRun's hosted Tokyo egress, so trading works out of the box; `setup` reports your status. Override `POLYMARKET_CLOB_HOST` to go direct or run your own egress.
 
 To route through a permitted egress you operate (e.g. a small always-on VM in an unrestricted region), two options:
 
@@ -346,7 +333,7 @@ Run your egress proxy **authenticated** (not an open relay — open proxies get 
 | `~/.blockrun/.chain` | unset | Optional explicit chain preference: `base` or `solana`. |
 | `~/.blockrun/.solana-session` | not created | Solana private key. File exists → switch to Solana unless `.chain` says `base`. |
 | `SOLANA_WALLET_KEY` | unset | Env-var override of `.solana-session`. Set → use Solana. |
-| `POLYMARKET_CLOB_HOST` | `clob.polymarket.com` | Point at a permitted-region egress/relay to place orders from a geoblocked region. Relayer creds are auto-bootstrapped from your wallet — no Polymarket API keys needed. |
+| `POLYMARKET_CLOB_HOST` | BlockRun Tokyo relay | Geoblock egress for order placement — **defaulted for you** so trading works out of the box. Override to go direct (`https://clob.polymarket.com`) or point at your own egress. Relayer creds are auto-bootstrapped from your wallet — no Polymarket API keys needed. |
 | `POLYMARKET_MAX_BET_USD` | `25` | Hard per-order notional cap for `blockrun_polymarket`. |
 | `POLYMARKET_MAX_SESSION_USD` | unset | Optional cumulative per-process betting cap. |
 | `POLYMARKET_SIG_TYPE` | `3` | `3` = deposit wallet (POLY_1271, gasless); `0` = plain EOA mode. |

--- a/docs/polymarket-trading-setup.md
+++ b/docs/polymarket-trading-setup.md
@@ -29,9 +29,9 @@ order that matched** — no Polymarket account, no manual API keys, no gas token
 - **No Polymarket account, no API keys.** The MCP bootstraps everything it needs
   (a builder key for the gasless relayer) from your own wallet, automatically, on
   first `setup`.
-- **Geoblock.** Polymarket blocks *order placement* by IP (US / UK / EU and many
-  regions). Route order traffic through a permitted **egress** (§3). Reads,
-  funding, and your x402/AI traffic are unaffected.
+- **Geoblock — handled for you.** Polymarket blocks *order placement* by IP
+  (US / UK / EU and many regions). The MCP defaults to BlockRun's Tokyo egress, so
+  it works out of the box (§3). Reads, funding, and x402/AI traffic stay direct.
 
 ---
 
@@ -70,48 +70,44 @@ in the very wallet that pays your AI bills. Lose the key, lose both — **back u
 
 ---
 
-## 3. Get past the geoblock (egress)
+## 3. Geoblock — handled by default
 
-From the US/EU a raw order returns `403 Trading restricted in your region`. You
-need order traffic to leave from a permitted region (e.g. Japan, where the API is
-unrestricted). Two ways:
+Polymarket blocks order placement by IP (US / UK / EU and many regions). **You
+don't need to do anything** — the MCP defaults to BlockRun's hosted Tokyo egress,
+so orders route through a permitted region out of the box, and `action:"setup"`
+confirms `✅ Region: order placement permitted`. The relay only forwards to
+Polymarket's CLOB (it can't see or move your funds — every order is signed
+locally by your key); reads, funding, and x402/AI traffic stay direct.
 
-### Option A — a Tokyo relay (simplest)
+**Run your own instead** (production, scale, or your own compliance posture) —
+override `POLYMARKET_CLOB_HOST`:
 
-Point the CLOB host at a relay that egresses from Tokyo:
+- Direct to Polymarket (only works from a permitted region):
+  ```
+  POLYMARKET_CLOB_HOST=https://clob.polymarket.com
+  ```
+- Your own Cloud Run relay — one command, `asia-northeast1`, no VM or public IP
+  (works even under a `vmExternalIpAccess=DENY` org policy):
+  ```bash
+  bash deploy/tokyo-egress/deploy.sh     # deploys, prints the URL → use as POLYMARKET_CLOB_HOST
+  ```
+- A forward proxy in a permitted region:
+  ```
+  HTTPS_PROXY=http://user:pass@host:port            # covers CLOB + relayer
+  POLYMARKET_CLOB_PROXY=http://user:pass@host:port  # Polymarket-only
+  ```
 
-```
-POLYMARKET_CLOB_HOST=https://<your-tokyo-relay>/clob
-```
-
-Deploy your own in one command (Google Cloud Run, `asia-northeast1` — no VM or
-public IP needed, works even under a `vmExternalIpAccess=DENY` org policy):
+Check any egress reaches CLOB V2 and isn't geoblocked (`401` = permitted; `403` =
+blocked):
 
 ```bash
-bash deploy/tokyo-egress/deploy.sh     # deploys, prints the URL
-```
-
-Sanity-check it reaches CLOB V2 from Tokyo and the order endpoint is **not**
-geoblocked (`401` = needs auth = permitted; `403` = still blocked):
-
-```bash
-curl -s   <RELAY>/clob/version                                   # → {"version":2}
-curl -s -o /dev/null -w "%{http_code}\n" -X POST <RELAY>/clob/order \
+curl -s   <CLOB_HOST>/version                                    # → {"version":2}
+curl -s -o /dev/null -w "%{http_code}\n" -X POST <CLOB_HOST>/order \
      -H "content-type: application/json" -d '{}'                 # → 401  (good)
 ```
 
-### Option B — a forward proxy
-
-Any authenticated proxy in a permitted region:
-
-```
-HTTPS_PROXY=http://user:pass@host:port        # covers CLOB + relayer
-# or, Polymarket-only (leaves x402/LLM traffic direct):
-POLYMARKET_CLOB_PROXY=http://user:pass@host:port
-```
-
 > The relayer (deploy/approve/redeem) is **not** geoblocked, so only order
-> placement strictly needs the egress. Routing everything through it is harmless.
+> placement needs the egress.
 
 ---
 
@@ -125,8 +121,9 @@ Add the env to your `blockrun` registration (in `~/.claude.json`, the server's
   "command": "npx",
   "args": ["-y", "@blockrun/mcp@latest", "--profile", "trading"],
   "env": {
-    // Egress for order placement (§3) — required from a restricted region:
-    "POLYMARKET_CLOB_HOST": "https://<your-tokyo-relay>/clob",
+    // Geoblock egress is handled by default (BlockRun's Tokyo relay) — you only
+    // need POLYMARKET_CLOB_HOST to run your own egress or go direct (§3).
+    // "POLYMARKET_CLOB_HOST": "https://clob.polymarket.com",
 
     // Optional safety knobs:
     "POLYMARKET_MAX_BET_USD": "25",       // per-order cap (default 25)
@@ -135,11 +132,12 @@ Add the env to your `blockrun` registration (in `~/.claude.json`, the server's
 }
 ```
 
-**That's the whole config.** No `POLYMARKET_RELAYER_API_KEY`, no Polymarket
-account, no API keys — the MCP creates the builder key it needs from your wallet
-on first `setup`. (Advanced: `POLYMARKET_SIG_TYPE=0` switches to plain-EOA mode,
-where you hold pUSD and pay POL gas yourself — useful for reads, but the deposit
-wallet is the path that places orders.)
+**Nothing here is required.** No Polymarket account, no API keys, no egress
+config — the MCP bootstraps its builder key from your wallet on first `setup` and
+defaults the geoblock egress for you; the knobs above are optional. (Advanced:
+`POLYMARKET_SIG_TYPE=0` switches to plain-EOA mode, where you hold pUSD and pay
+POL gas yourself — useful for reads, but the deposit wallet is the path that
+places orders.)
 
 ---
 

--- a/skills/polymarket-trading/SKILL.md
+++ b/skills/polymarket-trading/SKILL.md
@@ -17,6 +17,10 @@ this tool only trades.
   signer's EIP-712 signatures. Deploy/approve/redeem are **gasless** (relayer).
 - **Money separation**: bets spend pUSD on Polygon; x402 API fees spend USDC on
   Base. The budget ledger does NOT cover bets — `confirm:true` + caps do.
+- **Zero setup**: no Polymarket account, no API keys, no gas token. On first
+  `setup` the MCP bootstraps a builder key from the user's OWN wallet, then
+  derives + deploys the vault (all gasless). Geoblock is handled by default —
+  CLOB traffic routes through BlockRun's Tokyo egress out of the box.
 
 ## Golden rules for agents
 
@@ -39,7 +43,10 @@ this tool only trades.
 blockrun_polymarket action:"setup"
 # → deposit wallet address + funding instructions + region status
 
-# 2. User funds the DEPOSIT WALLET with pUSD (or USDC via Polymarket bridge)
+# 2. Fund the vault from the user's Base USDC — gasless x402, one call ($0.01 fee,
+#    non-custodial). pUSD credit is ASYNC (minutes) — re-run setup to watch it. Min $2.
+blockrun_polymarket action:"fund" amount_usd:5             # dry-run preview
+blockrun_polymarket action:"fund" amount_usd:5 confirm:true
 
 # 3. Sign the one-time gasless approval batch (after user consent)
 blockrun_polymarket action:"setup" confirm:true
@@ -61,6 +68,10 @@ blockrun_polymarket action:"positions"                  # holdings + PnL + redee
 # 7. Claim winnings after resolution (gasless)
 blockrun_polymarket action:"redeem" condition_id:"0x..."             # preview
 blockrun_polymarket action:"redeem" condition_id:"0x..." confirm:true
+
+# 8. Cash out — pUSD → native USDC on Base, back to the user's agent wallet
+blockrun_polymarket action:"withdraw"                                # dry-run (full balance)
+blockrun_polymarket action:"withdraw" confirm:true                   # (partial: amount_usd:5)
 ```
 
 ## Order semantics
@@ -73,17 +84,19 @@ blockrun_polymarket action:"redeem" condition_id:"0x..." confirm:true
 
 ## Regions / geoblock
 
-Opening positions is IP-geoblocked in ~35 countries (US/UK/EU = close-only;
-cancel/sell/redeem still work there). `setup` reports status. A user-operated
-egress can be set via `POLYMARKET_CLOB_PROXY` (Polymarket traffic only) or
-`HTTPS_PROXY`. Respecting Polymarket's ToS for the user's jurisdiction is the
-user's responsibility — never suggest evading restrictions.
+Order placement is IP-geoblocked (US/UK/EU + many regions). **Handled by
+default** — CLOB traffic routes through BlockRun's Tokyo egress, so `setup`
+reports `✅ Region: order placement permitted` out of the box; you don't need to
+do anything. A user can override with `POLYMARKET_CLOB_HOST` (their own relay),
+or `POLYMARKET_CLOB_PROXY` / `HTTPS_PROXY`. Respecting Polymarket's ToS for the
+user's jurisdiction is the user's responsibility — never suggest evading it.
 
 ## Troubleshooting
 
 - "No deposit wallet configured" → run `action:"setup"`.
-- "relayer API credentials are not configured" → the env vars above; or
-  `POLYMARKET_SIG_TYPE=0` for EOA mode (needs POL gas + pUSD in the EOA).
+- No manual creds are ever needed — the MCP bootstraps its builder key from the
+  user's own wallet on first `setup`. (Advanced: `POLYMARKET_SIG_TYPE=0` = plain
+  EOA mode; needs POL gas + pUSD in the EOA, and is read-only for orders.)
 - Balance/allowance errors right after funding → `setup` again (refreshes the
   CLOB's balance cache).
 - 403 → region issue; see setup's region line.

--- a/src/utils/polymarket/constants.ts
+++ b/src/utils/polymarket/constants.ts
@@ -51,8 +51,14 @@ export function assertContractConfig(): void {
 }
 
 // --- Hosts (env-overridable so Phase 2 can point them at the BlockRun gateway) ---
+// CLOB order placement is geoblocked by IP (US/UK/EU and many regions). We
+// DEFAULT to BlockRun's hosted Tokyo egress so trading works out of the box with
+// zero config — it only forwards to Polymarket's CLOB (it can't see or move
+// funds; every order is still signed locally by the user's key). Override with
+// POLYMARKET_CLOB_HOST to hit Polymarket directly (from a permitted region) or to
+// run your own egress. Direct Polymarket host: https://clob.polymarket.com
 export const CLOB_HOST =
-  process.env.POLYMARKET_CLOB_HOST || "https://clob.polymarket.com";
+  process.env.POLYMARKET_CLOB_HOST || "https://pm-egress-vbsbhh7lea-an.a.run.app/clob";
 export const RELAYER_URL =
   process.env.POLYMARKET_RELAYER_URL || "https://relayer-v2.polymarket.com";
 export const DATA_API_HOST =


### PR DESCRIPTION
**Zero-config geoblock.** CLOB order placement is IP-geoblocked (US/UK/EU + many
regions). This defaults `POLYMARKET_CLOB_HOST` to BlockRun's hosted Tokyo egress
so trading works out of the box — verified: with no env set, the region check
reports `permitted` egressing from JP. Still fully overridable (go direct from a
permitted region, or run your own relay). The relay only forwards to Polymarket's
CLOB — it can't see or move funds; every order is still signed locally.

> Operational note: this makes the relay production-critical for order placement.
> It should be monitored/maintained (not a throwaway demo), and routing all users'
> order flow through it has the compliance considerations already flagged in the
> plan (interface/relayer status). Worth a follow-up decision.

**Docs.**
- Reframe the geoblock sections (guide §0/§3/§4, README, SKILL.md) around the
  default: nothing to configure; override only to run your own.
- **Teach the agent** (`SKILL.md`): the zero-setup model (builder key
  bootstrapped from the user's own wallet, gasless vault deploy), funding via
  x402 (`action:"fund"`, async pUSD credit), the `withdraw` cash-out step, and
  drop the stale relayer-creds troubleshooting line.
- Remove the 'When NOT to use BlockRun MCP' self-deprecating section from README.

Docs + one default value; typecheck, build, 148 tests green.