### PR TITLE
fix(search): reserve what the gateway settles; typecheck tests (0.30.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to BlockRun MCP will be documented in this file.
 
+## 0.30.10
+
+- **`fix(search)` — the budget gate reserved less than a search actually costs.** `blockrun_search` is the most expensive tool here (priced per *source*: a default call settles ~$0.26 while most tools cost $0.001), and its reserve mirrored `$0.025 x max_results` — but the gateway settles **5% above that, rounded up to 4dp**. So every search reserved short, and the gate exists precisely to stop an agent overshooting its cap. Verified against the gateway's own 402 quotes, which are free to request (send any call with no payment header and it replies with the exact price): `max_results` 1/5/10/20/50 quote $0.0263/$0.1313/$0.2625/$0.5250/$1.3125 — the reserve now matches each exactly.
+- Computed in **integer micro-dollars**, because the float form is not exact: `0.025 * 1.05` is `0.026250000000000002`, which rounds to `$0.026251` — still under the gateway's `$0.0263`, i.e. still short. A reserve must never be short. New `test/search-cost.test.ts` pins the five live quotes, the bare-`{query}` default, the 50-source ceiling, and that garbage `max_results` (`0`, `-5`, `"10"`, `null`, `NaN`, `{}`) falls back to the default reserve rather than $0 — a $0 reserve is a gate bypass.
+- The tool description was understating it too (`default max_results=10 → $0.25`); it now leads with the fact that search is priced per source and expensive by default (~$0.26 at the default, ~$1.31 at 50), and suggests capping `max_results`.
+- **`fix(build)` — tests were never typechecked.** `tsconfig.json` had `include: ["src/**/*"]`, so `npm run typecheck` passed while `test/` contained genuine type errors — which is exactly how 0.30.6's broken `estimateChatCost` call signatures reached a commit. Proven before fixing: a planted `const _bad: number = "definitely not a number"` in `test/chat.test.ts` typechecked clean. Now `include: ["src/**/*", "test/**/*"]` and the same planted error fails with `TS2322`. `dist/` is unaffected (tsup builds from `entry`, not `include`) — no test artifacts ship.
+
 ## 0.30.9
 
 - **`docs(skills)` — new `crypto-data` skill: three crypto tools had no skill, and agents were paying for data two of them give away free.** `blockrun_defi` (DefiLlama TVL/yields), `blockrun_price` (Pyth quotes + OHLC for crypto/FX/commodities/12 stock markets), and `blockrun_dex` (DexScreener pairs/liquidity) were mentioned only in passing by the general `gentech-blockrun` catalog — no triggers, no paths, no examples. They were effectively undiscoverable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.30.9",
+  "version": "0.30.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/mcp",
-      "version": "0.30.9",
+      "version": "0.30.10",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.30.9",
+  "version": "0.30.10",
   "mcpName": "io.github.BlockRunAI/blockrun-mcp",
   "description": "BlockRun MCP Server - Give your AI agent web search, deep research, prediction markets, and crypto data. Paid via x402 micropayments.",
   "type": "module",

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -22,21 +22,34 @@ type RawClient = {
 // Pricing scales with max_results (capped 1–50, default 10 upstream) at
 // $0.025 per returned source. Mirrors getSearchPrice() in
 // blockrun/src/app/api/v1/search/route.ts.
-const SEARCH_PRICE_PER_SOURCE = 0.025;
 const SEARCH_DEFAULT_MAX_RESULTS = 10;
+// The gateway settles 5% above $0.025 × max_results, then rounds UP to 4dp.
+// Verified against its own 402 quotes, which are free to request (send any call
+// with no payment header): max_results 1/5/10/20/50 quote
+// $0.0263/$0.1313/$0.2625/$0.5250/$1.3125. Reserving the unbuffered $0.025 × n
+// left the gate short of what the call actually settles at — the exact overshoot
+// the reserve exists to prevent.
+//
+// Integer micro-dollars, because the float form is not exact: 0.025 * 1.05 is
+// 0.026250000000000002, which rounds to $0.026251 — still under the gateway's
+// $0.0263, i.e. still short. A reserve must never be short.
+const SEARCH_MICRO_PER_SOURCE = 26_250; // $0.025 x 1.05, exact in micro-dollars
+const SEARCH_MICRO_QUANTUM = 100; // the gateway quotes to 4dp = 100 micro-dollars
 
-function estimateSearchCost(body: unknown): number {
-  if (!body || typeof body !== "object") return SEARCH_PRICE_PER_SOURCE * SEARCH_DEFAULT_MAX_RESULTS;
+export function estimateSearchCost(body: unknown): number {
+  const reserve = (max: number) =>
+    (Math.ceil((SEARCH_MICRO_PER_SOURCE * max) / SEARCH_MICRO_QUANTUM) * SEARCH_MICRO_QUANTUM) / 1e6;
+  if (!body || typeof body !== "object") return reserve(SEARCH_DEFAULT_MAX_RESULTS);
   const raw = (body as { max_results?: unknown }).max_results;
   const max = typeof raw === "number" && raw > 0 ? Math.min(50, Math.floor(raw)) : SEARCH_DEFAULT_MAX_RESULTS;
-  return SEARCH_PRICE_PER_SOURCE * max;
+  return reserve(max);
 }
 
 export function registerSearchTool(server: McpServer, budget: BudgetState): void {
   server.registerTool(
     "blockrun_search",
     {
-      description: `Grok Live Search — real-time web + X/Twitter + news with AI-summarized results and citations. $0.025 per returned source (max_results × $0.025; default max_results=10 → $0.25).
+      description: `Grok Live Search — real-time web + X/Twitter + news with AI-summarized results and citations. PRICED PER SOURCE and expensive by default: $0.025 × max_results, +5% gateway buffer — default max_results=10 settles ~$0.26 (max_results=50 → ~$1.31). Pass a smaller max_results to cap spend; for a plain fact, 3 sources (~$0.08) is usually enough.
 
 Common shape:
 - body: { query: "...", sources: ["web","x","news"], max_results: 10, from_date: "YYYY-MM-DD", to_date: "YYYY-MM-DD" }

--- a/test/search-cost.test.ts
+++ b/test/search-cost.test.ts
@@ -1,0 +1,66 @@
+// Run with: npm test  (tsx --test)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { estimateSearchCost } from "../src/tools/search.js";
+
+// blockrun_search is the most expensive tool per call in the server — priced per
+// SOURCE, so a default call settles ~$0.26 while most tools cost $0.001. The gate
+// can only stop a looping agent if the reserve is >= what the gateway settles.
+//
+// These figures are the gateway's own 402 quotes (free to request — send any call
+// with no payment header and it replies with the exact price), captured 2026-07-14:
+//   max_results  1 → $0.0263
+//   max_results  5 → $0.1313
+//   max_results 10 → $0.2625   (default)
+//   max_results 20 → $0.5250
+//   max_results 50 → $1.3125
+// Each is exactly 1.05x per_source x max_results. If the gateway's buffer moves,
+// these pins fail — which is the point.
+const QUOTES: Array<[number, number]> = [
+  [1, 0.0263],
+  [5, 0.1313],
+  [10, 0.2625],
+  [20, 0.525],
+  [50, 1.3125],
+];
+
+test("estimateSearchCost reserves at least what the gateway actually settles", () => {
+  for (const [max, quoted] of QUOTES) {
+    const reserved = estimateSearchCost({ query: "x", max_results: max });
+    assert.ok(
+      reserved >= quoted - 1e-6,
+      `max_results=${max}: reserved $${reserved} < gateway $${quoted} — the gate would under-reserve`,
+    );
+  }
+});
+
+test("estimateSearchCost does not over-reserve by more than a cent", () => {
+  // Reserving wildly high would block calls a budget could actually afford.
+  for (const [max, quoted] of QUOTES) {
+    const reserved = estimateSearchCost({ query: "x", max_results: max });
+    assert.ok(reserved - quoted < 0.01, `max_results=${max}: reserved $${reserved} vs gateway $${quoted}`);
+  }
+});
+
+test("estimateSearchCost defaults to the 10-source price when max_results is absent", () => {
+  // Upstream defaults to 10. Reserving less than that on a bare { query } — the
+  // most common call shape — would let every default search skip the gate.
+  assert.ok(estimateSearchCost({ query: "x" }) >= 0.2625 - 1e-6);
+  assert.ok(estimateSearchCost(undefined) >= 0.2625 - 1e-6);
+  assert.ok(estimateSearchCost("not an object") >= 0.2625 - 1e-6);
+});
+
+test("estimateSearchCost caps at 50 sources, matching the upstream ceiling", () => {
+  assert.equal(estimateSearchCost({ max_results: 999 }), estimateSearchCost({ max_results: 50 }));
+});
+
+test("estimateSearchCost ignores garbage max_results instead of reserving $0", () => {
+  // A $0 reserve is a gate bypass: it would authorize a ~$0.26 call against an
+  // exhausted budget.
+  for (const bad of [0, -5, "10", null, NaN, {}]) {
+    assert.ok(
+      estimateSearchCost({ max_results: bad }) >= 0.2625 - 1e-6,
+      `max_results=${JSON.stringify(bad)} fell back below the default reserve`,
+    );
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
     "declaration": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Two fixes, both found by things that went wrong earlier in the same session.

## 1. The budget gate reserved less than a search actually costs

`blockrun_search` is the most expensive tool in the server — priced **per source**, so a default call settles ~$0.26 while most tools cost $0.001. Its reserve mirrored `$0.025 × max_results`, but **the gateway settles 5% above that, rounded up to 4dp**. Every search reserved short — and stopping an agent overshooting its cap is the entire job of the reserve.

Verified against the gateway's own 402 quotes, which are **free** to request (send any call with no payment header and it replies with the exact price):

| max_results | gateway quote | old reserve | new reserve |
|---|---|---|---|
| 1 | $0.0263 | $0.0250 ✗ | **$0.0263** ✓ |
| 5 | $0.1313 | $0.1250 ✗ | **$0.1313** ✓ |
| 10 (default) | $0.2625 | $0.2500 ✗ | **$0.2625** ✓ |
| 20 | $0.5250 | $0.5000 ✗ | **$0.5250** ✓ |
| 50 | $1.3125 | $1.2500 ✗ | **$1.3125** ✓ |

**Integer micro-dollars**, because the float form is not exact: `0.025 * 1.05` is `0.026250000000000002`, which rounds to `$0.026251` — still under the gateway's `$0.0263`, i.e. still short. My first attempt shipped exactly that bug and the new test caught it.

New `test/search-cost.test.ts` pins all five live quotes, the bare-`{query}` default, the 50-source ceiling, and that garbage `max_results` (`0`, `-5`, `"10"`, `null`, `NaN`, `{}`) falls back to the default reserve rather than **$0** — a $0 reserve is a gate bypass.

The description understated it too (`default max_results=10 → $0.25`); it now leads with the fact that search is priced per source and expensive by default, and suggests capping `max_results`.

## 2. Tests were never typechecked

`tsconfig.json` had `include: ["src/**/*"]`. Proven before fixing — a planted error typechecked **clean**:

```ts
const _bad: number = "definitely not a number";   // in test/chat.test.ts
$ npm run typecheck   → passes ✓✗
```

That is exactly how 0.30.6's broken `estimateChatCost` call signatures reached a commit; only running the tests caught them. Now `include: ["src/**/*", "test/**/*"]`, and the same planted error fails with `TS2322`.

`dist/` is unaffected — tsup builds from `entry`, not `include`. No test artifacts ship (verified).

## Verified

`typecheck` ✓ `build` ✓ **159 tests** ✓ · `dist/` contains only `index.js` + `index.d.ts`.