### PR TITLE
ci(publish): resolve the registry's LATEST version, not servers[0]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
           PKG=$(node -p "require('./package.json').version")
           NPM=$(npm view @blockrun/mcp version 2>/dev/null || echo "none")
           REG=$(curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.BlockRunAI/blockrun-mcp" \
-                | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{const j=JSON.parse(s);console.log(j.servers?.[0]?.server?.version||'none')}catch{console.log('none')}})")
+                | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{const j=JSON.parse(s);const a=j.servers||[];const cur=a.find(x=>x['_meta']?.['io.modelcontextprotocol.registry/official']?.isLatest)||a[a.length-1];console.log(cur?.server?.version||'none')}catch{console.log('none')}})")
           echo "pkg=$PKG"  >> "$GITHUB_OUTPUT"
           echo "npm=$NPM"  >> "$GITHUB_OUTPUT"
           echo "reg=$REG"  >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
**The MCP registry was never actually stuck.** It has every version of
`io.github.BlockRunAI/blockrun-mcp` including **0.30.1**, correctly marked
`isLatest: true, status: active`. The scare came from the publish workflow's
version guard: it read `j.servers[0].server.version` from the registry search,
but the registry returns *all* version-records and `servers[0]` is the **oldest**
(0.2.2, Jan 2026). So `reg` was permanently `0.2.2` → the 'already published?'
check never matched (harmless re-publishes) and it *looked* frozen.

Fix: pick the record whose `_meta.io.modelcontextprotocol.registry/official.isLatest`
is true. Verified live: new resolver → `0.30.1`, old → `0.2.2`.

CI-only (no package change, no version bump). On merge the workflow runs and now
correctly **skips** both npm and registry (both already at 0.30.1).