### PR TITLE
fix(ci): give the tag step a git identity and drop the invalid --target

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -128,6 +128,14 @@ jobs:
             TITLE="$TAG — $HEADLINE"
           fi
 
+          # Annotated tags need a committer identity, and the runner has none:
+          # `git tag -a` died with "fatal: empty ident name", failing the job
+          # AFTER npm and the MCP registry had already published — 0.32.3 shipped
+          # with no tag and no release and had to be repaired by hand. This is
+          # exactly the drift the step exists to prevent.
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           # Ask the REMOTE, not the local clone: actions/checkout fetches no tags
           # by default, so `git rev-parse "$TAG"` always missed and the push ran
           # unconditionally. An annotated tag already on origin is then rejected
@@ -140,7 +148,9 @@ jobs:
             git push origin "$TAG"
           fi
 
-          # Pin the release to the tag's commit explicitly rather than letting
-          # GitHub default to the branch head.
-          gh release create "$TAG" --title "$TITLE" --notes-file /tmp/notes.md --latest --target "$(git rev-parse HEAD)"
+          # No --target: GitHub rejects target_commitish for a tag that already
+          # exists ("Release.target_commitish is invalid"), and by this point the
+          # tag always exists — we either just pushed it or found it on origin.
+          # The release inherits the tag's commit, which is what we wanted anyway.
+          gh release create "$TAG" --title "$TITLE" --notes-file /tmp/notes.md --latest
           echo "Released $TAG"


### PR DESCRIPTION
The tag/release automation from #63 ran its **create** path for the first time on 0.32.3 and failed:

```
fatal: empty ident name (for <runner@...>) not allowed
```

`git tag -a` needs a committer identity; the runner has none. It failed **after** npm and the MCP registry had already published, so 0.32.3 shipped with **no tag and no release** and I repaired it by hand. That is exactly the drift the step was added to prevent, and exactly the "fails after publishing" shape flagged as the worst place to fail.

Two fixes:

1. **Configure `user.name` / `user.email`** before tagging (github-actions[bot]).
2. **Drop `--target "$(git rev-parse HEAD)"`.** GitHub rejects `target_commitish` for a tag that already exists (`Release.target_commitish is invalid`), and by that point the tag always exists — we either just pushed it or found it on origin. I hit this error while repairing 0.32.3 manually. The release inherits the tag's commit, which was the intent anyway.

**Why neither showed up before:** the 0.32.2 run only ever reached the `release already exists — skipping` branch. The version-changed path had never executed. A workflow step that only runs on release is only really tested by a release.

No version bump — CI-only, so merging will not publish.

Current state is consistent: npm `0.32.3`, registry `0.32.3`, tag `v0.32.3`, release `v0.32.3`.