### PR TITLE
0.32.0 — Kimi K3, the current high-end lineup, and a free tier that was 4/5 retired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to BlockRun MCP will be documented in this file.
 
+## 0.32.0
+
+Kimi K3 and the current high-end lineup, plus the tier lists rebuilt against the live catalogue instead of edited by hand. The interesting part is why nobody noticed they had rotted: **a retired model ID does not fail.** The gateway silently aliases it onto something else — `nvidia/llama-4-maverick` answers `200 OK` while being served by `gpt-oss-120b`, and `moonshot/kimi-k2.6` still quotes a price. Only a wholly unknown ID `400`s. So "it works" was never evidence a tier was correct, and 8 dead IDs had accumulated across 6 tiers.
+
+- **`feat(models)` — `moonshot/kimi-k3` ($3/$15, 1M ctx, vision + reasoning + coding)** added to `balanced`, `reasoning`, and `coding`. It supersedes the whole k2.x line, which is gone from the catalogue — `kimi-k2.6` was still listed in three tiers and was being aliased somewhere unchosen on every hit.
+- **`feat(models)` — the current high end, none of which we served.** `gpt-5.6-sol` ($5/$30, 1M) and `gpt-5.6-terra` ($2.5/$15, 1M); `claude-sonnet-5` ($3/$15, 1M) and `claude-fable-5` ($10/$50, 1M); `grok-4.5` ($2.5/$9, native search), `grok-4.3` ($1.5/$4, 1M) and `grok-build-0.1` (coding); `qwen3.7-max`; `deepseek-v4-pro` ($0.435/$0.87, 1M — frontier-class reasoning at budget-tier pricing, now `cheap[0]`); `minimax-m3`; `glm-5.2`/`glm-5.1`.
+- **`feat(chat)` — the default model is now `openai/gpt-5.6-terra`.** `balanced[0]` is what every call with no `model` resolves to. Newer line, 1M context, and **half the price** of the outgoing `gpt-5.5` default ($2.5/$15 vs $5/$30).
+- **`fix(models)` — the `free` tier was 4/5 retired.** `llama-4-maverick`, `qwen3-coder-480b`, `gpt-oss-120b` and `gpt-oss-20b` are all delisted; the tier only ever "worked" through the aliasing above, i.e. free calls were being served by a model nobody picked. Rebuilt from the `$0` models the catalogue actually lists.
+- **`fix(models)` — being listed is not being alive; every entry was live-probed.** `nvidia/mistral-large-3-675b` is in the catalogue at `$0` and **hangs**: no response, no error, connection held open past 90s, reproduced twice. It had landed at `free[0]` on the first pass — the first model every `mode:"free"` call tries — where it would have stalled the routing loop before it could fall through. Excluded and documented.
+- **`docs(chat)` — the tool description no longer advertises the old tiers.** It still told the model `mode:"coding"` meant "GLM-5 first" when `coding[0]` had been `claude-opus-4.8` for several releases, and pointed `mode:"reasoning"` at `o1`. Modes, examples and the `model` hints now match what the tiers actually contain.
+- **Budget gate re-verified, not assumed.** Adding $180/M and $168/M models raises the question of whether the `$20/M` frontier reserve still covers the worst case. It does — the gateway quotes sublinearly, so `gpt-5.4-pro` at 128k `max_tokens` quotes **$2.42** against a **$2.56** reserve — but headroom is only ~5%, so the constant was left alone rather than guessed at. Cheap-tier candidates probed the same way, all with wide margins.
+- All 49 tier IDs validated against live `GET /v1/models`. 169 tests, typecheck, build, `verify:prices` (20/20 exact), and the stdio smoke test (19 tools) green.
+
 ## 0.31.6
 
 Round 3. Two of these were live the whole time and invisible to every prior round: a skill that never loaded, and an endpoint that never existed. Both were found by asking the gateway instead of reading our own files.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.31.6",
+  "version": "0.32.0",
   "mcpName": "io.github.BlockRunAI/blockrun-mcp",
   "description": "BlockRun MCP Server - Give your AI agent web search, deep research, prediction markets, and crypto data. Paid via x402 micropayments.",
   "type": "module",

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -29,8 +29,8 @@ export function estimateChatCost(
   // free, and `mode` alone does not make it so.
   //
   // An explicit `model` WINS over `mode` at call time:
-  //   targetModel = model || MODEL_TIERS[mode ?? "balanced"][0] || "openai/gpt-5.5"
-  // so { mode: "free", model: "openai/gpt-5.5" } runs gpt-5.5 and settles at
+  //   targetModel = model || MODEL_TIERS[mode ?? "balanced"][0] || "openai/gpt-5.6-terra"
+  // so { mode: "free", model: "openai/gpt-5.6-sol" } runs gpt-5.6-sol and settles at
   // frontier prices. Returning 0 for it — which is what an unconditional
   // `mode === "free"` check does — is a TOTAL budget-gate bypass: any agent, even
   // one already at its cap, gets unmetered frontier calls by tacking on
@@ -60,7 +60,7 @@ export function estimateChatCost(
 
   // Any tier whose FIRST-CHOICE model is a frontier model, plus any explicit
   // single model, can settle at a price we can't know up front — reserve
-  // conservatively. balanced[0] = openai/gpt-5.5 and coding[0] =
+  // conservatively. balanced[0] = openai/gpt-5.6-terra and coding[0] =
   // anthropic/claude-opus-4.8 (see MODEL_TIERS), the same frontier primaries as
   // reasoning/powerful, and a no-mode chat resolves to "balanced" (see the
   // routing loop below) — so undefined counts too. Reserving the cheap heuristic
@@ -106,19 +106,20 @@ export function registerChatTool(server: McpServer, budget: BudgetState): void {
       description: `Get a second opinion from another AI model, or use a specialized model for a specific task.
 
 Notable modes:
-- mode:"glm" → Zhipu GLM-5 / GLM-5-Turbo ($0.001/call, excellent for coding tasks, pays via USDC on BlockRun)
-- mode:"coding" → GLM-5 first, then code-specialized models
-- mode:"cheap" → GLM-5, NVIDIA free, DeepSeek
-- mode:"reasoning" → Claude Opus, o3, o1, deepseek-reasoner
+- mode:"powerful" → Claude Opus 4.8, GPT-5.6-sol, Claude Fable 5 (frontier, 1M context)
+- mode:"reasoning" → Claude Opus 4.8, GPT-5.6-sol, Kimi K3, Grok 4.3, deepseek-v4-pro
+- mode:"coding" → Claude Opus 4.8, GPT-5.3-codex, Kimi K3, Grok Build, GLM-5.2
+- mode:"cheap" → deepseek-v4-pro, MiniMax M3, GLM-5, NVIDIA free
+- mode:"glm" → Zhipu GLM-5 / 5.2 / 5.1 / 5-Turbo (cheap, strong at coding)
 - mode:"free" → NVIDIA models (no cost)
 
-Pick directly: model:"zai/glm-5", model:"openai/o3", model:"nvidia/deepseek-v4-flash" (free).
+Pick directly: model:"moonshot/kimi-k3", model:"openai/gpt-5.6-sol", model:"anthropic/claude-opus-4.8", model:"xai/grok-4.5", model:"nvidia/deepseek-v4-flash" (free).
 
 Run blockrun_models to see all available models with pricing.`,
       inputSchema: {
         message: z.string().describe("Your message to the AI"),
-        model: z.string().optional().describe("Specific model ID (e.g., 'zai/glm-5', 'openai/o3')"),
-        mode: z.enum(["fast", "balanced", "powerful", "cheap", "reasoning", "free", "coding", "glm"]).optional().describe("Routing mode: glm = Zhipu GLM-5/GLM-5-Turbo ($0.001/call, great for coding), coding = GLM-5 + code models, cheap = GLM-5 + budget, free = NVIDIA only (ignored if model specified)"),
+        model: z.string().optional().describe("Specific model ID (e.g., 'moonshot/kimi-k3', 'openai/gpt-5.6-sol', 'zai/glm-5')"),
+        mode: z.enum(["fast", "balanced", "powerful", "cheap", "reasoning", "free", "coding", "glm"]).optional().describe("Routing mode: powerful/reasoning = frontier models (Opus 4.8, GPT-5.6-sol, Kimi K3), coding = code-specialized, glm = Zhipu GLM (cheap, great for coding), cheap = budget models, free = NVIDIA only (ignored if model specified)"),
         system: z.string().optional().describe("Optional system prompt"),
         max_tokens: z.number().optional().default(1024).describe("Max tokens in response"),
         temperature: z.number().optional().default(1).describe("Creativity 0-2"),
@@ -138,7 +139,7 @@ Run blockrun_models to see all available models with pricing.`,
               z.object({ type: z.literal("image_url"), image_url: z.object({ url: z.string().describe("https URL or data:<mime>;base64,<...> URI") }) }),
             ])),
           ]).describe("Plain text, or an array of parts for multimodal input (text + image_url). Images are honored on the native anthropic/claude-* path."),
-        })).optional().describe("Conversation history for multi-turn context. When provided, 'message' is appended as the final user turn. Use with explicit 'model' param (defaults to 'openai/gpt-5.5' if not specified). Note: if you include a role:'system' entry in messages[], do not also pass the system param to avoid duplicate system messages."),
+        })).optional().describe("Conversation history for multi-turn context. When provided, 'message' is appended as the final user turn. Use with explicit 'model' param (defaults to 'openai/gpt-5.6-terra' if not specified). Note: if you include a role:'system' entry in messages[], do not also pass the system param to avoid duplicate system messages."),
       },
     },
     async ({ message, model, mode, system, max_tokens, temperature, response_format, stop, thinking, agent_id, messages }) => {
@@ -207,7 +208,7 @@ Run blockrun_models to see all available models with pricing.`,
 
       // Multi-turn conversation
       if (messages && messages.length > 0) {
-        const targetModel = model || MODEL_TIERS[(mode ?? "balanced") as RoutingMode]?.[0] || "openai/gpt-5.5";
+        const targetModel = model || MODEL_TIERS[(mode ?? "balanced") as RoutingMode]?.[0] || "openai/gpt-5.6-terra";
         const fullMessages = [
           ...(system ? [{ role: "system" as const, content: system }] : []),
           ...messages,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,43 +14,62 @@ export const BASE_RPC_URLS = [
   "https://1rpc.io/base",
 ];
 
-// Models organized by provider:
-// OpenAI (14): openai/gpt-5.5 (balanced default), openai/gpt-5.4, openai/gpt-5.4-pro,
-//   openai/gpt-5.3, openai/gpt-5.2, openai/gpt-5.4-mini, openai/gpt-5-mini,
-//   openai/gpt-5.4-nano, openai/gpt-5.2-pro, openai/gpt-5.3-codex, openai/o1,
-//   openai/o1-mini, openai/o3, openai/o3-mini
-// Anthropic (flagships): anthropic/claude-opus-4.8 (most capable, 1M context, 128k output),
-//   anthropic/claude-opus-4.7 (1M context), anthropic/claude-opus-4.6, anthropic/claude-sonnet-4.6,
-//   anthropic/claude-haiku-4.5 (plus opus-4.5, opus-4, sonnet-4 legacy)
-// Google (8): google/gemini-3.1-pro, google/gemini-3-pro-preview, google/gemini-3.5-flash
-//   (latest flash, thinking, $0.5/$3), google/gemini-3-flash-preview, google/gemini-2.5-pro,
-//   google/gemini-2.5-flash, google/gemini-3.1-flash-lite, google/gemini-2.5-flash-lite
-// DeepSeek (2): deepseek/deepseek-chat, deepseek/deepseek-reasoner
-// Moonshot (2): moonshot/kimi-k2.6 (flagship, $0.95/$4, vision + reasoning), moonshot/kimi-k2.5 (legacy)
-// NVIDIA FREE — serving healthy as of the 2026-06-07 sweep: nvidia/llama-4-maverick
-//   (general workhorse), nvidia/qwen3-coder-480b (coding), nvidia/deepseek-v4-flash
-//   (1M context), nvidia/nemotron-3-nano-omni-30b-a3b-reasoning (vision),
-//   nvidia/gpt-oss-120b, nvidia/gpt-oss-20b.
-//   Down/redirected server-side (do NOT route to): nvidia/qwen3-next-80b-a3b-thinking
-//   (NVIDIA EOL 2026-05-21, 410), nvidia/mistral-small-4-119b (timing out),
-//   nvidia/deepseek-v3.2 + nvidia/glm-4.7 (NIM hung). Other retired-but-aliased:
-//   nvidia/kimi-k2.5, nvidia/nemotron-{ultra-253b,3-super-120b,super-49b},
-//   nvidia/mistral-large-3-675b, nvidia/devstral-2-123b, nvidia/qwen3.5-397b-a17b.
-// ZAI (2): zai/glm-5, zai/glm-5-turbo
-// MiniMax (2): minimax/minimax-m3 (flagship, 1M context, reasoning + coding), minimax/minimax-m2.7
-// xAI (hidden, API-routable): xai/grok-4.20-reasoning, xai/grok-4.20-non-reasoning, xai/grok-4-fast-reasoning
+// Model catalogue, refreshed against the live GET /v1/models on 2026-07-20.
+// Prices below are $/M input / $/M output as the gateway quotes them.
+//
+// A NOTE ON STALENESS: the gateway silently ALIASES retired IDs onto a live
+// model rather than 404ing (the 2026-07-20 sweep found nvidia/llama-4-maverick
+// answering as nvidia/gpt-oss-120b, and moonshot/kimi-k2.6 still quoting a
+// price). So a dead entry here does NOT surface as an error — it quietly routes
+// somewhere you did not choose. Only a genuinely unknown ID 400s. That is why
+// these lists are checked against the catalogue rather than "tested by working".
+//
+// OpenAI (22): gpt-5.6-sol ($5/$30, 1M, deepest reasoning), gpt-5.6-terra
+//   ($2.5/$15, 1M — the balanced default), gpt-5.6-luna ($1/$6, 1M, no
+//   reasoning), gpt-5.5 ($5/$30), gpt-5.4 ($2.5/$15), gpt-5.4-pro ($30/$180,
+//   the priciest model served), gpt-5.3 / gpt-5.2 / gpt-5.3-codex ($1.75/$14),
+//   gpt-5.2-pro ($21/$168), gpt-5.4-mini, gpt-5-mini, gpt-5.4-nano, gpt-4.1{,
+//   -mini,-nano}, gpt-4o{,-mini}, o1 ($15/$60), o3 ($2/$8), o3-mini, o4-mini
+// Anthropic (8): claude-opus-4.8 ($5/$25, 1M — most capable), claude-fable-5
+//   ($10/$50, 1M), claude-opus-4.7 ($5/$25, 1M), claude-sonnet-5 ($3/$15, 1M),
+//   claude-opus-4.5, claude-sonnet-4.6, claude-sonnet-4.5, claude-haiku-4.5
+// Google (7): gemini-3.1-pro ($2/$12), gemini-3.5-flash + gemini-3-flash-preview
+//   ($0.5/$3), gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-flash-lite,
+//   gemini-2.5-flash-lite — all 1M context
+// DeepSeek (3): deepseek-v4-pro ($0.435/$0.87, 1M, reasoning + coding — the
+//   cheapest frontier-class option served), deepseek-chat, deepseek-reasoner
+// Moonshot (1): kimi-k3 ($3/$15, 1M, vision + reasoning + coding). Supersedes
+//   the k2.x line, which is gone from the catalogue.
+// ZAI (4): glm-5.2 ($1.4/$4.4, 1M), glm-5.1 ($1.4/$4.4), glm-5 ($0.6/$1.92 —
+//   still the cheapest ZAI), glm-5-turbo ($1.2/$4)
+// xAI (3): grok-4.5 ($2.5/$9, 500K, native search), grok-4.3 ($1.5/$4, 1M),
+//   grok-build-0.1 ($1.5/$3, coding)
+// MiniMax (2): minimax-m3 ($0.3/$1.2, 1M), minimax-m2.7 ($0.3/$1.2, 200K)
+// Qwen (1): qwen3.7-max ($1.475/$4.425, 1M)
+// NVIDIA — genuinely $0. Serving healthy on the 2026-07-20 probe:
+//   deepseek-v4-flash (1M context), mistral-nemotron, step-3.7-flash,
+//   seed-oss-36b, nemotron-nano-9b-v2, nemotron-nano-12b-v2-vl (vision),
+//   nemotron-3-nano-omni-30b-a3b-reasoning (vision).
+//   Listed but NOT serving — do NOT route to: mistral-large-3-675b (hangs).
 export const MODEL_TIERS = {
   fast: ["google/gemini-3.5-flash", "google/gemini-2.5-flash", "google/gemini-3.1-flash-lite", "openai/gpt-5-mini", "deepseek/deepseek-chat", "google/gemini-3-flash-preview"],
-  balanced: ["openai/gpt-5.5", "anthropic/claude-sonnet-4.6", "google/gemini-3.1-pro", "moonshot/kimi-k2.6", "openai/gpt-5.3", "openai/gpt-5.4"],
-  powerful: ["anthropic/claude-opus-4.8", "openai/gpt-5.4-pro", "anthropic/claude-opus-4.7", "anthropic/claude-opus-4.6", "openai/o3", "openai/gpt-5.4"],
-  cheap: ["zai/glm-5", "zai/glm-5-turbo", "nvidia/gpt-oss-120b", "nvidia/deepseek-v4-flash", "google/gemini-2.5-flash", "deepseek/deepseek-chat", "openai/gpt-5.4-nano"],
-  reasoning: ["anthropic/claude-opus-4.8", "openai/o3", "openai/o1", "openai/o3-mini", "deepseek/deepseek-reasoner", "moonshot/kimi-k2.6", "openai/gpt-5.3-codex"],
-  // 2026-06-07 sweep: dropped qwen3-next (NVIDIA EOL, 410), mistral-small-4-119b
-  // (timing out), deepseek-v3.2 + glm-4.7 (NIM hung). All redirect server-side
-  // anyway; these are the free models actually serving themselves.
-  free: ["nvidia/llama-4-maverick", "nvidia/qwen3-coder-480b", "nvidia/deepseek-v4-flash", "nvidia/gpt-oss-120b", "nvidia/gpt-oss-20b"],
-  coding: ["anthropic/claude-opus-4.8", "zai/glm-5", "openai/gpt-5.3-codex", "moonshot/kimi-k2.6", "nvidia/qwen3-coder-480b", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4"],
-  glm: ["zai/glm-5", "zai/glm-5-turbo"],
+  balanced: ["openai/gpt-5.6-terra", "anthropic/claude-sonnet-5", "moonshot/kimi-k3", "google/gemini-3.1-pro", "xai/grok-4.5", "openai/gpt-5.5"],
+  powerful: ["anthropic/claude-opus-4.8", "openai/gpt-5.6-sol", "anthropic/claude-fable-5", "openai/gpt-5.4-pro", "anthropic/claude-opus-4.7", "openai/gpt-5.2-pro"],
+  cheap: ["deepseek/deepseek-v4-pro", "minimax/minimax-m3", "zai/glm-5", "nvidia/deepseek-v4-flash", "google/gemini-2.5-flash", "deepseek/deepseek-chat", "openai/gpt-5.4-nano"],
+  reasoning: ["anthropic/claude-opus-4.8", "openai/gpt-5.6-sol", "moonshot/kimi-k3", "xai/grok-4.3", "deepseek/deepseek-v4-pro", "openai/o3", "deepseek/deepseek-reasoner"],
+  // 2026-07-20 sweep: the previous list was 4/5 retired (llama-4-maverick,
+  // qwen3-coder-480b, gpt-oss-120b, gpt-oss-20b) and only "worked" via the
+  // server-side aliasing described above.
+  //
+  // Every entry below was live-probed and returned a completion. Being IN the
+  // catalogue is not sufficient: nvidia/mistral-large-3-675b is listed at $0 but
+  // hangs — no response, no error, connection open past 90s (the NIM-hung mode
+  // seen in earlier sweeps) — so it is deliberately excluded. Order matters:
+  // free[0] is what every mode:"free" call tries first, and a hung primary
+  // stalls the whole routing loop before it can fall through.
+  free: ["nvidia/deepseek-v4-flash", "nvidia/mistral-nemotron", "nvidia/step-3.7-flash", "nvidia/seed-oss-36b", "nvidia/nemotron-nano-12b-v2-vl", "nvidia/nemotron-nano-9b-v2"],
+  coding: ["anthropic/claude-opus-4.8", "openai/gpt-5.3-codex", "moonshot/kimi-k3", "xai/grok-build-0.1", "zai/glm-5.2", "qwen/qwen3.7-max", "anthropic/claude-sonnet-5"],
+  glm: ["zai/glm-5", "zai/glm-5.2", "zai/glm-5.1", "zai/glm-5-turbo"],
 } as const;
 
 export type RoutingMode = keyof typeof MODEL_TIERS;

--- a/test/chat.test.ts
+++ b/test/chat.test.ts
@@ -25,7 +25,7 @@ test("estimateChatCost keeps genuinely-free paths at $0", () => {
   assert.equal(estimateChatCost(1024, undefined, "nvidia/deepseek-v4-flash"), 0);
 });
 
-// ── balanced/coding tiers have FRONTIER primaries (gpt-5.5 / claude-opus-4.8),
+// ── balanced/coding tiers have FRONTIER primaries (gpt-5.6-terra / claude-opus-4.8),
 //    so the gate must reserve the frontier worst-case — not the cheap heuristic ──
 test("estimateChatCost reserves the frontier worst-case for balanced/coding (their primary is a frontier model)", () => {
   const frontier = estimateChatCost(1024, "reasoning", undefined);
@@ -33,7 +33,7 @@ test("estimateChatCost reserves the frontier worst-case for balanced/coding (the
   assert.equal(estimateChatCost(1024, "coding", undefined), frontier);
 });
 
-test("estimateChatCost reserves the frontier worst-case for a no-mode chat (defaults to the balanced tier → gpt-5.5)", () => {
+test("estimateChatCost reserves the frontier worst-case for a no-mode chat (defaults to the balanced tier → gpt-5.6-terra)", () => {
   const frontier = estimateChatCost(1024, "reasoning", undefined);
   assert.equal(estimateChatCost(1024, undefined, undefined), frontier);
 });


### PR DESCRIPTION
Adds Kimi K3 and the models the gateway serves that we didn't, and rebuilds `MODEL_TIERS` against the live catalogue.

## Why the tiers had rotted invisibly

**A retired model ID does not fail.** The gateway silently aliases it onto something else:

- `nvidia/llama-4-maverick` → `200 OK`, response body says `"model": "nvidia/gpt-oss-120b"`
- `moonshot/kimi-k2.6` → still returns a `402` price quote
- only a wholly unknown ID (`nvidia/totally-fake-model`) `400`s

So "the tier works" was never evidence the tier was correct. 8 dead IDs had accumulated across 6 tiers, quietly routing to models nobody chose.

## Changes

- **Kimi K3** (`$3/$15`, 1M ctx, vision + reasoning + coding) → `balanced`, `reasoning`, `coding`. Supersedes the k2.x line, gone from the catalogue.
- **New high end**: `gpt-5.6-sol`/`terra`, `claude-sonnet-5`, `claude-fable-5`, `grok-4.5`/`4.3`/`build-0.1`, `qwen3.7-max`, `deepseek-v4-pro`, `minimax-m3`, `glm-5.2`/`5.1`.
- **Default model** `balanced[0]`: `gpt-5.5` → `gpt-5.6-terra`. Newer line, 1M ctx, half the price.
- **`free` tier was 4/5 retired** — rebuilt from the `$0` models actually listed.
- **`nvidia/mistral-large-3-675b` excluded**: listed at `$0` but *hangs* (no response, >90s, reproduced twice). It had landed at `free[0]` on the first pass — where it would stall every `mode:"free"` call before the loop could fall through.
- **Tool description** no longer advertises stale tiers (claimed `coding` = "GLM-5 first" when `coding[0]` is `claude-opus-4.8`; pointed `reasoning` at `o1`).

## Budget gate — verified, not assumed

Adding `$180/M` and `$168/M` models raises whether the `$20/M` frontier reserve still holds. It does; the gateway quotes sublinearly:

| max_tokens | gpt-5.4-pro quote | reserve | headroom |
|---|---|---|---|
| 1024 | $0.0220 | $0.0225 | +2.2% |
| 16384 | $0.3123 | $0.3297 | +5.6% |
| 128000 | $2.4217 | $2.5620 | +5.8% |

Margin is thin (~5%), so the constant was **left alone** rather than guessed at. Cheap-tier candidates probed the same way, all wide.

## Verification

- 169/169 tests, typecheck, build green
- `verify:prices` — 20/20 routes exact
- stdio MCP smoke test — 19 tools
- all 49 tier IDs validated against live `GET /v1/models`; free tier confirmed genuinely `$0` and completing end-to-end