### PR TITLE
fix(release): correct repository.url casing so provenance publish works (unblocks 0.30.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/blockrunai/blockrun-mcp"
+    "url": "https://github.com/BlockRunAI/blockrun-mcp"
   },
   "homepage": "https://blockrun.ai",
   "bugs": {
-    "url": "https://github.com/blockrunai/blockrun-mcp/issues"
+    "url": "https://github.com/BlockRunAI/blockrun-mcp/issues"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",


### PR DESCRIPTION
**This is why npm has been frozen at 0.28.0.** `npm publish --provenance` rejected
every release with:

```
E422 — Error verifying sigstore provenance bundle: package.json "repository.url"
is ".../blockrunai/blockrun-mcp.git", expected to match ".../BlockRunAI/blockrun-mcp"
```

The build + test steps passed; publish then failed on the provenance check because
`repository.url` used lowercase `blockrunai` while the real GitHub owner (and the
OIDC provenance) is `BlockRunAI`. So 0.29.0 and 0.30.0 built and tested fine but
never published.

Fixes the casing on `repository.url` and `bugs.url`. Merging re-triggers
`publish.yml` (package.json changed); 0.30.0 was never published, so it publishes
now → `npx @blockrun/mcp@latest` finally serves the whole Polymarket feature.