### PR TITLE
fix(skills): repair regex artifacts in the surf rewrite (0.31.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to BlockRun MCP will be documented in this file.
 
+## 0.31.5
+
+Round 2 of the audit loop — regression-hunting round 1's own fixes. Everything functional held; the only casualties were artifacts of my own regex surgery in 0.31.4.
+
+- **`fix(skills)` — the surf rewrite left the file inconsistent.** Deleting the `chat/completions` section with a regex (rather than by hand) left: worked-example headings numbered **1, 2, 3, 4, 6, 7** with a hole where 5 had been; an **empty `### Chat — 1` category heading** whose only endpoint 404s; and a catalog claiming **83 endpoints / 13 categories** while the per-category counts still summed to **84**. Renumbered, orphan removed, counts reconciled — 12 categories summing to 83, matching the header.
+- **Verified no functional regression from the 0.31.2–0.31.4 fixes.** Every genuinely free path still reserves exactly $0 (`chat` mode:"free" alone, `nvidia/*`, `phone/numbers/release`, GET `voice/call/{id}`) — important because `checkBudget` only short-circuits at exactly 0, so a $0.002 reserve on a free call would deny it on an exhausted budget. Every paid path still > $0. `search` returns a finite, positive reserve for all of `2.7 / 0.5 / 50.9 / 51 / 1e308 / Infinity / -Infinity / NaN / "10" / null / true / [] / {} / undefined`, and 50.9 still caps at 50. `modal` returns a finite reserve for every garbage body, and non-create paths stay $0.0030 regardless of what the body carries.
+- **`modal` divergence on invalid input is harmless, confirmed live:** `gpu:"h100"` (lowercase), `gpu:"NOPE"`, `timeout:86401`, `timeout:"3600"` all return **HTTP 400 without charging**, so an estimate that diverges there costs nothing — the reserve is released in the `finally`. Every *valid* shape matches the header exactly.
+- 165 tests, typecheck, build green.
+
 ## 0.31.4
 
 Closes the last of the audit findings: every price an agent reads is now the price it is **charged**, verified against live `payment-required` headers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.31.4",
+  "version": "0.31.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/mcp",
-      "version": "0.31.4",
+      "version": "0.31.5",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.31.4",
+  "version": "0.31.5",
   "mcpName": "io.github.BlockRunAI/blockrun-mcp",
   "description": "BlockRun MCP Server - Give your AI agent web search, deep research, prediction markets, and crypto data. Paid via x402 micropayments.",
   "type": "module",

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -187,7 +187,7 @@ blockrun_surf({ path: "prediction-market/polymarket/prices",
                 params: { condition_id: "0x..." } })
 ```
 
-### 6. "Where's mindshare moving for L1s?"
+### 5. "Where's mindshare moving for L1s?"
 
 ```ts
 blockrun_surf({ path: "social/mindshare", params: { q: "solana", interval: "1d" } })
@@ -195,7 +195,7 @@ blockrun_surf({ path: "social/mindshare", params: { q: "monad",  interval: "1d" 
 blockrun_surf({ path: "social/ranking" })
 ```
 
-### 7. "ETF flows + funding rate + long/short — give me the macro picture"
+### 6. "ETF flows + funding rate + long/short — give me the macro picture"
 
 ```ts
 blockrun_surf({ path: "market/etf",                params: { symbol: "BTC" } })       // T1
@@ -230,7 +230,7 @@ result = client._request_with_payment_raw("/v1/surf/onchain/sql", {
 })
 ```
 
-## Full Endpoint Catalog (83 endpoints, 13 categories)
+## Full Endpoint Catalog (83 endpoints, 12 categories)
 
 ### Exchange (CEX) — 7
 `exchange/markets` · `exchange/price` · `exchange/perp` · `exchange/depth` · `exchange/klines` · `exchange/funding-history` · `exchange/long-short-ratio`
@@ -268,8 +268,6 @@ result = client._request_with_payment_raw("/v1/surf/onchain/sql", {
 
 ### Web — 1
 `web/fetch`
-
-### Chat — 1
 
 ## Gotchas
 


### PR DESCRIPTION
**Round 2 of the audit loop** — regression-hunting round 1's own fixes. Everything functional held. The only casualties were artifacts of my own regex surgery in 0.31.4.

## What round 2 found

Deleting the `chat/completions` section **with a regex** instead of by hand left three inconsistencies:

```
### 1.  ### 2.  ### 3.  ### 4.  ### 6.  ### 7.     ← a hole where 5 was
### Chat — 1                                        ← empty heading; its only
                                                       endpoint 404s
## Full Endpoint Catalog (83 endpoints, 13 categories)
   per-category counts still summed to 84 ↑
```

Renumbered, orphan removed, counts reconciled: **12 categories summing to 83**, matching the header.

## What held (no functional regression)

**Free paths still reserve exactly $0** — `chat` mode:`"free"` alone, `nvidia/*`, `phone/numbers/release`, GET `voice/call/{id}`. This matters: `checkBudget` only short-circuits at *exactly* 0, so a $0.002 reserve on a free call would **deny it on an exhausted budget**. The `withTxFee` $0 no-op is what prevents that.

**Paid paths still > $0** — including `chat` mode:`"free"` + a paid model (the bypass 0.31.2 closed).

**`search`** returns a finite, positive reserve for `2.7 / 0.5 / 50.9 / 51 / 1e308 / Infinity / -Infinity / NaN / "10" / null / true / [] / {} / undefined`, and 50.9 still caps at 50.

**`modal`** returns a finite reserve for every garbage body, and non-create paths stay $0.0030 no matter what the body carries.

## A divergence that turns out to be harmless

`modal` estimates diverge from the gateway on invalid input — but every one of those **400s without charging**, so the reserve is released in the `finally` and nothing settles:

```
gpu:"h100" (lowercase) → HTTP 400     gpu:"NOPE"        → HTTP 400
timeout:86401 (>max)   → HTTP 400     timeout:"3600"    → HTTP 400
gpu:"H100" (valid)     → HTTP 402  charged $8.0020 = reserve $8.0020 ✓
```

Every **valid** shape matches the header exactly.

## Note on the round itself

The round-2 workflow was **killed mid-flight** — its 5 agents did real work (81–180 KB transcripts) but never returned structured results. I ran the regression checks directly rather than report an incomplete round as "clean."

165 tests, typecheck, build green.