### PR TITLE
ci(publish): create the git tag and GitHub release automatically

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write          # required to push the tag + create the GitHub release
       id-token: write          # required for `mcp-publisher login github-oidc`
     steps:
       - uses: actions/checkout@v4
@@ -85,3 +85,48 @@ jobs:
       - name: Skip registry (already published)
         if: steps.v.outputs.pkg == steps.v.outputs.reg
         run: echo "registry already at ${{ steps.v.outputs.pkg }} — skipping"
+
+      # ---- git tag + GitHub release ----
+      # These used to be manual, and manual meant forgotten: 0.32.1 and 0.32.2
+      # both reached npm and the MCP registry with no tag and no release entry,
+      # because `npm view` showing the new version looks exactly like success.
+      # Same independent-guard shape as the two publishes above — it checks
+      # whether the tag already exists rather than assuming, so re-runs and
+      # workflow_dispatch are safe.
+      - name: Tag + GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.v.outputs.pkg }}
+        run: |
+          set -euo pipefail
+          TAG="v${VERSION}"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG already exists — skipping"
+            exit 0
+          fi
+
+          # Release notes come from the CHANGELOG entry that was already written,
+          # so the release and the CHANGELOG can never drift apart. If the entry
+          # is missing, say so plainly rather than publishing an empty release.
+          if ! node scripts/changelog-section.mjs "$VERSION" > /tmp/notes.md; then
+            echo "See CHANGELOG.md for details." > /tmp/notes.md
+          fi
+
+          # Title convention is "vX.Y.Z — <headline>", and the headline already
+          # exists as the squash-merge subject on main. Strip its "(#NN)" suffix.
+          SUBJECT=$(git log -1 --format=%s)
+          HEADLINE=$(printf '%s' "$SUBJECT" | sed -E 's/ \(#[0-9]+\)$//; s/^v?[0-9]+\.[0-9]+\.[0-9]+ (— )?//')
+          if [ -z "$HEADLINE" ] || [ "$HEADLINE" = "$SUBJECT" ]; then
+            TITLE="$TAG"
+          else
+            TITLE="$TAG — $HEADLINE"
+          fi
+
+          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            git tag -a "$TAG" -m "$TITLE"
+            git push origin "$TAG"
+          fi
+
+          gh release create "$TAG" --title "$TITLE" --notes-file /tmp/notes.md --latest
+          echo "Released $TAG"

--- a/scripts/changelog-section.mjs
+++ b/scripts/changelog-section.mjs
@@ -1,0 +1,55 @@
+// scripts/changelog-section.mjs — print one version's CHANGELOG section.
+//
+// Used by publish.yml to build GitHub release notes from the entry that was
+// already written, so the release and the CHANGELOG can never disagree.
+//
+// Usage: node scripts/changelog-section.mjs 0.32.2
+// Exits 1 with nothing on stdout when the version has no section, so the
+// workflow can fall back to a generic note instead of publishing an empty one.
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Sections are `## <version>` and run until the next `## ` heading.
+ * Kept string-based rather than regex-built-from-input: a version like
+ * "1.2.3" would otherwise let `.` match any character and pick up "1x2x3".
+ */
+export function extractSection(changelog, version) {
+  const lines = changelog.split("\n");
+  const isHeading = (l) => l.startsWith("## ");
+  // Accept "## 0.32.2" and "## v0.32.2", plus a trailing " — headline".
+  const matches = (l) => {
+    const h = l.slice(3).trim();
+    const v = h.startsWith("v") ? h.slice(1) : h;
+    return v === version || v.startsWith(version + " ");
+  };
+
+  const start = lines.findIndex((l) => isHeading(l) && matches(l));
+  if (start === -1) return null;
+
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (isHeading(lines[i])) { end = i; break; }
+  }
+  // Drop the heading itself — the release title already carries it.
+  const body = lines.slice(start + 1, end).join("\n").trim();
+  return body.length ? body : null;
+}
+
+// Only run as a CLI when invoked directly, so the test can import it.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const version = process.argv[2];
+  if (!version) {
+    console.error("usage: node scripts/changelog-section.mjs <version>");
+    process.exit(1);
+  }
+  const section = extractSection(readFileSync(join(root, "CHANGELOG.md"), "utf8"), version);
+  if (!section) {
+    console.error(`no CHANGELOG section for ${version}`);
+    process.exit(1);
+  }
+  process.stdout.write(section + "\n");
+}

--- a/test/changelog-section.test.ts
+++ b/test/changelog-section.test.ts
@@ -1,0 +1,59 @@
+// Run with: npm test  (tsx --test)
+//
+// publish.yml builds GitHub release notes from the CHANGELOG entry, so an
+// extractor bug ships an empty or wrong-version release. 0.32.1 and 0.32.2 both
+// reached npm with no tag and no release at all, which is what this automation
+// exists to prevent — it needs to be right.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+// @ts-expect-error — plain .mjs helper, no types
+import { extractSection } from "../scripts/changelog-section.mjs";
+
+const CHANGELOG = readFileSync(new URL("../CHANGELOG.md", import.meta.url), "utf8");
+
+test("extracts a real section and stops at the next version heading", () => {
+  const s = extractSection(CHANGELOG, "0.32.2") as string;
+  assert.ok(s, "0.32.2 section must be found");
+  assert.match(s, /128 KiB/);
+  assert.doesNotMatch(s, /^## /m, "must not swallow the next heading");
+  assert.doesNotMatch(s, /gpt-oss-120b and gpt-oss-20b are back/, "must not bleed into 0.32.1");
+});
+
+test("each version returns its OWN section", () => {
+  const a = extractSection(CHANGELOG, "0.32.1") as string;
+  const b = extractSection(CHANGELOG, "0.32.2") as string;
+  assert.notEqual(a, b);
+  assert.match(a, /never retired/);
+  assert.match(b, /truncat/i);
+});
+
+test("the heading itself is dropped (the release title already carries it)", () => {
+  const s = extractSection(CHANGELOG, "0.32.2") as string;
+  assert.doesNotMatch(s.split("\n")[0] ?? "", /^## /);
+});
+
+test("an unknown version returns null rather than an empty release", () => {
+  assert.equal(extractSection(CHANGELOG, "99.99.99"), null);
+});
+
+// A version is used as a literal, not spliced into a regex — otherwise the dots
+// in "1.2.3" would match any character and select the wrong section.
+test("version matching is literal, not regex", () => {
+  const fake = "## 1x2x3\n\nwrong section\n\n## 1.2.3\n\nright section\n";
+  assert.equal(extractSection(fake, "1.2.3"), "right section");
+});
+
+test("a prefix version does not match a longer one", () => {
+  const fake = "## 0.32.11\n\neleven\n\n## 0.32.1\n\none\n";
+  assert.equal(extractSection(fake, "0.32.1"), "one");
+});
+
+test("headings carrying a headline still match", () => {
+  const fake = "## 0.9.0 — some headline\n\nbody here\n";
+  assert.equal(extractSection(fake, "0.9.0"), "body here");
+});
+
+test("a section with no body returns null, so the workflow can fall back", () => {
+  assert.equal(extractSection("## 1.0.0\n\n## 0.9.0\n\nbody\n", "1.0.0"), null);
+});


### PR DESCRIPTION
`publish.yml` shipped npm and the MCP registry but left the tag and the release **manual** — and manual meant forgotten.

**0.32.1 and 0.32.2 both reached npm and the MCP registry with no `vX.Y.Z` tag and no release entry.** Nothing failed loudly, because `npm view @blockrun/mcp version` returning the new number looks exactly like a finished release. Two of the four artifacts landed and the other two were invisible until someone went looking.

## What changes

A `Tag + GitHub release` step with the same **independent-guard** shape as the two publishes above it: it checks whether the release already exists rather than assuming, so re-runs and `workflow_dispatch` stay safe, and a push that touches only `publish.yml` is a no-op.

Release notes come from the CHANGELOG entry that was already written, via a new `scripts/changelog-section.mjs`, so **the release and the CHANGELOG cannot drift apart**.

The title keeps the existing `vX.Y.Z — headline` convention by reusing the squash-merge subject on `main` and stripping its `(#NN)` suffix. Verified against every real release subject:

```
0.32.2 — the free tier throws away … (#62)  ->  v0.32.2 — the free tier throws away …
0.32.1 — two working models were … (#61)   ->  v0.32.1 — two working models were …
0.32.0 — Kimi K3, the current … (#60)      ->  v0.32.0 — Kimi K3, the current …
chore: unrelated commit                    ->  falls back to the bare tag
```

## On the extractor

Versions are matched as **literals**, not spliced into a regex — `1.2.3` spliced in would match `1x2x3` and select the wrong section. A missing entry returns nothing so the workflow falls back rather than publishing an empty release. Eight tests cover it, including prefix collisions (`0.32.1` vs `0.32.11`) and the "must not bleed into the next section" case.

Needs `contents: write` to push the tag and create the release (was `contents: read`).

## Verification

193 tests, typecheck and build green. Workflow YAML parses; 11 steps, permissions `{contents: write, id-token: write}`.

**This PR cannot self-test the happy path** — it only fires on a version change, and this PR has none. First real exercise is the next release; if it misbehaves the failure mode is a missing release, exactly the status quo, not a broken publish.