### PR TITLE
docs: drop routing:"smart" claims the 0.30.6 release deleted (0.30.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to BlockRun MCP will be documented in this file.
 
+## 0.30.7
+
+- **`docs` — the README documented a feature 0.30.6 deleted.** `routing:"smart"` was removed from `blockrun_chat` along with the ClawRouter dependency, but three README claims survived the release and shipped inside the package (`files` includes `README.md`, so it is also what npmjs.com renders): the Base-only fallback list, a **CRITICAL** note telling agents smart routing is Base-only, and a troubleshooting entry for a `Smart routing (ClawRouter) not available on Solana` error that can no longer occur. Anyone following them would pass `routing:"smart"`, get nothing back, and reasonably conclude the server was broken — the exact failure mode 0.30.6 set out to end. Removed all three. The ClawRouter links under Related Projects stay: it is still a real product, just no longer anything this server depends on.
+- No code change; `dist/` is byte-identical to 0.30.6.
+
 ## 0.30.6
 
 - **`fix(deps)` — decouple from ClawRouter, and bust the npx caches poisoned by its outage.** From 2026-07-11 to 07-14, `npx -y @blockrun/mcp@latest` could not start at all: `SyntaxError: Identifier '__cjs_createRequire' has already been declared`. Nothing was wrong with this package. `@blockrun/clawrouter@0.12.220` published a bundle that had inlined a stale copy of *itself* (it and `@blockrun/llm` depend on each other, so its own `noExternal` build resolved the back-import to the last published dist in `node_modules`), and the duplicated banner made every entrypoint a load-time `SyntaxError`. Fixed upstream in `@blockrun/clawrouter@0.12.222`.

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ blockrun_wallet action:"setup"                  # shows the Solana address + fun
 
 Then send USDC (SPL) on the **Solana** network — from Coinbase (pick "Solana"), Phantom, Solflare, or Backpack. Switch back with `blockrun_wallet action:"chain" chain:"base"`. The server keeps both wallets; switching just changes which one pays.
 
-**Base-only** — these fall back to Base regardless of active chain: `blockrun_music`, `blockrun_speech`, `blockrun_video`, paid `blockrun_realface`, paid stock `blockrun_price`, `blockrun_chat routing:"smart"` (ClawRouter), and native Anthropic (`claude-*`) passthrough. In Solana mode they return a "switch to Base" message instead of charging. `blockrun_image` pays on either chain.
+**Base-only** — these fall back to Base regardless of active chain: `blockrun_music`, `blockrun_speech`, `blockrun_video`, paid `blockrun_realface`, paid stock `blockrun_price`, and native Anthropic (`claude-*`) passthrough. In Solana mode they return a "switch to Base" message instead of charging. `blockrun_image` pays on either chain.
 
 ---
 
@@ -298,7 +298,6 @@ Then send USDC (SPL) on the **Solana** network — from Coinbase (pick "Solana")
 - **CRITICAL: On any payment / balance / 402 error, call `blockrun_wallet` *first*** to check status, then `action:"setup"` for funding. Don't retry the failing tool blindly — the wallet is empty.
 - **CRITICAL: `blockrun_polymarket` moves REAL user funds** (pUSD on Polygon), separate from the x402 API budget. Never `buy`/`sell`/`redeem` with `confirm:true` unless the user explicitly approved that exact trade; without `confirm` you get a safe dry-run. Discover markets/token IDs with `blockrun_markets` first.
 - **CRITICAL: `blockrun_surf`'s 84-endpoint catalog is in [`skills/surf/SKILL.md`](skills/surf/SKILL.md); `blockrun_markets`' full endpoint list is in its tool description** (worked examples in [`skills/prediction-markets/SKILL.md`](skills/prediction-markets/SKILL.md)). Browse those before guessing paths.
-- **CRITICAL: `blockrun_chat routing:"smart"` (ClawRouter) only works on Base wallets.** On Solana, pass `mode:` or `model:` directly.
 - **CRITICAL: `blockrun_music` and `blockrun_video` are payment-on-completion async.** Failures / client timeouts do NOT charge. Don't retry-loop — they may take 60–180s.
 - **CRITICAL: Before spawning child agents, allocate per-agent budget:** `blockrun_wallet action:"delegate" agent_id:"X" agent_limit:1.00`, then pass `agent_id:"X"` to every downstream call. The child is auto-blocked at zero.
 - **Free tier first for drafts:** `blockrun_chat mode:"free"` (NVIDIA), `blockrun_dex`, `blockrun_price` (crypto/FX/commodity), and `blockrun_models` are $0.
@@ -374,7 +373,6 @@ The server runs a non-blocking npm registry check at startup and prints an `Upda
   ```
   Then restart Claude Code. Or pin absolute paths (`which npx`).
 - **`claude mcp list` doesn't show `blockrun`** → Check `node -v` (≥20.19). Clear the npx cache: `rm -rf ~/.npm/_npx`. Re-run the install.
-- **`Smart routing (ClawRouter) not available on Solana`** → Pass `model:` or `mode:` to `blockrun_chat`, or `echo base > ~/.blockrun/.chain`.
 - **`fetch failed` / balance-check timeout** → Base RPC transient outage. The tool falls through 3 public RPCs; retry after 30s. Persistent = local proxy / firewall blocking outbound RPC.
 - **`Video`/`Music generation timed out`** → Upstream queue congestion. **No charge** (payment-on-completion). Retry, or pick a faster model.
 - **Polymarket: neg-risk ("winner") market buy fails, or `redeem` reverts, though setup shows ready** → Re-run `action:"setup" confirm:true` once (grants the on-chain approvals a pre-upgrade deposit wallet may lack — including the collateral-adapter approvals `redeem` needs). See the [setup guide](docs/polymarket-trading-setup.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.30.6",
+  "version": "0.30.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/mcp",
-      "version": "0.30.6",
+      "version": "0.30.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.30.6",
+  "version": "0.30.7",
   "mcpName": "io.github.BlockRunAI/blockrun-mcp",
   "description": "BlockRun MCP Server - Give your AI agent web search, deep research, prediction markets, and crypto data. Paid via x402 micropayments.",
   "type": "module",


### PR DESCRIPTION
## Why

0.30.6 removed `routing:"smart"` from `blockrun_chat` along with the ClawRouter dependency — but **three README claims survived the release**:

| line | stale claim |
|---|---|
| 290 | lists `blockrun_chat routing:"smart"` (ClawRouter) in the Base-only fallback list |
| 301 | **CRITICAL:** `blockrun_chat routing:"smart"` (ClawRouter) only works on Base wallets |
| 377 | troubleshooting for `Smart routing (ClawRouter) not available on Solana` — an error that can no longer occur |

`README.md` is in `files`, so it **ships inside the package** and is what npmjs.com renders. Anyone following it — including the external user whose report triggered the 0.30.6 work — would pass `routing:"smart"`, get nothing back, and reasonably conclude the server was broken. That is the exact failure mode 0.30.6 set out to end.

Line 301 is worse than a stale doc: it is addressed to **LLMs** under "For agents & LLMs", so it actively instructs agents toward a parameter that no longer exists.

## What

Removed all three. No code change — `dist/` is byte-identical to 0.30.6.

The ClawRouter links under Related Projects **stay**: it is still a real product, just no longer anything this server depends on.

## Verified

```
✓ no routing:"smart" / routing_profile / "Smart routing" left in README.md or skills/
✓ typecheck, build, 151 tests green
```