### PR TITLE
docs(skills): every advertised price is now the charged price (0.31.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to BlockRun MCP will be documented in this file.
 
+## 0.31.4
+
+Closes the last of the audit findings: every price an agent reads is now the price it is **charged**, verified against live `payment-required` headers.
+
+- **`docs(surf)` — taught an endpoint that does not exist.** `chat/completions` (Surf-1.5) returns **404** on the gateway; the skill had a worked example, a catalog row, a trigger and pricing notes for it. All removed.
+- **`docs(surf)` — Surf has no premium tier any more.** The skill billed `onchain/sql` at `$0.0200`. Upstream `SURF_TIER_1/2/3_PRICE` are now **all identical**, and `onchain/sql` quotes the same **$0.0095** as every other Surf read. The tier column is gone — one flat rate, SQL included.
+- **`docs(gentech-blockrun)` — billed free calls.** `blockrun_price` crypto/FX/commodity quotes are **FREE**; the skill charged `$0.001` for them across four patterns and told agents to cache aggressively to save money that was never being spent. Also refreshed stale `defi` ($0.001 → **$0.0070**, prices/* → **$0.0030**) and `exa` ($0.01 → **$0.0120**) figures, and stopped quoting a flat rate for `blockrun_chat`, which is per-token.
+- **`docs(crypto-data, search, phone)`** — repriced to the charge: `defi` **$0.0070** / prices/* **$0.0030**, `rpc` **$0.0040**, `surf` **$0.0095**, stocks **$0.0030**, `phone/lookup` **$0.0120**, `lookup/fraud` **$0.0520**, `numbers/list` **$0.0030**, `numbers/buy` **$5.002**. `search` understated every example — the default 10-source call settles **$0.2645**, not $0.25, and the skill now says it is priced per source and expensive by default.
+- No code change; 165 tests, typecheck, build green.
+
 ## 0.31.3
 
 - **`docs(modal)` — the tool and skill advertised `$0.01` for a call that can cost `$192`.** 0.31.2 fixed the *reserve* so the gate catches it; this fixes what we **tell the agent**, which is what walks it into the charge in the first place. Three separate lies, all live-verified:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/mcp",
-      "version": "0.31.3",
+      "version": "0.31.4",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "mcpName": "io.github.BlockRunAI/blockrun-mcp",
   "description": "BlockRun MCP Server - Give your AI agent web search, deep research, prediction markets, and crypto data. Paid via x402 micropayments.",
   "type": "module",

--- a/skills/crypto-data/SKILL.md
+++ b/skills/crypto-data/SKILL.md
@@ -60,12 +60,14 @@ Five tools cover crypto data and they overlap. **Pick by cost first** — two of
 | **FX rate / commodity (gold, oil)** | `blockrun_price` category:"fx" or `"commodity"` | **FREE** |
 | **Which symbols exist?** | `blockrun_price` action:"list" | **FREE** |
 | **DEX pair, liquidity, volume, contract** | `blockrun_dex` | **FREE** |
-| Stock quote / history (12 markets) | `blockrun_price` category:"stocks" | $0.001 |
-| Token price by contract address | `blockrun_defi` path:"prices/{coins}" | $0.001 |
-| Raw JSON-RPC on 40+ chains | `blockrun_rpc` | $0.002 |
-| Protocol TVL, chain TVL, yields/APY | `blockrun_defi` | $0.005 |
+| Stock quote / history (12 markets) | `blockrun_price` category:"stocks" | $0.0030 |
+| Token price by contract address | `blockrun_defi` path:"prices/{coins}" | $0.0030 |
+| Raw JSON-RPC on 40+ chains | `blockrun_rpc` | $0.0040 |
+| Protocol TVL, chain TVL, yields/APY | `blockrun_defi` | $0.0070 |
 | **Everything below** (on-chain SQL, wallet labels, social, news, unlocks, liquidations, ETF flows) | `blockrun_surf` | $0.0095 |
 | Raw SQL over 80+ ClickHouse tables | `blockrun_surf` path:"onchain/sql" | $0.0095 |
+
+Every price below is what x402 actually **charges** (the base plus the gateway's $0.002 flat fee), verified against live `payment-required` headers — not the base you may see in a 402 body.
 
 **The rule:** a plain crypto price or a DEX pair is free. Only reach for `blockrun_surf` when you need something the free tools genuinely do not have — labels, SQL, social, news, unlocks.
 
@@ -73,7 +75,7 @@ Five tools cover crypto data and they overlap. **Pick by cost first** — two of
 
 ## blockrun_price — quotes & history (Pyth-backed)
 
-Free for crypto, FX and commodities. $0.001 only for stocks.
+Free for crypto, FX and commodities. $0.0030 only for stocks.
 
 ```ts
 blockrun_price({ action: "price",   category: "crypto",    symbol: "BTC-USD" })            // FREE
@@ -82,7 +84,7 @@ blockrun_price({ action: "history", category: "crypto",    symbol: "ETH-USD",
 blockrun_price({ action: "price",   category: "fx",        symbol: "EUR-USD" })            // FREE
 blockrun_price({ action: "price",   category: "commodity", symbol: "XAU-USD" })            // FREE — gold
 blockrun_price({ action: "list",    category: "crypto" })                                  // FREE — discovery
-blockrun_price({ action: "price",   category: "stocks",    symbol: "AAPL", market: "us" }) // $0.001
+blockrun_price({ action: "price",   category: "stocks",    symbol: "AAPL", market: "us" }) // $0.0030
 ```
 
 Stock markets: `us`, `hk`, `jp`, `kr`, `gb`, `de`, `fr`, `nl`, `ie`, `lu`, `cn`, `ca` — `market` is required when `category:"stocks"`.
@@ -104,11 +106,11 @@ Path-based, GET only.
 
 | path | cost | returns |
 |---|---|---|
-| `protocols` | $0.005 | every DeFi protocol ranked by TVL |
-| `protocol/{slug}` | $0.005 | one protocol's TVL history + chain breakdown |
-| `chains` | $0.005 | TVL by chain |
-| `yields` | $0.005 | yield pools with APY + TVL (large — filter client-side) |
-| `prices/{coins}` | $0.001 | token prices by contract, e.g. `base:0x8335…,coingecko:ethereum` |
+| `protocols` | $0.0070 | every DeFi protocol ranked by TVL |
+| `protocol/{slug}` | $0.0070 | one protocol's TVL history + chain breakdown |
+| `chains` | $0.0070 | TVL by chain |
+| `yields` | $0.0070 | yield pools with APY + TVL (large — filter client-side) |
+| `prices/{coins}` | $0.0030 | token prices by contract, e.g. `base:0x8335…,coingecko:ethereum` |
 
 ```ts
 blockrun_defi({ path: "protocol/aave-v3" })
@@ -129,12 +131,12 @@ blockrun_surf({ path: "market/etf",          params: { symbol: "BTC" } })       
 blockrun_surf({ path: "social/mindshare",    params: { project: "base" } })
 blockrun_surf({ path: "onchain/sql", body: {
   sql: "SELECT token_address, count() FROM ethereum.dex_trades WHERE block_time > now() - INTERVAL 1 DAY GROUP BY 1 ORDER BY 2 DESC LIMIT 10"
-}})                                                                                   // $0.020
+}})                                                                                   // $0.0095
 ```
 
 ## blockrun_rpc — raw chain access
 
-40+ chains, one endpoint, no node, no key. $0.002/call (batches charge per element). See [`skills/rpc/SKILL.md`](../rpc/SKILL.md).
+40+ chains, one endpoint, no node, no key. $0.0040/call (batches charge per element, plus one flat fee per request). See [`skills/rpc/SKILL.md`](../rpc/SKILL.md).
 
 ```ts
 blockrun_rpc({ chain: "base", method: "eth_blockNumber", params: [] })

--- a/skills/gentech-blockrun/SKILL.md
+++ b/skills/gentech-blockrun/SKILL.md
@@ -63,9 +63,11 @@ blockrun_wallet(action="status")
 
 ## Daily Usage Patterns
 
-### Pattern 1: Regular Price Checks ($0.001 each)
+### Pattern 1: Regular Price Checks (FREE)
 
-The cheapest BlockRun calls. Use them liberally.
+Crypto, FX and commodity quotes cost **nothing** — `blockrun_price` is free for those
+categories (only `stocks`/`usstock` is paid, at $0.0030). Use them liberally, and do
+not pay $0.0095 to `blockrun_surf` for a quote you can get for $0.
 
 ```python
 # Single price
@@ -79,42 +81,42 @@ blockrun_price(action="price", category="crypto", symbol="SOL-USD")
 blockrun_price(action="list", category="crypto", query="sol")
 ```
 
-**Cost:** $0 per list call, $0.001 per price call. **Use `list` for free discovery.**
+**Cost:** $0 — crypto/FX/commodity price *and* list calls are both free. Only `category:"stocks"` is paid ($0.0030).
 
-### Pattern 2: Token Research Pipeline ($0.002–0.012)
+### Pattern 2: Token Research Pipeline (~$0.014)
 
-Combine free + cheap tools for a complete token picture.
+Start with the free tools, then pay only for what they cannot answer.
 
 ```python
 # 1. Free — DEX liquidity + volume (free endpoint)
 blockrun_dex({ query: "SOL" })
 
-# 2. $0.001 — CEX price
+# 2. FREE — CEX price (crypto category is free)
 blockrun_price(action="price", category="crypto", symbol="SOL-USD")
 
-# 3. $0.001 — Protocol TVL
+# 3. $0.0070 each — Protocol TVL
 blockrun_defi({ path: "protocols" })
 blockrun_defi({ path: "protocol/jupiter" })
 
-# 4. $0.001 — Chain TVL
+# 4. $0.0070 — Chain TVL
 blockrun_defi({ path: "chains" })
 ```
 
-**Total: ~$0.003–0.004 per full token analysis.** Replace CoinGecko/CMC tabs entirely.
+**Total: ~$0.021 per full token analysis** (2 free calls + 3 x $0.0070 DefiLlama). Replace CoinGecko/CMC tabs entirely.
 
-### Pattern 3: Research + Synthesis ($0.010–0.035)
+### Pattern 3: Research + Synthesis (~$0.012 + chat)
 
 Use Exa (neural search) + BlockRun Chat (second opinion) for thorough research.
 
 ```python
-# 1. $0.01 — Neural web search with Exa
+# 1. $0.0120 — Neural web search with Exa
 blockrun_exa({ path: "search", body: {
   query: "latest AI agent infrastructure developments 2026",
   numResults: 10,
   category: "research paper"
 }})
 
-# 2. $0.001 — Get second opinion from GLM-5 (excellent for technical details)
+# 2. per-token — Get second opinion from GLM-5 (excellent for technical details)
 blockrun_chat({ mode: "glm", message: "Summarize the key trends..." })
 ```
 
@@ -144,13 +146,13 @@ blockrun_wallet(action="report")
 ### DeFi Intelligence Pipeline
 
 ```python
-# 1. TVL & protocol health ($0.001)
+# 1. TVL & protocol health ($0.0070)
 blockrun_defi({ path: "protocol/aave-v3" })
 
-# 2. Yield pools ($0.001)
+# 2. Yield pools ($0.0070)
 blockrun_defi({ path: "yields" })
 
-# 3. Token price ($0.001)
+# 3. Token price (FREE — crypto category)
 blockrun_price(action="price", category="crypto", symbol="AAVE-USD")
 
 # 4. DEX activity (free)
@@ -163,7 +165,7 @@ blockrun_dex({ token: "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9" })
 # 1. Current holdings (free — local data or blockrun_rpc)
 blockrun_rpc({ network: "base", method: "eth_getBalance", params: ["0xabc...", "latest"] })
 
-# 2. Token prices ($0.001 each)
+# 2. Token prices (FREE — crypto category)
 blockrun_price(action="price", category="crypto", symbol="ETH-USD")
 blockrun_price(action="price", category="crypto", symbol="USDC-USD")
 
@@ -202,10 +204,10 @@ blockrun_video({ prompt: "animated data visualization", duration_seconds: 8 })
 | `blockrun_dex` | FREE | unlimited |
 | `blockrun_rpc` | $0.002 | on-chain reads |
 | `blockrun_wallet` (status/report) | FREE | before every session |
-| `blockrun_price` (quote) | $0.001 | per-token lookup |
-| `blockrun_defi` | $0.005 | protocol/chain analysis |
+| `blockrun_price` (quote) | **FREE** | crypto/FX/commodity; stocks $0.0030 |
+| `blockrun_defi` | $0.0070 | protocol/chain analysis ($0.0030 for prices/*) |
 | `blockrun_chat` (free mode) | $0 | NVIDIA-backed chat |
-| `blockrun_chat` (glm mode) | $0.001 | Zhipu GLM-5 coding |
+| `blockrun_chat` (glm mode) | per-token | Zhipu GLM-5 coding — billed on tokens used, not a flat rate |
 | `blockrun_exa` (search) | $0.01 | deep research |
 | `blockrun_surf` | $0.0095 | crypto data, wallets/candles/search, on-chain SQL (flat) |
 | `blockrun_speech` | $0.05/1k chars | TTS |
@@ -269,7 +271,7 @@ if float(balance["usdcBalance"]) < 0.50:
 
 BlockRun calls are cheap but not free. Cache results that don't change minute-to-minute:
 
-- **Token prices:** Cache for 30–60 seconds (change faster but $0.001 each is negligible)
+- **Token prices:** No need to cache aggressively — crypto/FX/commodity quotes via `blockrun_price` are FREE.
 - **Protocol TVL:** Cache for 1 hour (updates hourly)
 - **Wallet labels:** Cache for 24 hours (rarely change)
 - **On-chain SQL results:** Cache for 1 hour (most queries return the same answer)

--- a/skills/phone/SKILL.md
+++ b/skills/phone/SKILL.md
@@ -52,11 +52,11 @@ blockrun_phone({ path: `voice/call/${r.call_id}` })
 
 | Path | Body | Price | Effect |
 |---|---|---|---|
-| `phone/lookup` | `{ phoneNumber }` | $0.01 | Carrier, line type (mobile/landline/VoIP) |
-| `phone/lookup/fraud` | `{ phoneNumber }` | $0.05 | + SIM-swap signals, call-forwarding detection |
+| `phone/lookup` | `{ phoneNumber }` | $0.0120 | Carrier, line type (mobile/landline/VoIP) |
+| `phone/lookup/fraud` | `{ phoneNumber }` | $0.0520 | + SIM-swap signals, call-forwarding detection |
 | `phone/numbers/buy` | `{ country?: "US"\|"CA", areaCode? }` | $5.00 | 30-day lease, US or CA |
 | `phone/numbers/renew` | `{ phoneNumber }` | $5.00 | Extend lease 30 days |
-| `phone/numbers/list` | `{}` | $0.001 | Your wallet-owned numbers |
+| `phone/numbers/list` | `{}` | $0.0030 | Your wallet-owned numbers |
 | `phone/numbers/release` | `{ phoneNumber }` | free | Return to pool |
 
 ### Outbound AI calls (`/v1/voice/*`)

--- a/skills/search/SKILL.md
+++ b/skills/search/SKILL.md
@@ -15,7 +15,7 @@ triggers:
 
 # Live Search (Grok)
 
-Real-time web + news search with AI-summarized results and citations. **$0.025 × `max_results`** (default 10 → $0.25 per call). Best for *fresh* queries; for semantic / neural research use `blockrun_exa` instead.
+Real-time web + news search with AI-summarized results and citations. **PRICED PER SOURCE and expensive by default: $0.025 × `max_results`, +5% +$0.002 → default 10 settles $0.2645 per call.** Best for *fresh* queries; for semantic / neural research use `blockrun_exa` instead.
 
 ## How to Call from MCP
 
@@ -33,7 +33,7 @@ blockrun_search({ body: {
 |---|---|---|---|
 | `query` | yes | string | Natural-language search query |
 | `sources` | no | string[] | Subset of `["web","news"]`. Default: both. Does NOT multiply price. |
-| `max_results` | no | number | 1–50, default 10. **Drives the price** at $0.025 each. |
+| `max_results` | no | number | 1–50, default 10. **Drives the price** — ~$0.0263 charged per source. Pass a small number to cap spend; the gateway prices the raw value and does not floor fractions. |
 | `from_date` | no | string | `YYYY-MM-DD` lower bound on result date |
 | `to_date` | no | string | `YYYY-MM-DD` upper bound |
 
@@ -53,14 +53,14 @@ blockrun_search({ body: {
 ```ts
 blockrun_search({ body: { query: "Ethereum ETF approval SEC", sources: ["news","web"], max_results: 8 } })
 ```
-**Cost: $0.025 × 8 = $0.20.**
+**Cost: ~$0.2120** (8 sources: $0.025 × 8 × 1.05 + $0.002).
 
 ### 2. "What is X saying about Solana's latest outage?"
 
 ```ts
 blockrun_search({ body: { query: "Solana outage today", sources: ["x"], max_results: 15 } })
 ```
-**Cost: $0.025 × 15 = $0.375.**
+**Cost: ~$0.3958** (15 sources: $0.025 × 15 × 1.05 + $0.002).
 
 ### 3. "Background on Pectra upgrade, last 90 days only"
 
@@ -71,7 +71,7 @@ blockrun_search({ body: {
   from_date: "2026-02-17"
 }})
 ```
-**Cost: $0.025 × 10 (default) = $0.25.**
+**Cost: $0.2645** (10 sources, the default — verified live).
 
 ## search vs exa — Pick the Right Tool
 

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: surf
-description: Use when the user wants crypto data — token prices, on-chain SQL, prediction-market positions, CEX order books, wallet labels/net-worth, social mindshare, news, or a Surf-1.5 chat answer with citations. 84 endpoints across exchange, on-chain, wallet, social, prediction, news, search, and chat — one API, pay-per-call in USDC via x402. Settles directly to Surf's Base treasury; no Surf account needed.
+description: Use when the user wants crypto data — token prices, on-chain SQL, prediction-market positions, CEX order books, wallet labels/net-worth, social mindshare, news, or unified search. 83 endpoints across exchange, on-chain, wallet, social, prediction, news and search — one API, flat $0.0095/call in USDC via x402. Settles directly to Surf's Base treasury; no Surf account needed.
 triggers:
   - "surf"
   - "asksurf"
-  - "surf-1.5"
   - "crypto data"
   - "on-chain sql"
   - "clickhouse crypto"
@@ -34,7 +33,7 @@ triggers:
 
 # Surf — Crypto Data via BlockRun
 
-Surf (asksurf.ai) aggregates **84 crypto data endpoints** across CEX market data, on-chain SQL (13 chains, 80+ ClickHouse tables), 100M+ labeled wallets, prediction markets (Polymarket + Kalshi side-by-side), social/CT intelligence, news, unified search, and Surf-1.5 chat with citations.
+Surf (asksurf.ai) aggregates **83 crypto data endpoints** across CEX market data, on-chain SQL (13 chains, 80+ ClickHouse tables), 100M+ labeled wallets, prediction markets (Polymarket + Kalshi side-by-side), social/CT intelligence, news and unified search.
 
 BlockRun is Surf's x402 payment rail — every call settles **directly to Surf's Base treasury**. You hold the wallet, BlockRun holds the Surf key, Surf holds the data. No Surf account, no API key, no monthly minimum.
 
@@ -49,20 +48,16 @@ blockrun_surf({ path: "onchain/sql", body: {
   sql: "SELECT token_address, count() FROM ethereum.dex_trades WHERE block_time > now() - INTERVAL 1 DAY GROUP BY 1 ORDER BY 2 DESC LIMIT 10"
 }})
 
-blockrun_surf({ path: "chat/completions", body: {
-  model: "surf/surf-1.5",
-  messages: [{ role: "user", content: "What's the Polymarket consensus for the 2028 US election?" }],
-}})
+blockrun_surf({ path: "wallet/labels/batch", params: { addresses: "0xabc,0xdef" } })
 ```
 
-## Pricing — two tiers, flat
+## Pricing — one flat rate
 
-| Tier | Price | Used by |
-|------|-------|---------|
-| Standard | $0.0095 | every read: prices, rankings, news, order books, candles, search, wallet detail, social, prediction markets (80 endpoints) |
-| Premium | $0.0200 | raw on-chain SQL, schema introspection, structured queries (3 endpoints) |
+**$0.0095 per call. Every endpoint, no tiers, including raw on-chain SQL.**
 
-Verified against the gateway's own 402 responses, which are free to request — send any call with no payment header and it replies with the exact price. Standard is genuinely flat: `market/price`, `wallet/labels/batch`, `social/mindshare`, `news/feed`, `exchange/klines` and `search/web` all quote $0.0095.
+Verified against the gateway's own `payment-required` header, which is free to request — send any call with no payment header and it quotes the exact charge. All of `market/price`, `wallet/labels/batch`, `social/mindshare`, `news/feed`, `exchange/klines`, `search/web` **and `onchain/sql`** return the same $0.0095 (`SURF_TIER_1/2/3_PRICE` are all identical upstream).
+
+Ignore any "premium tier" pricing you may have seen — SQL used to cost more and no longer does.
 
 Wrong / missing required params return HTTP 400 **without charging** — pre-validation runs before settlement.
 
@@ -84,59 +79,58 @@ The only Surf prediction-market endpoint with no Predexon equivalent is `predict
 
 ## Quick Decision Table — "User asks about X"
 
-| User wants… | Method | Path | Required | Tier |
-|---|---|---|---|---|
-| BTC/ETH price | GET | `market/price` | `symbol` | 1 |
-| ETF flow history | GET | `market/etf` | `symbol` | 1 |
-| Fear & Greed index | GET | `market/fear-greed` | – | 1 |
-| Top 100 tokens by market cap | GET | `market/ranking` | – | 1 |
-| Options skew / IV / volume | GET | `market/options` | `symbol` | 1 |
-| CEX ticker for a pair | GET | `exchange/price` | `pair` | 1 |
-| Perp snapshot (funding + OI) | GET | `exchange/perp` | `pair` | 1 |
-| Order book depth | GET | `exchange/depth` | `pair` | 2 |
-| OHLCV candles | GET | `exchange/klines` | `pair` | 2 |
-| Funding rate history | GET | `exchange/funding-history` | `pair` | 2 |
-| Long/short ratio | GET | `exchange/long-short-ratio` | `pair` | 2 |
-| Bridge protocols by volume | GET | `onchain/bridge/ranking` | – | 1 |
-| Yield pool ranking | GET | `onchain/yield/ranking` | – | 1 |
-| Current gas price (per chain) | GET | `onchain/gas-price` | `chain` | 1 |
-| Transaction details | GET | `onchain/tx` | `hash`, `chain` | 1 |
-| **Raw on-chain SQL** | POST | `onchain/sql` | body: `sql` | 3 |
-| **Structured on-chain query** | POST | `onchain/query` | body: typed predicates | 3 |
-| Inspect ClickHouse schema | GET | `onchain/schema` | – | 3 |
-| Polymarket markets ranking | GET | `prediction-market/polymarket/ranking` | – | 1 |
-| Polymarket price history | GET | `prediction-market/polymarket/prices` | `condition_id` | 1 |
-| Polymarket positions for wallet | GET | `prediction-market/polymarket/positions` | `address` | 2 |
-| Kalshi markets ranking | GET | `prediction-market/kalshi/ranking` | – | 1 |
-| Kalshi market detail | GET | `prediction-market/kalshi/markets` | `market_ticker` | 1 |
-| **Search Polymarket / Kalshi** | GET | `search/polymarket` / `search/kalshi` | – | 2 |
-| Wallet profile (cross-chain) | GET | `wallet/detail` | `address` | 2 |
-| Wallet net-worth time series | GET | `wallet/net-worth` | `address` | 2 |
-| Wallet DeFi positions | GET | `wallet/protocols` | `address` | 2 |
-| **Batch wallet labels (CEX/Whale/MEV…)** | GET | `wallet/labels/batch` | `addresses` | 2 |
-| Token tokenomics + unlocks | GET | `token/tokenomics` | – | 1 |
-| Token holders top N | GET | `token/holders` | `address`, `chain` | 2 |
-| Token transfers | GET | `token/transfers` | `address`, `chain` | 2 |
-| Token DEX trades | GET | `token/dex-trades` | `address` | 2 |
-| Social mindshare time series | GET | `social/mindshare` | `q`, `interval` | 2 |
-| Smart-follower history | GET | `social/smart-followers/history` | – | 2 |
-| Twitter user profile | GET | `social/user` | `handle` | 1 |
-| Twitter user posts | GET | `social/user/posts` | `handle` | 1 |
-| Tweet replies | GET | `social/tweet/replies` | `tweet_id` | 1 |
-| **Web search (crypto-scoped)** | GET | `search/web` | `q` | 2 |
-| News article search | GET | `search/news` | `q` | 2 |
-| KOL / CT people search | GET | `search/social/people` | `q` | 2 |
-| Tweet full-text search | GET | `search/social/posts` | `q` | 2 |
-| Project / token search | GET | `search/project` | `q` | 2 |
-| Wallet search (by ENS, label) | GET | `search/wallet` | `q` | 2 |
-| VC fund portfolio | GET | `fund/portfolio` | – | 1 |
-| VC fund ranking | GET | `fund/ranking` | `metric` | 1 |
-| DeFi protocol ranking | GET | `project/defi/ranking` | `metric` | 1 |
-| Project full profile | GET | `project/detail` | – | 1 |
-| Clean a webpage to markdown | GET | `web/fetch` | `url` | 2 |
-| **Surf-1.5 chat with citations** | POST | `chat/completions` | body: `model`, `messages` | 3 |
-| News feed | GET | `news/feed` | – | 1 |
-| Single news article | GET | `news/detail` | `id` | 1 |
+| User wants… | Method | Path | Required |
+|---|---|---|---|
+| BTC/ETH price | GET | `market/price` | `symbol` |
+| ETF flow history | GET | `market/etf` | `symbol` |
+| Fear & Greed index | GET | `market/fear-greed` | – |
+| Top 100 tokens by market cap | GET | `market/ranking` | – |
+| Options skew / IV / volume | GET | `market/options` | `symbol` |
+| CEX ticker for a pair | GET | `exchange/price` | `pair` |
+| Perp snapshot (funding + OI) | GET | `exchange/perp` | `pair` |
+| Order book depth | GET | `exchange/depth` | `pair` |
+| OHLCV candles | GET | `exchange/klines` | `pair` |
+| Funding rate history | GET | `exchange/funding-history` | `pair` |
+| Long/short ratio | GET | `exchange/long-short-ratio` | `pair` |
+| Bridge protocols by volume | GET | `onchain/bridge/ranking` | – |
+| Yield pool ranking | GET | `onchain/yield/ranking` | – |
+| Current gas price (per chain) | GET | `onchain/gas-price` | `chain` |
+| Transaction details | GET | `onchain/tx` | `hash`, `chain` |
+| **Raw on-chain SQL** | POST | `onchain/sql` | body: `sql` |
+| **Structured on-chain query** | POST | `onchain/query` | body: typed predicates |
+| Inspect ClickHouse schema | GET | `onchain/schema` | – |
+| Polymarket markets ranking | GET | `prediction-market/polymarket/ranking` | – |
+| Polymarket price history | GET | `prediction-market/polymarket/prices` | `condition_id` |
+| Polymarket positions for wallet | GET | `prediction-market/polymarket/positions` | `address` |
+| Kalshi markets ranking | GET | `prediction-market/kalshi/ranking` | – |
+| Kalshi market detail | GET | `prediction-market/kalshi/markets` | `market_ticker` |
+| **Search Polymarket / Kalshi** | GET | `search/polymarket` / `search/kalshi` | – |
+| Wallet profile (cross-chain) | GET | `wallet/detail` | `address` |
+| Wallet net-worth time series | GET | `wallet/net-worth` | `address` |
+| Wallet DeFi positions | GET | `wallet/protocols` | `address` |
+| **Batch wallet labels (CEX/Whale/MEV…)** | GET | `wallet/labels/batch` | `addresses` |
+| Token tokenomics + unlocks | GET | `token/tokenomics` | – |
+| Token holders top N | GET | `token/holders` | `address`, `chain` |
+| Token transfers | GET | `token/transfers` | `address`, `chain` |
+| Token DEX trades | GET | `token/dex-trades` | `address` |
+| Social mindshare time series | GET | `social/mindshare` | `q`, `interval` |
+| Smart-follower history | GET | `social/smart-followers/history` | – |
+| Twitter user profile | GET | `social/user` | `handle` |
+| Twitter user posts | GET | `social/user/posts` | `handle` |
+| Tweet replies | GET | `social/tweet/replies` | `tweet_id` |
+| **Web search (crypto-scoped)** | GET | `search/web` | `q` |
+| News article search | GET | `search/news` | `q` |
+| KOL / CT people search | GET | `search/social/people` | `q` |
+| Tweet full-text search | GET | `search/social/posts` | `q` |
+| Project / token search | GET | `search/project` | `q` |
+| Wallet search (by ENS, label) | GET | `search/wallet` | `q` |
+| VC fund portfolio | GET | `fund/portfolio` | – |
+| VC fund ranking | GET | `fund/ranking` | `metric` |
+| DeFi protocol ranking | GET | `project/defi/ranking` | `metric` |
+| Project full profile | GET | `project/detail` | – |
+| Clean a webpage to markdown | GET | `web/fetch` | `url` |
+| News feed | GET | `news/feed` | – |
+| Single news article | GET | `news/detail` | `id` |
 
 ## Worked Examples
 
@@ -164,7 +158,7 @@ blockrun_surf({
   }
 })
 ```
-**Cost: $0.02.** Raw ClickHouse — same query language Surf's own UI uses.
+**Cost: $0.0095.** Raw ClickHouse — same query language Surf's own UI uses, at the same flat rate as any other Surf read.
 
 ### 3. "Is this whale wallet labeled? What does it hold?"
 
@@ -179,7 +173,7 @@ blockrun_surf({ path: "wallet/protocols", params: { address: "0xabc..." } })
 // Step 3 — net-worth time series
 blockrun_surf({ path: "wallet/net-worth", params: { address: "0xabc..." } })
 ```
-**Cost: 4 × $0.005 = $0.02.** Replaces a Nansen subscription for one-off lookups.
+**Cost: 4 × $0.0095 = $0.038.** Replaces a Nansen subscription for one-off lookups.
 
 ### 4. "What's the market saying about the 2028 election?"
 
@@ -192,22 +186,6 @@ blockrun_surf({ path: "search/kalshi",     params: { q: "2028 US president" } })
 blockrun_surf({ path: "prediction-market/polymarket/prices",
                 params: { condition_id: "0x..." } })
 ```
-
-### 5. "Surf-1.5 chat with grounded citations"
-
-```ts
-blockrun_surf({
-  path: "chat/completions",
-  body: {
-    model: "surf/surf-1.5",
-    messages: [
-      { role: "user", content: "Summarize ETH's on-chain activity this week. Cite sources." }
-    ],
-    citation: ["source", "chart"]
-  }
-})
-```
-**Cost: $0.02 flat (per-token billing in Phase 2).** Returns OpenAI-compatible response + citations.
 
 ### 6. "Where's mindshare moving for L1s?"
 
@@ -233,7 +211,6 @@ Pass `body` (POST) only for these three endpoints:
 
 - `onchain/query` — structured, typed predicates against ClickHouse
 - `onchain/sql` — raw SQL string in `{ sql: "..." }`
-- `chat/completions` — OpenAI-compatible chat completion
 
 Everything else is GET with `params`.
 
@@ -253,7 +230,7 @@ result = client._request_with_payment_raw("/v1/surf/onchain/sql", {
 })
 ```
 
-## Full Endpoint Catalog (84 endpoints, 13 categories)
+## Full Endpoint Catalog (83 endpoints, 13 categories)
 
 ### Exchange (CEX) — 7
 `exchange/markets` · `exchange/price` · `exchange/perp` · `exchange/depth` · `exchange/klines` · `exchange/funding-history` · `exchange/long-short-ratio`
@@ -293,15 +270,12 @@ result = client._request_with_payment_raw("/v1/surf/onchain/sql", {
 `web/fetch`
 
 ### Chat — 1
-`chat/completions` (POST) — Surf-1.5 with `citation: ["source","chart"]` support
 
 ## Gotchas
 
-- **Required params:** 56 of 84 endpoints require at least one param. The 402 response and the in-tool route surface which fields are missing. Missing params → 400 + no charge.
+- **Required params:** 56 of 83 endpoints require at least one param. The 402 response and the in-tool route surface which fields are missing. Missing params → 400 + no charge.
 - **Solana wallet works too**: `blockrun_surf` routes through whichever chain the BlockRun wallet is on (Base or Solana). Surf settlement always lands in Surf's Base treasury.
 - **`onchain/sql` is powerful but unrestricted**: there's no row limit on the server side. Add `LIMIT` to your query or you'll pay for a megabyte of JSON.
-- **`chat/completions` is flat $0.02 in v1** — per-token billing rolls out in Phase 2. For high-volume chat, run cost estimates assuming the flat rate.
-- **The chat endpoint uses a different upstream base** (`api.asksurf.ai/v1` instead of `/gateway/v1`). The BlockRun proxy handles this transparently — you just call `chat/completions`.
 - **`X-Payment-Receipt` header** lands on the response with the settlement tx hash — keep it for accounting.
 
 ## Reference


### PR DESCRIPTION
Closes the last of the audit findings. Every figure below is verified against a live `payment-required` header.

## `surf` taught an endpoint that doesn't exist

```
POST /api/v1/surf/chat/completions  →  HTTP 404
```

The skill had a worked example, a catalog row, a trigger (`surf-1.5`) and pricing notes for it. All removed.

## `surf` has no premium tier any more

The skill billed `onchain/sql` at **$0.0200**. Upstream:

```
SURF_TIER_1_PRICE = 0.0075
SURF_TIER_2_PRICE = 0.0075
SURF_TIER_3_PRICE = 0.0075     ← all identical
live: surf/onchain/sql → $0.0095, same as every other read
```

The tier column is gone. **One flat rate, SQL included.**

## `gentech-blockrun` charged for free calls

`blockrun_price` crypto/FX/commodity quotes cost **$0**. The skill billed them at `$0.001` across four usage patterns — and advised agents to *"cache for 30–60 seconds"* to save money **that was never being spent**.

Also refreshed: `defi` $0.001 → **$0.0070** (prices/* → **$0.0030**), `exa` $0.01 → **$0.0120**, and stopped quoting a flat rate for `blockrun_chat`, which is per-token.

## Everything repriced to the charge

| | was | is |
|---|---|---|
| `defi` protocols/chains/yields | $0.005 | **$0.0070** |
| `defi` prices/* | $0.001 | **$0.0030** |
| `rpc` | $0.002 | **$0.0040** |
| `surf` (all, incl. SQL) | $0.0075 / $0.0200 | **$0.0095** |
| `price` stocks | $0.001 | **$0.0030** |
| `price` crypto/FX/commodity | $0.001 | **FREE** |
| `phone/lookup` | $0.01 | **$0.0120** |
| `phone/lookup/fraud` | $0.05 | **$0.0520** |
| `phone/numbers/list` | $0.001 | **$0.0030** |
| `phone/numbers/buy` | $5 | **$5.002** |
| `search` (default 10 sources) | $0.25 | **$0.2645** |

`search` also now says plainly that it is **priced per source and expensive by default** — it was the one tool most likely to surprise an agent.

## Verified

Spot-checked live after editing: `phone/lookup` $0.0120 ✓ · `lookup/fraud` $0.0520 ✓ · `numbers/list` $0.0030 ✓ · `surf/onchain/sql` $0.0095 ✓

No code change. **165 tests**, typecheck, build green; all 11 skill frontmatters parse.