### PR TITLE
docs(modal): tell the truth about pricing — $0.01 advertised, $192 charged (0.31.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to BlockRun MCP will be documented in this file.
 
+## 0.31.3
+
+- **`docs(modal)` — the tool and skill advertised `$0.01` for a call that can cost `$192`.** 0.31.2 fixed the *reserve* so the gate catches it; this fixes what we **tell the agent**, which is what walks it into the charge in the first place. Three separate lies, all live-verified:
+  - **The price table said a flat `$0.01`.** `sandbox/create` is bimodal: `timeout ≤ 300s` is flat ($0.0120 CPU → $0.4020 H100); `timeout > 300s` bills **per-hour × the full requested lifetime, upfront, with no refund on early terminate** ($0.10/h CPU → $8.00/h H100). A 24h H100 sandbox is **$192.0020**.
+  - **The skill's own worked example cost 67× its table.** `{ gpu: "A100", timeout: 600 }` quotes **$0.6687** live, not `$0.01`. Anyone copying the documented snippet was already on hourly billing and had no way to know.
+  - **`timeout` was documented as "idle eviction".** It is the **billed lifetime** — you pay for the time you *ask for*, not the time you use. An agent told "idle eviction" would reasonably set a generous `86400` ceiling expecting to pay for what it consumes. That single misreading *is* the $192.
+  - Also removed `A100-80GB` from the advertised GPU list — it does not exist; the gateway returns `HTTP 400 "Unsupported GPU type. Allowed: T4, L4, A10G, A100, H100"`.
+- Every one of the 13 published prices was checked against the live `payment-required` header and matches exactly ($0.0120 / $0.0520 / $0.0820 / $0.1020 / $0.2020 / $0.4020 flat; $0.1020 / $1.5020 / $4.0020 / $8.0020 / $192.0020 / $0.6687 / $2.0020 hourly). Documents the flat→hourly cliff too: `timeout:300` is $0.0120 but `timeout:301` is $0.0104 — briefly cheaper on CPU, until ~432s.
+- No code change to pricing logic; 165 tests, typecheck, build green.
+
 ## 0.31.2
 
 Found by an adversarial multi-agent audit of everything shipped tonight. 0.31.1 fixed three tools by hand; that was treating symptoms. The gateway applies its flat $0.002 transaction fee in `buildPaymentRequirements` for **every** route, so **every** tool reserving the base was short. This fixes the class.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/mcp",
-      "version": "0.31.2",
+      "version": "0.31.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "mcpName": "io.github.BlockRunAI/blockrun-mcp",
   "description": "BlockRun MCP Server - Give your AI agent web search, deep research, prediction markets, and crypto data. Paid via x402 micropayments.",
   "type": "module",

--- a/skills/modal/SKILL.md
+++ b/skills/modal/SKILL.md
@@ -16,16 +16,34 @@ triggers:
 
 # Modal Sandboxes
 
-Disposable remote containers (with optional GPU) via Modal, paid per call in USDC. No Modal account, no GPU procurement — pay only for what runs.
+Disposable remote containers (with optional GPU) via Modal, paid per call in USDC. No Modal account, no GPU procurement.
+
+## READ THIS BEFORE SETTING `timeout`
+
+**`timeout` is the BILLED lifetime, charged upfront in full, and never refunded — not an idle timeout.** Above 300s the price switches from a flat rate to **per-hour billing for the entire duration you ask for**, whether you use it or not. Terminating early refunds nothing.
+
+That makes `timeout` the single most expensive field in this MCP:
+
+| what you ask for | what you pay |
+|---|---|
+| `{ timeout: 300 }` | **$0.0120** |
+| `{ timeout: 300, gpu: "A100" }` | **$0.2020** |
+| `{ timeout: 600, gpu: "A100" }` | **$0.6687** |
+| `{ timeout: 86400, gpu: "H100" }` | **$192.0020** |
+
+All four are live-verified quotes. A 24h H100 sandbox costs **$192 upfront, non-refundable**, even if your job finishes in a minute.
+
+**So: ask for the time you need, not a safe-looking ceiling.** Need 20 minutes of H100? `timeout: 1200` is $2.67, not $192. Keep `timeout ≤ 300` and you stay on the flat rate entirely.
 
 ## How to Call from MCP
 
 ```ts
-// 1. Create
+// 1. Create — timeout: 300 keeps you on the FLAT rate ($0.0120, or $0.2020 with A100).
+//    Anything above 300 bills hourly for the full requested lifetime, no refund.
 blockrun_modal({ path: "sandbox/create", body: {
   image: "python:3.11",
   gpu: "A100",
-  timeout: 600,
+  timeout: 300,
   setup_commands: ["pip install torch transformers"]
 }})
 // returns { sandbox_id, ... }
@@ -44,20 +62,48 @@ blockrun_modal({ path: "sandbox/terminate", body: { sandbox_id: "sb_abc..." } })
 
 | Path | Method | Body | Price |
 |---|---|---|---|
-| `sandbox/create` | POST | `{ image?, timeout?, cpu?, memory?, gpu?, setup_commands? }` | $0.01 |
-| `sandbox/exec` | POST | `{ sandbox_id, command: ["python","-c","..."], timeout? }` | $0.001 |
-| `sandbox/status` | POST | `{ sandbox_id }` | $0.001 |
-| `sandbox/terminate` | POST | `{ sandbox_id }` | $0.001 |
+| `sandbox/create` | POST | `{ image?, timeout?, cpu?, memory?, gpu?, setup_commands? }` | **depends on `timeout` + `gpu` — see below** |
+| `sandbox/exec` | POST | `{ sandbox_id, command: ["python","-c","..."], timeout? }` | $0.0030 |
+| `sandbox/status` | POST | `{ sandbox_id }` | $0.0030 |
+| `sandbox/terminate` | POST | `{ sandbox_id }` | $0.0030 |
+
+### `sandbox/create` pricing is bimodal
+
+**`timeout ≤ 300s` — flat rate, charged once:**
+
+| gpu | price |
+|---|---|
+| *(none, CPU)* | $0.0120 |
+| `T4` | $0.0520 |
+| `L4` | $0.0820 |
+| `A10G` | $0.1020 |
+| `A100` | $0.2020 |
+| `H100` | $0.4020 |
+
+**`timeout > 300s` — per-hour × the full requested lifetime, upfront, no refund:**
+
+| gpu | per hour | 1h | 24h (max) |
+|---|---|---|---|
+| *(none, CPU)* | $0.10 | $0.1020 | $2.4020 |
+| `T4` | $1.50 | $1.5020 | $36.0020 |
+| `L4` | $2.00 | $2.0020 | $48.0020 |
+| `A10G` | $2.50 | $2.5020 | $60.0020 |
+| `A100` | $4.00 | $4.0020 | $96.0020 |
+| `H100` | $8.00 | $8.0020 | **$192.0020** |
+
+Hours are exact, not rounded up — `timeout: 1800` on `A100` is 0.5h = $2.0020. Every figure above includes the $0.002 flat transaction fee. Max `timeout` is 86400 (24h).
+
+One quirk worth knowing: `timeout: 300` costs $0.0120 (flat) but `timeout: 301` costs $0.0104 (CPU-hourly) — just past the cliff is briefly *cheaper* on CPU. It stops being cheaper around 432s.
 
 ## Field Reference
 
 | Field | Default | Notes |
 |---|---|---|
 | `image` | `python:3.11` | Any public Docker image. `nvidia/cuda:12-runtime` if you bring GPU code. |
-| `timeout` | 300 | Sandbox lifetime in seconds (idle eviction) |
+| `timeout` | 300 | **BILLED lifetime in seconds — charged upfront for the full amount, never refunded.** NOT idle eviction: you pay for what you ask for, not what you use. `≤300` = flat rate; `>300` switches to per-hour billing (see the tables above). Max 86400 (24h). This is the field that turns a $0.01 sandbox into a $192 one. |
 | `cpu` | 1 | CPU cores |
 | `memory` | 1024 | Memory in MB |
-| `gpu` | none | `T4` / `L4` / `A10G` / `A100` / `A100-80GB` / `H100` |
+| `gpu` | none | `T4` / `L4` / `A10G` / `A100` / `H100` — those five only. Anything else is rejected: `{"gpu":"A100-80GB"}` returns HTTP 400 *"Unsupported GPU type. Allowed: T4, L4, A10G, A100, H100"*. Drives the price hard — see the tables above. |
 | `setup_commands` | `[]` | Shell commands run once during sandbox provisioning |
 | `command` (exec) | required | Array form: `["python","-c","print(2+2)"]` |
 

--- a/src/tools/modal.ts
+++ b/src/tools/modal.ts
@@ -93,15 +93,20 @@ export function registerModalTool(server: McpServer, budget: BudgetState): void 
     {
       description: `Run isolated code in a BlockRun-hosted Modal sandbox — disposable remote container, optional GPU.
 
-Use when you need: a clean ephemeral environment, GPU access (T4/L4/A10G/A100/A100-80GB/H100), or a safer place for untrusted code. Prefer local tools for normal repo work.
+Use when you need: a clean ephemeral environment, GPU access (T4/L4/A10G/A100/H100 — those five only), or a safer place for untrusted code. Prefer local tools for normal repo work.
+
+⚠️ \`timeout\` IS THE BILLED LIFETIME — charged upfront in full, NEVER refunded. It is not an idle timeout: you pay for the time you ASK for, not the time you use, and terminating early refunds nothing. Ask for what you need, not a safe-looking ceiling.
+- timeout ≤ 300s → flat: $0.0120 CPU · $0.0520 T4 · $0.0820 L4 · $0.1020 A10G · $0.2020 A100 · $0.4020 H100
+- timeout > 300s → PER-HOUR × the full requested lifetime: $0.10/h CPU · $1.50 T4 · $2.00 L4 · $2.50 A10G · $4.00 A100 · $8.00/h H100
+  e.g. { timeout: 600, gpu: "A100" } = $0.6687 · { timeout: 86400, gpu: "H100" } = $192.00
 
 Common paths (all POST):
-- sandbox/create     — body: { image?, timeout?, cpu?, memory?, gpu?, setup_commands? }    ($0.01)
-- sandbox/exec       — body: { sandbox_id, command: ["python","-c","..."], timeout? }      ($0.001)
-- sandbox/status     — body: { sandbox_id }                                                ($0.001)
-- sandbox/terminate  — body: { sandbox_id }                                                ($0.001)
+- sandbox/create     — body: { image?, timeout?, cpu?, memory?, gpu?, setup_commands? }    (see above — $0.0120 to $192.00)
+- sandbox/exec       — body: { sandbox_id, command: ["python","-c","..."], timeout? }      ($0.0030)
+- sandbox/status     — body: { sandbox_id }                                                ($0.0030)
+- sandbox/terminate  — body: { sandbox_id }                                                ($0.0030)
 
-Full action shapes + GPU type details in the \`modal\` skill.`,
+Full pricing tables + GPU details in the \`modal\` skill.`,
       inputSchema: {
         path: z.string().describe("Endpoint under /v1/modal/, e.g. 'sandbox/create', 'sandbox/exec'"),
         body: z.any().optional().describe("JSON body. Sent as POST."),


### PR DESCRIPTION
0.31.2 fixed the **reserve**, so the gate now catches a $192 sandbox. This fixes what we **tell the agent** — which is what walks it into the charge in the first place.

## Three lies, all live-verified

**1. The price table said a flat `$0.01`.** `sandbox/create` is bimodal:

| | |
|---|---|
| `timeout ≤ 300s` | flat — **$0.0120** CPU → **$0.4020** H100 |
| `timeout > 300s` | **per-hour × the FULL requested lifetime, upfront, no refund on early terminate** — $0.10/h CPU → **$8.00/h** H100 |

A 24h H100 sandbox is **$192.0020**. Ask for 24h, finish in a minute, still pay $192.

**2. The skill's own worked example cost 67× its own table.**

```ts
// skills/modal/SKILL.md:28 — the documented snippet
blockrun_modal({ path: "sandbox/create", body: { gpu: "A100", timeout: 600, ... }})
```
```
live quote: $0.6687        table says: $0.01
```

Anyone copying the documented example was already on hourly billing with no way to know.

**3. `timeout` was documented as the wrong thing entirely.**

```
| `timeout` | 300 | Sandbox lifetime in seconds (idle eviction) |
                                                 ^^^^^^^^^^^^^^
```

It is the **billed lifetime** — you pay for the time you *ask for*, not the time you use. An agent told "idle eviction" would reasonably set a generous `86400` ceiling expecting to pay only for what it consumes. **That single misreading is the $192.**

Also removed `A100-80GB` from the advertised GPU list — it doesn't exist:
```
{"gpu":"A100-80GB"} → HTTP 400 "Unsupported GPU type. Allowed: T4, L4, A10G, A100, H100"
```

## Verified

All **13** published prices checked against the live `payment-required` header — every one matches exactly:

```
flat:    $0.0120  $0.0520  $0.0820  $0.1020  $0.2020  $0.4020
hourly:  $0.1020  $1.5020  $4.0020  $8.0020  $192.0020  $0.6687  $2.0020
```

The skill now also documents the cliff: `timeout:300` is $0.0120 but `timeout:301` is **$0.0104** — one second more is briefly *cheaper* on CPU (until ~432s), because it crosses from the flat rate onto hourly.

No pricing-logic change — docs and tool description only. **165 tests**, typecheck, build green.