### PR TITLE
fix(budget): reserve the charged price, not the 402 body's base (0.31.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to BlockRun MCP will be documented in this file.
 
+## 0.31.1
+
+- **`fix(budget)` — every paid tool reserved the BASE price, not the price. The 402's JSON `price` field is not what x402 charges.** A 402 body reports `price: {amount: "0.0075"}` — that is the base. What actually gets charged is `maxAmountRequired` inside the base64 **`payment-required` header**, and it is base **+ a $0.002 flat transaction fee**. The gateway states the split itself in `src/app/api/v1/pm/[...path]/route.ts`: *"Tier 1 (GET) = $0.0095/call ($0.0075 base + $0.002 tx fee)"*. Decoded live: every `/v1/surf/*` and `/v1/pm/*` route returns `maxAmountRequired=9500` → **$0.0095**.
+- **`blockrun_markets` was ~9.5x short.** `estimateMarketCost` still returned the pre-flat tiers (`$0.001` / `$0.005`) — 0.31.0 updated the tool *description* to flat but not the estimator. So the gate reserved `$0.001` against a `$0.0095` charge, and `recordSpending()` booked `$0.001` of a `$0.0095` spend: the budget **ledger** under-counted too, not just the reserve. Now flat `$0.0095`.
+- **`blockrun_surf` was $0.002 short.** Its own comment already said *"the gateway adds a $0.002 transaction fee on top → $0.0095 customer-facing"* and *"this estimator feeds the BUDGET GATE, so it must never under-quote"* — and then set the constant to the base. Now `$0.0095`.
+- **`blockrun_search` was $0.002 short** — 0.30.10 fixed the 5% buffer but pinned the body's `price` field, so it stayed under by the flat fee at every size. Reserves now match the header exactly: `max_results` 1/5/10/20/50 → `$0.0283/$0.1333/$0.2645/$0.5270/$1.3145`. Tests repinned to the **charged** column; `test/surf.test.ts` likewise.
+- **Skills corrected**: `prediction-markets`, `crypto-data`, `surf` and `gentech-blockrun` advertised `$0.0075`. Users pay **$0.0095**. An agent budgeting off those numbers under-reserves on every call.
+- **The lesson, now written into the code**: the base is not the price. Read `maxAmountRequired` from the `payment-required` header. This has been wrong twice in the same direction — first stale tiers after the gateway went flat, then the base mistaken for the price — both times by trusting a number that looked authoritative. The public pricing pages (`/services/surf` $0.0095, `/services/predexon` GET $0.003 / POST $0.007 for the then-current base) were **right all along**.
+
 ## 0.31.0
 
 - **`fix(surf,markets)` — Surf and Predexon are now one flat $0.0075/call, and the budget gate was under-reserving.** The gateway collapsed every prediction-market / crypto-data tier to a single network-uniform price (2026-07-15). `estimateSurfCost()` still priced from tier tables ($0.001 / $0.005 / $0.02) — and it had *already* drifted before this change, since the gateway moved Surf T1/T2 to $0.0075 while the estimator kept quoting $0.001. It feeds the spend cap, so every cheap-looking call reserved less than it cost. It now returns the flat rate, which deletes the drift at the root rather than re-syncing a table that will drift again.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/mcp",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "mcpName": "io.github.BlockRunAI/blockrun-mcp",
   "description": "BlockRun MCP Server - Give your AI agent web search, deep research, prediction markets, and crypto data. Paid via x402 micropayments.",
   "type": "module",

--- a/skills/crypto-data/SKILL.md
+++ b/skills/crypto-data/SKILL.md
@@ -64,12 +64,12 @@ Five tools cover crypto data and they overlap. **Pick by cost first** — two of
 | Token price by contract address | `blockrun_defi` path:"prices/{coins}" | $0.001 |
 | Raw JSON-RPC on 40+ chains | `blockrun_rpc` | $0.002 |
 | Protocol TVL, chain TVL, yields/APY | `blockrun_defi` | $0.005 |
-| **Everything below** (on-chain SQL, wallet labels, social, news, unlocks, liquidations, ETF flows) | `blockrun_surf` | $0.0075 |
-| Raw SQL over 80+ ClickHouse tables | `blockrun_surf` path:"onchain/sql" | $0.0075 |
+| **Everything below** (on-chain SQL, wallet labels, social, news, unlocks, liquidations, ETF flows) | `blockrun_surf` | $0.0095 |
+| Raw SQL over 80+ ClickHouse tables | `blockrun_surf` path:"onchain/sql" | $0.0095 |
 
 **The rule:** a plain crypto price or a DEX pair is free. Only reach for `blockrun_surf` when you need something the free tools genuinely do not have — labels, SQL, social, news, unlocks.
 
-**Prediction markets are never a Surf question.** Surf carries `prediction-market/*` endpoints, but Predexon (`blockrun_markets`) serves the same Polymarket/Kalshi data at the **same $0.0075** — and adds wallet clustering, smart money, sports, UMA, and five more venues that Surf does not have at all. Price is no longer the argument (it was 7.5× cheaper before 2026-07-15); coverage is, and it is decisive. Route odds, positions and market history to [`skills/prediction-markets/SKILL.md`](../prediction-markets/SKILL.md).
+**Prediction markets are never a Surf question.** Surf carries `prediction-market/*` endpoints, but Predexon (`blockrun_markets`) serves the same Polymarket/Kalshi data at the **same $0.0095** — and adds wallet clustering, smart money, sports, UMA, and five more venues that Surf does not have at all. Price is no longer the argument (it was 7.5× cheaper before 2026-07-15); coverage is, and it is decisive. Route odds, positions and market history to [`skills/prediction-markets/SKILL.md`](../prediction-markets/SKILL.md).
 
 ## blockrun_price — quotes & history (Pyth-backed)
 
@@ -148,7 +148,7 @@ blockrun_rpc({ chain: "base", method: "eth_blockNumber", params: [] })
 blockrun_price({ action: "price", category: "crypto", symbol: "BTC-USD" })   // FREE
 ```
 
-Not `blockrun_surf({ path: "market/price" })` — that is $0.0075 for an answer you can get free.
+Not `blockrun_surf({ path: "market/price" })` — that is $0.0095 for an answer you can get free.
 
 ### 2. "Is this token legit?" ← compound, mostly free
 

--- a/skills/gentech-blockrun/SKILL.md
+++ b/skills/gentech-blockrun/SKILL.md
@@ -167,7 +167,7 @@ blockrun_rpc({ network: "base", method: "eth_getBalance", params: ["0xabc...", "
 blockrun_price(action="price", category="crypto", symbol="ETH-USD")
 blockrun_price(action="price", category="crypto", symbol="USDC-USD")
 
-# 3. Prediction market positions ($0.0075)
+# 3. Prediction market positions ($0.0095)
 blockrun_markets({ path: "polymarket/positions" })
 ```
 
@@ -207,12 +207,12 @@ blockrun_video({ prompt: "animated data visualization", duration_seconds: 8 })
 | `blockrun_chat` (free mode) | $0 | NVIDIA-backed chat |
 | `blockrun_chat` (glm mode) | $0.001 | Zhipu GLM-5 coding |
 | `blockrun_exa` (search) | $0.01 | deep research |
-| `blockrun_surf` | $0.0075 | crypto data, wallets/candles/search, on-chain SQL (flat) |
+| `blockrun_surf` | $0.0095 | crypto data, wallets/candles/search, on-chain SQL (flat) |
 | `blockrun_speech` | $0.05/1k chars | TTS |
 | `blockrun_image` | $0.015–0.12 | image generation |
 | `blockrun_music` | $0.1575 | music tracks |
 | `blockrun_video` | $0.40+ | short video clips |
-| `blockrun_markets` | $0.0075 | prediction market data, wallet analytics (flat) |
+| `blockrun_markets` | $0.0095 | prediction market data, wallet analytics (flat) |
 | `blockrun_modal` | $0.001+ | remote sandbox execution |
 | `blockrun_phone` | $0.01–5.00 | phone lookups |
 

--- a/skills/prediction-markets/SKILL.md
+++ b/skills/prediction-markets/SKILL.md
@@ -77,7 +77,7 @@ Paths are relative — no `/api/v1/pm/` prefix. Use `agent_id` to bill a child a
 
 | Tier | Price | What |
 |---|---|---|
-| **All endpoints** | $0.0075 | Market data, events, history, candles, orderbooks, trades, leaderboard, sports, UMA, wallet analytics, smart money, identity + clustering, cross-venue matching, Binance |
+| **All endpoints** | $0.0095 | Market data, events, history, candles, orderbooks, trades, leaderboard, sports, UMA, wallet analytics, smart money, identity + clustering, cross-venue matching, Binance |
 
 Pass-through pricing, 0% BlockRun margin — settles straight to Predexon's Base treasury.
 

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -59,10 +59,10 @@ blockrun_surf({ path: "chat/completions", body: {
 
 | Tier | Price | Used by |
 |------|-------|---------|
-| Standard | $0.0075 | every read: prices, rankings, news, order books, candles, search, wallet detail, social, prediction markets (80 endpoints) |
+| Standard | $0.0095 | every read: prices, rankings, news, order books, candles, search, wallet detail, social, prediction markets (80 endpoints) |
 | Premium | $0.0200 | raw on-chain SQL, schema introspection, structured queries (3 endpoints) |
 
-Verified against the gateway's own 402 responses, which are free to request — send any call with no payment header and it replies with the exact price. Standard is genuinely flat: `market/price`, `wallet/labels/batch`, `social/mindshare`, `news/feed`, `exchange/klines` and `search/web` all quote $0.0075.
+Verified against the gateway's own 402 responses, which are free to request — send any call with no payment header and it replies with the exact price. Standard is genuinely flat: `market/price`, `wallet/labels/batch`, `social/mindshare`, `news/feed`, `exchange/klines` and `search/web` all quote $0.0095.
 
 Wrong / missing required params return HTTP 400 **without charging** — pre-validation runs before settlement.
 
@@ -74,7 +74,7 @@ Predexon used to be 7.5× cheaper; since 2026-07-15 both bill the same flat rate
 
 | | Predexon (`blockrun_markets`) | Surf |
 |---|---|---|
-| Polymarket / Kalshi markets | $0.0075 | $0.0075 (same) |
+| Polymarket / Kalshi markets | $0.0095 | $0.0095 (same) |
 | Wallet clustering, smart money, leaderboards | ✅ | ❌ none |
 | Limitless, Opinion, Predict.Fun, dFlow, sports, UMA | ✅ | ❌ Polymarket + Kalshi only |
 

--- a/src/tools/markets.ts
+++ b/src/tools/markets.ts
@@ -8,26 +8,28 @@ import { extractErrorMessage, formatError } from "../utils/errors.js";
 import { hasPathTraversal } from "../utils/path-safety.js";
 import type { BudgetState } from "../types.js";
 
-function estimateMarketCost(path: string, body: unknown): number {
-  if (body !== undefined) return 0.005;
-  const p = path.toLowerCase();
-  if (
-    p.includes("wallet") ||
-    p.includes("smart") ||
-    p.includes("matching-markets") ||
-    p.includes("markets/search") ||
-    p.includes("binance/")
-  ) {
-    return 0.005;
-  }
-  return 0.001;
+// What x402 CHARGES, which is not the 402's JSON `price` field. That field is the
+// BASE ($0.0075); the charge is base + a $0.002 flat transaction fee, and it lives
+// in `maxAmountRequired` inside the base64 `payment-required` header. Decoded live
+// 2026-07-15: every /v1/pm/* route quotes maxAmountRequired=9500 → $0.0095, flat.
+// The gateway states the same split in src/app/api/v1/pm/[...path]/route.ts:
+//   "Tier 1 (GET) = $0.0095/call ($0.0075 base + $0.002 tx fee)"
+//
+// This used to return the old tiers (0.001/0.005). Predexon went flat on
+// 2026-07-15 and the tool description was updated but this was not — so the gate
+// reserved $0.001 against a $0.0095 charge (~9.5x short) and recordSpending()
+// booked $0.001 of a $0.0095 spend, under-counting the ledger too.
+export const MARKETS_PRICE_USD = 0.0095;
+
+function estimateMarketCost(_path: string, _body: unknown): number {
+  return MARKETS_PRICE_USD;
 }
 
 export function registerMarketsTool(server: McpServer, budget: BudgetState): void {
   server.registerTool(
     "blockrun_markets",
     {
-      description: `Prediction market + derivatives data via Predexon aggregator. Flat $0.0075/call (every endpoint)/call.
+      description: `Prediction market + derivatives data via Predexon aggregator. Flat $0.0095/call (every endpoint) — $0.0075 base + $0.002 tx fee.
 
 CANONICAL CROSS-VENUE (Tier 1) — Predexon v2 unified data layer:
 - markets — list canonical market/question containers with cross-venue Predexon IDs

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -23,22 +23,33 @@ type RawClient = {
 // $0.025 per returned source. Mirrors getSearchPrice() in
 // blockrun/src/app/api/v1/search/route.ts.
 const SEARCH_DEFAULT_MAX_RESULTS = 10;
-// The gateway settles 5% above $0.025 × max_results, then rounds UP to 4dp.
-// Verified against its own 402 quotes, which are free to request (send any call
-// with no payment header): max_results 1/5/10/20/50 quote
-// $0.0263/$0.1313/$0.2625/$0.5250/$1.3125. Reserving the unbuffered $0.025 × n
-// left the gate short of what the call actually settles at — the exact overshoot
-// the reserve exists to prevent.
+// READ THE `payment-required` HEADER, NOT THE JSON BODY.
 //
-// Integer micro-dollars, because the float form is not exact: 0.025 * 1.05 is
-// 0.026250000000000002, which rounds to $0.026251 — still under the gateway's
-// $0.0263, i.e. still short. A reserve must never be short.
-const SEARCH_MICRO_PER_SOURCE = 26_250; // $0.025 x 1.05, exact in micro-dollars
-const SEARCH_MICRO_QUANTUM = 100; // the gateway quotes to 4dp = 100 micro-dollars
+// A 402's JSON `price` field is the BASE. What x402 actually charges is
+// `maxAmountRequired` inside the base64 `payment-required` header, and it is
+// base + a $0.002 flat transaction fee. The two differ on every route:
+//
+//   max_results   body price   header (CHARGED)
+//   1             $0.0263      $0.0283
+//   10 (default)  $0.2625      $0.2645
+//   50            $1.3125      $1.3145
+//
+// Keying the reserve off the body — which is what 0.30.10 did — leaves the gate
+// $0.002 short on every search. Same trap as $0.0075 vs $0.0095 elsewhere: the
+// base is not the price.
+const SEARCH_MICRO_PER_SOURCE = 26_250; // $0.025 x 1.05 base, exact in micro-dollars
+const SEARCH_MICRO_QUANTUM = 100; // the gateway rounds the base UP to 4dp = 100 micro
+const SEARCH_MICRO_TX_FEE = 2_000; // $0.002 flat, added on top of the rounded base
+//
+// Integer micro-dollars throughout, because the float form is not exact:
+// 0.025 * 1.05 is 0.026250000000000002, which rounds to $0.026251 — under the
+// base itself, let alone the charge. A reserve must never be short.
 
 export function estimateSearchCost(body: unknown): number {
-  const reserve = (max: number) =>
-    (Math.ceil((SEARCH_MICRO_PER_SOURCE * max) / SEARCH_MICRO_QUANTUM) * SEARCH_MICRO_QUANTUM) / 1e6;
+  const reserve = (max: number) => {
+    const base = Math.ceil((SEARCH_MICRO_PER_SOURCE * max) / SEARCH_MICRO_QUANTUM) * SEARCH_MICRO_QUANTUM;
+    return (base + SEARCH_MICRO_TX_FEE) / 1e6;
+  };
   if (!body || typeof body !== "object") return reserve(SEARCH_DEFAULT_MAX_RESULTS);
   const raw = (body as { max_results?: unknown }).max_results;
   const max = typeof raw === "number" && raw > 0 ? Math.min(50, Math.floor(raw)) : SEARCH_DEFAULT_MAX_RESULTS;

--- a/src/tools/surf.ts
+++ b/src/tools/surf.ts
@@ -29,23 +29,28 @@ type SurfClient = {
 // list endpoints rather than use loose substring matching so a future T2
 // endpoint under wallet/* or social/* doesn't silently get charged as T1.
 
-// Flat per-call price for EVERY Surf endpoint, base only (the gateway adds a
-// $0.002 transaction fee on top → $0.0095 customer-facing). Keep in step with
-// SURF_TIER_*_PRICE in the gateway's src/lib/surf.ts.
-export const SURF_PRICE_USD = 0.0075;
+// Flat per-call price CHARGED for every Surf endpoint: $0.0075 base + $0.002
+// flat transaction fee. Keep in step with SURF_TIER_*_PRICE in the gateway's
+// src/lib/surf.ts, and note that constant is the BASE — not what a caller pays.
+export const SURF_PRICE_USD = 0.0095;
 
 // Exported for unit tests.
 //
-// Surf is now a FLAT $0.0075/call — every endpoint, every former tier (gateway
-// change 2026-07-15: one network-uniform price across Surf and Predexon). The
-// tier sets above are retained because they still describe endpoint weight, but
-// they no longer affect price.
+// Surf is a FLAT $0.0095/call — every endpoint, every former tier (gateway change
+// 2026-07-15: one network-uniform price across Surf and Predexon). The tier sets
+// above are retained because they still describe endpoint weight, but they no
+// longer affect price.
 //
-// This estimator feeds the BUDGET GATE, so it must never under-quote: it used
-// to return $0.001/$0.005/$0.02 while the gateway had already moved to
-// $0.0075 for T1/T2 — under-reserving on every cheap-looking call. A flat rate
-// removes the whole class of drift, since there is no longer a tier to
-// misclassify.
+// This estimator feeds the BUDGET GATE, so it must never under-quote — and the
+// number to quote is what x402 CHARGES, not the 402's JSON `price` field. That
+// field reports the base ($0.0075); the charge is in `maxAmountRequired` inside
+// the base64 `payment-required` header, and every /v1/surf/* route decodes to
+// 9500 micro = $0.0095 (verified live 2026-07-15).
+//
+// This has now been wrong twice in the same direction, both times by trusting a
+// number that looked authoritative: first the stale $0.001/$0.005/$0.02 tiers
+// after the gateway went flat, then the $0.0075 base after it was mistaken for
+// the price. Read the header.
 export function estimateSurfCost(_path: string): number {
   return SURF_PRICE_USD;
 }
@@ -59,7 +64,7 @@ export function registerSurfTool(server: McpServer, budget: BudgetState): void {
 Coverage: CEX market data (16 exchanges), on-chain SQL across 13 chains, 100M+ labeled wallets, prediction markets (Polymarket + Kalshi), social mindshare / CT intelligence, news, unified search, and Surf-1.5 chat with citations.
 
 Pricing (settled in USDC to Surf's Base treasury):
-- Flat $0.0075/call — every endpoint, including raw on-chain SQL. No tiers.
+- Flat $0.0095/call — every endpoint, including raw on-chain SQL. No tiers. ($0.0075 base + $0.002 tx fee.)
 
 Common paths (full 84-endpoint catalog in the surf skill):
 - market/price?symbol=BTC                     (T1)

--- a/test/search-cost.test.ts
+++ b/test/search-cost.test.ts
@@ -7,36 +7,43 @@ import { estimateSearchCost } from "../src/tools/search.js";
 // SOURCE, so a default call settles ~$0.26 while most tools cost $0.001. The gate
 // can only stop a looping agent if the reserve is >= what the gateway settles.
 //
-// These figures are the gateway's own 402 quotes (free to request — send any call
-// with no payment header and it replies with the exact price), captured 2026-07-14:
-//   max_results  1 → $0.0263
-//   max_results  5 → $0.1313
-//   max_results 10 → $0.2625   (default)
-//   max_results 20 → $0.5250
-//   max_results 50 → $1.3125
-// Each is exactly 1.05x per_source x max_results. If the gateway's buffer moves,
-// these pins fail — which is the point.
-const QUOTES: Array<[number, number]> = [
-  [1, 0.0263],
-  [5, 0.1313],
-  [10, 0.2625],
-  [20, 0.525],
-  [50, 1.3125],
+// These are what x402 ACTUALLY charges — `maxAmountRequired` decoded from the
+// base64 `payment-required` header on a live 402 (free to request: send any call
+// with no payment header). Captured 2026-07-15.
+//
+// They are NOT the 402's JSON `price` field. That field is the BASE, and the
+// charge is base + a $0.002 flat transaction fee:
+//
+//   max_results   body price   header (CHARGED)   <- pin the RIGHT column
+//   1             $0.0263      $0.0283
+//   5             $0.1313      $0.1333
+//   10            $0.2625      $0.2645
+//   20            $0.5250      $0.5270
+//   50            $1.3125      $1.3145
+//
+// 0.30.10 pinned the body column and shipped a gate that was $0.002 short on
+// every search. If the fee or the buffer moves, these fail — which is the point.
+const CHARGED: Array<[number, number]> = [
+  [1, 0.0283],
+  [5, 0.1333],
+  [10, 0.2645],
+  [20, 0.527],
+  [50, 1.3145],
 ];
 
-test("estimateSearchCost reserves at least what the gateway actually settles", () => {
-  for (const [max, quoted] of QUOTES) {
+test("estimateSearchCost reserves at least what x402 actually charges (header, not body)", () => {
+  for (const [max, quoted] of CHARGED) {
     const reserved = estimateSearchCost({ query: "x", max_results: max });
     assert.ok(
       reserved >= quoted - 1e-6,
-      `max_results=${max}: reserved $${reserved} < gateway $${quoted} — the gate would under-reserve`,
+      `max_results=${max}: reserved $${reserved} < charged $${quoted} — the gate would under-reserve`,
     );
   }
 });
 
 test("estimateSearchCost does not over-reserve by more than a cent", () => {
   // Reserving wildly high would block calls a budget could actually afford.
-  for (const [max, quoted] of QUOTES) {
+  for (const [max, quoted] of CHARGED) {
     const reserved = estimateSearchCost({ query: "x", max_results: max });
     assert.ok(reserved - quoted < 0.01, `max_results=${max}: reserved $${reserved} vs gateway $${quoted}`);
   }
@@ -45,9 +52,9 @@ test("estimateSearchCost does not over-reserve by more than a cent", () => {
 test("estimateSearchCost defaults to the 10-source price when max_results is absent", () => {
   // Upstream defaults to 10. Reserving less than that on a bare { query } — the
   // most common call shape — would let every default search skip the gate.
-  assert.ok(estimateSearchCost({ query: "x" }) >= 0.2625 - 1e-6);
-  assert.ok(estimateSearchCost(undefined) >= 0.2625 - 1e-6);
-  assert.ok(estimateSearchCost("not an object") >= 0.2625 - 1e-6);
+  assert.ok(estimateSearchCost({ query: "x" }) >= 0.2645 - 1e-6);
+  assert.ok(estimateSearchCost(undefined) >= 0.2645 - 1e-6);
+  assert.ok(estimateSearchCost("not an object") >= 0.2645 - 1e-6);
 });
 
 test("estimateSearchCost caps at 50 sources, matching the upstream ceiling", () => {
@@ -59,7 +66,7 @@ test("estimateSearchCost ignores garbage max_results instead of reserving $0", (
   // exhausted budget.
   for (const bad of [0, -5, "10", null, NaN, {}]) {
     assert.ok(
-      estimateSearchCost({ max_results: bad }) >= 0.2625 - 1e-6,
+      estimateSearchCost({ max_results: bad }) >= 0.2645 - 1e-6,
       `max_results=${JSON.stringify(bad)} fell back below the default reserve`,
     );
   }

--- a/test/surf.test.ts
+++ b/test/surf.test.ts
@@ -3,7 +3,17 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { estimateSurfCost, SURF_PRICE_USD } from "../src/tools/surf.js";
 
-// Surf went FLAT on 2026-07-15: every endpoint bills $0.0075 base, no tiers
+// Surf went FLAT on 2026-07-15. Pin what x402 CHARGES — $0.0095 — not the base.
+//
+// The 402's JSON `price` field reports $0.0075; that is the BASE. The charge is
+// base + a $0.002 flat tx fee and lives in `maxAmountRequired` inside the base64
+// `payment-required` header (decoded live: every /v1/surf/* route → 9500 micro =
+// $0.0095). The gateway says so itself in src/app/api/v1/pm/[...path]/route.ts:
+// "Tier 1 (GET) = $0.0095/call ($0.0075 base + $0.002 tx fee)".
+//
+// This estimator feeds the budget gate and must never under-quote. It has been
+// wrong twice in the same direction: stale tiers after the gateway went flat,
+// then the base mistaken for the price. Read the header.
 // (one network-uniform price across Surf and Predexon).
 //
 // This estimator feeds the budget gate, so under-quoting is the failure that
@@ -11,7 +21,7 @@ import { estimateSurfCost, SURF_PRICE_USD } from "../src/tools/surf.js";
 // the gateway had already moved T1/T2 to $0.0075 — under-reserving on every
 // cheap-looking call. Flat pricing removes that drift at the root.
 test("estimateSurfCost returns the flat rate for every endpoint", () => {
-  assert.equal(SURF_PRICE_USD, 0.0075);
+  assert.equal(SURF_PRICE_USD, 0.0095);
   for (const path of [
     "market/price",     // was T1 $0.001
     "social/mindshare", // was T2 $0.005 (exact)
@@ -21,7 +31,7 @@ test("estimateSurfCost returns the flat rate for every endpoint", () => {
     "chat/completions", // was T3 $0.02
     "prediction-market/polymarket/ranking",
   ]) {
-    assert.equal(estimateSurfCost(path), 0.0075, `${path} should be flat-rated`);
+    assert.equal(estimateSurfCost(path), 0.0095, `${path} should be flat-rated`);
   }
 });
 
@@ -40,6 +50,6 @@ test("no path perturbation can change the quoted cost", () => {
     "/onchain/sql/",
     "",
   ]) {
-    assert.equal(estimateSurfCost(path), 0.0075, `${path} must not be repriced`);
+    assert.equal(estimateSurfCost(path), 0.0095, `${path} must not be repriced`);
   }
 });


### PR DESCRIPTION
## The root mistake

A 402's JSON `price` field is the **base**. What x402 charges is `maxAmountRequired` inside the base64 **`payment-required` header** — base **+ a $0.002 flat transaction fee**.

```
body   price.amount:      $0.0075          ← the base
header maxAmountRequired: 9500 = $0.0095   ← what the caller actually pays
```

The gateway says so itself in `src/app/api/v1/pm/[...path]/route.ts`:
> `Tier 1 (GET) = $0.0095/call ($0.0075 base + $0.002 tx fee)`

Every paid tool keyed off the wrong field.

## What was broken

| tool | reserved | charged | |
|---|---|---|---|
| **`blockrun_markets`** | **$0.001** | $0.0095 | **~9.5× short** |
| `blockrun_surf` | $0.0075 | $0.0095 | $0.002 short |
| `blockrun_search` | $0.2625 | $0.2645 | $0.002 short |

**`blockrun_markets` is the serious one.** `estimateMarketCost` still returned the pre-flat tiers (`$0.001`/`$0.005`) — 0.31.0 updated the tool *description* to flat but not the estimator. And `recordSpending(budget, estimatedCost)` booked `$0.001` of a `$0.0095` spend, so the budget **ledger** under-counted too, not just the reserve.

**`blockrun_surf`'s own comment already knew**: *"the gateway adds a $0.002 transaction fee on top → $0.0095 customer-facing"* and *"this estimator feeds the BUDGET GATE, so it must never under-quote"* — then set the constant to the base.

**`blockrun_search`**: 0.30.10 fixed the 5% buffer but pinned the body's `price`, staying $0.002 short at every size.

## The fix

All three reserve what the header says. Tests repinned to the **charged** column (`test/search-cost.test.ts`, `test/surf.test.ts`):

```
max_results   body price   CHARGED (pinned)
1             $0.0263      $0.0283
10            $0.2625      $0.2645
50            $1.3125      $1.3145
```

Skills corrected from `$0.0075` → `$0.0095` (`prediction-markets`, `crypto-data`, `surf`, `gentech-blockrun`) — agents budgeting off those numbers under-reserve on every call.

## For the record

**The public pricing pages were right all along.** `/services/surf` $0.0095 ✓, and `/services/predexon`'s $0.003 GET / $0.007 POST was correct for the then-current $0.001/$0.005 base. The tell was in the data the whole time: a live `blockrun_markets` call **quoted $0.0010 and settled $0.003** — base + fee.

This has now been wrong twice in the same direction, both times by trusting a number that looked authoritative: stale tiers after the gateway went flat, then the base mistaken for the price. That lesson is now a comment in each estimator.

**Possible follow-up in the gateway repo:** the 402 body advertises `price: $0.0075` while charging `$0.0095`. Any client reading that field under-reserves by $0.002.

## Verified

`typecheck` ✓ `build` ✓ **159 tests** ✓ · reserves checked against live `payment-required` headers.