### PR TITLE
fix(polymarket): make redemption and legacy withdrawal reliable

### DIFF
--- a/scripts/polymarket-e2e-approve.ts
+++ b/scripts/polymarket-e2e-approve.ts
@@ -1,0 +1,22 @@
+/**
+ * One-time preflight for the bounded live redeem test. It grants only the two
+ * official collateral adapters the ERC-1155 operator permissions that their
+ * redeem entrypoints require, then re-reads the resulting state. It prints no
+ * wallet address or transaction id.
+ */
+import { runSetup } from "../src/utils/polymarket/setup.js";
+
+try {
+  const submitted = await runSetup({ confirm: true });
+  const verified = await runSetup({ confirm: false });
+  const approvals = verified.structured.approvals as Array<{ label: string; granted: boolean }>;
+  console.log(JSON.stringify({
+    approvalBatchSubmitted: !submitted.structured.approvalsPending,
+    adaptersApproved: approvals.filter(({ label }) => label.includes("Collateral Adapter")),
+    approvalsPending: verified.structured.approvalsPending,
+  }, null, 2));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(JSON.stringify({ failed: true, error: message.replace(/0x[a-fA-F0-9]{40,}/g, "<redacted>") }));
+  process.exitCode = 1;
+}

--- a/scripts/polymarket-e2e-live.ts
+++ b/scripts/polymarket-e2e-live.ts
@@ -1,0 +1,44 @@
+/**
+ * A deliberately narrow live verification for the redeem/withdraw repair.
+ * Preconditions prevent it from redeeming a valuable position or moving more
+ * than $2.00. Wallet addresses and transaction IDs are never printed.
+ */
+import { fetchPositions, getFundsAddress } from "../src/utils/polymarket/positions.js";
+import { redeemPosition } from "../src/utils/polymarket/redeem.js";
+import { withdrawFunds } from "../src/utils/polymarket/withdraw.js";
+
+const owner = getFundsAddress();
+const positions = await fetchPositions(owner);
+const target = positions.find((position) =>
+  position.redeemable === true &&
+  (position.currentValue ?? Number.POSITIVE_INFINITY) <= 0.001 &&
+  Boolean(position.conditionId),
+);
+
+if (!target?.conditionId) {
+  throw new Error("No zero-value redeemable position is available for the bounded live redeem test.");
+}
+
+const redeem = await redeemPosition({ condition_id: target.conditionId, confirm: true });
+if (redeem.isError || redeem.structured?.status !== undefined) {
+  throw new Error(`Redeem verification did not complete cleanly: ${redeem.text.replace(/0x[a-fA-F0-9]{64}/g, "<tx>")}`);
+}
+
+const withdrawal = await withdrawFunds({ amount_usd: 2, confirm: true });
+if (withdrawal.isError) {
+  throw new Error(`Withdrawal submission failed: ${withdrawal.text.replace(/0x[a-fA-F0-9]{64}/g, "<tx>")}`);
+}
+
+console.log(JSON.stringify({
+  redeem: {
+    verified: true,
+    market: target.title,
+    outcome: target.outcome,
+    sharesBurned: target.size,
+  },
+  withdrawal: {
+    submitted: true,
+    amountUsd: 2,
+    destinationChainId: withdrawal.structured?.toChainId,
+  },
+}, null, 2));

--- a/scripts/polymarket-e2e-readonly.ts
+++ b/scripts/polymarket-e2e-readonly.ts
@@ -1,0 +1,46 @@
+/**
+ * Read-only local-wallet preflight for Polymarket redeem/withdraw changes.
+ * It never supplies confirm:true and never emits a wallet address, private key,
+ * or transaction identifier.
+ */
+import { listPositions } from "../src/utils/polymarket/positions.js";
+import { withdrawFunds } from "../src/utils/polymarket/withdraw.js";
+
+const [positionsResult, withdrawalResult] = await Promise.all([
+  listPositions(),
+  withdrawFunds({}),
+]);
+
+const positions = ((positionsResult.structured as {
+  positions?: Array<{
+    title?: string;
+    outcome?: string;
+    size?: number;
+    currentValue?: number;
+    redeemable?: boolean;
+    negativeRisk?: boolean;
+    conditionId?: string;
+  }>;
+} | undefined)?.positions ?? []).map((position) => ({
+  title: position.title,
+  outcome: position.outcome,
+  size: position.size,
+  currentValue: position.currentValue,
+  redeemable: position.redeemable,
+  negativeRisk: position.negativeRisk,
+  condition: position.conditionId ? `${position.conditionId.slice(0, 10)}…` : undefined,
+}));
+
+console.log(JSON.stringify({
+  positions,
+  withdrawalPreview: withdrawalResult.isError
+    ? withdrawalResult.text.replace(/0x[a-fA-F0-9]{40}/g, "<wallet>")
+    : {
+      dryRun: withdrawalResult.structured?.dryRun,
+      amountUsd: withdrawalResult.structured?.amountUsd,
+      pusdUsd: withdrawalResult.structured?.pusdUsd,
+      usdceUsd: withdrawalResult.structured?.usdceUsd,
+      wrapUsd: withdrawalResult.structured?.wrapUsd,
+      toChainId: withdrawalResult.structured?.toChainId,
+    },
+}, null, 2));

--- a/scripts/polymarket-e2e-verify-approvals.ts
+++ b/scripts/polymarket-e2e-verify-approvals.ts
@@ -1,0 +1,8 @@
+import { runSetup } from "../src/utils/polymarket/setup.js";
+
+const result = await runSetup({ confirm: false });
+const approvals = result.structured.approvals as Array<{ label: string; granted: boolean }>;
+console.log(JSON.stringify({
+  adaptersApproved: approvals.filter(({ label }) => label.includes("Collateral Adapter")),
+  approvalsPending: result.structured.approvalsPending,
+}, null, 2));

--- a/scripts/polymarket-e2e-withdraw.ts
+++ b/scripts/polymarket-e2e-withdraw.ts
@@ -1,0 +1,12 @@
+/** Bounded live withdrawal check, independent of the adapter-approval flow. */
+import { withdrawFunds } from "../src/utils/polymarket/withdraw.js";
+
+const result = await withdrawFunds({ amount_usd: 2, confirm: true });
+if (result.isError) {
+  throw new Error(result.text.replace(/0x[a-fA-F0-9]{64}/g, "<tx>"));
+}
+console.log(JSON.stringify({
+  submitted: true,
+  amountUsd: result.structured?.amountUsd,
+  destinationChainId: result.structured?.toChainId,
+}, null, 2));

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { initializeMcpServer } from "./mcp-handler.js";
 import { warnOnLeakedKeys } from "./utils/key-leak-scanner.js";
+import { installBlockrunMcpUserAgent } from "./utils/user-agent.js";
 import { PROFILES } from "./profiles.js";
 
 // Read version from package.json so it can never drift from the published version.
@@ -54,6 +55,7 @@ function handleCliMetadataFlags(argv: string[]): void {
 }
 
 handleCliMetadataFlags(process.argv);
+installBlockrunMcpUserAgent(VERSION);
 
 async function checkForUpdate() {
   try {

--- a/src/utils/polymarket/client.ts
+++ b/src/utils/polymarket/client.ts
@@ -30,7 +30,7 @@ import {
   getClobProxy,
   getSigType,
   POLYGON_CHAIN_ID,
-  POLYGON_RPC_URLS,
+  POLYGON_WRITE_RPC_URL,
 } from "./constants.js";
 import { loadDepositWalletForSigner, loadL2Creds, saveL2Creds } from "./creds.js";
 import { deriveApiCreds } from "./l1-auth-1271.js";
@@ -146,7 +146,7 @@ function buildWalletClient(reportAddress?: Hex): WalletClient {
   return createWalletClient({
     account,
     chain: polygon,
-    transport: http(POLYGON_RPC_URLS[0]),
+    transport: http(POLYGON_WRITE_RPC_URL),
   });
 }
 

--- a/src/utils/polymarket/constants.ts
+++ b/src/utils/polymarket/constants.ts
@@ -22,6 +22,11 @@ export const CONDITIONAL_TOKENS = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045";
 // pUSD — Polymarket's 1:1 collateral wrapper (labelled CollateralToken proxy).
 export const PUSD_COLLATERAL = "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB";
 export const COLLATERAL_ONRAMP = "0x93070a847efEf7F70739046A929D47a521F5B8ee";
+// Legacy collateral used by the CTF position IDs. The V2 adapters unwrap/wrap
+// this asset internally so callers with pUSD must use the adapters for CTF ops.
+export const USDCE_COLLATERAL = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
+export const CTF_COLLATERAL_ADAPTER = "0xADa100874d00e3331D00F2007a9c336a65009718";
+export const NEG_RISK_CTF_COLLATERAL_ADAPTER = "0xAdA200001000ef00D07553cEE7006808F895c6F1";
 export const DEPOSIT_WALLET_FACTORY = "0x00000000000Fb5C9ADea0298D729A0CB3823Cc07";
 
 /**
@@ -78,15 +83,19 @@ export const GEOBLOCK_URL =
   process.env.POLYMARKET_GEOBLOCK_URL || "https://polymarket.com/api/geoblock";
 export const BRIDGE_UI_URL = "https://polymarket.com"; // deposits happen via the Polymarket bridge UI/API
 
-// Public Polygon RPCs with fallback, mirroring BASE_RPC_URLS in ../constants.ts.
-// Used only for read-only approval/balance checks (viem public client).
-// 1rpc first — polygon-rpc.com was observed lagging several blocks behind, which
-// made freshly-confirmed deploys/approvals read as still-pending.
-export const POLYGON_RPC_URLS = [
+// Public Polygon RPCs used only by the read-only viem public client. Keep this
+// list separate from the write transport: reordering a read fallback must never
+// silently change where EOA transactions are broadcast. All endpoints are
+// health-checked in the integration preflight.
+export const POLYGON_READ_RPC_URLS = [
   "https://1rpc.io/matic",
-  "https://polygon.llamarpc.com",
-  "https://polygon-rpc.com",
+  "https://polygon-bor-rpc.publicnode.com",
+  "https://polygon.drpc.org",
 ];
+
+// The explicit EOA broadcast endpoint. Override only when an operator has
+// reviewed that node's transaction propagation policy.
+export const POLYGON_WRITE_RPC_URL = process.env.POLYMARKET_WRITE_RPC_URL || "https://1rpc.io/matic";
 
 // --- Safety knobs ---
 /**

--- a/src/utils/polymarket/orders.ts
+++ b/src/utils/polymarket/orders.ts
@@ -145,6 +145,11 @@ export async function mapClobError(err: unknown): Promise<string> {
   const message = `${e?.message ?? String(err)}${dataText}`;
   const m = message.toLowerCase();
 
+  if (m.includes("setapprovalforall operator") && m.includes("not in the allowed list")) {
+    return `Polymarket's relayer rejected the ERC-1155 operator approval because this official collateral adapter ` +
+      `is missing from the relayer allowlist. No approval or redemption was sent. The relayer operator must add ` +
+      `the V2 CTF collateral-adapter addresses, then re-run action:"setup"; retrying locally cannot fix this. Raw: ${message}`;
+  }
   if (e?.status === 403 || (/(^|[^0-9.])403($|[^0-9.])/).test(m)) {
     const geo = await checkGeoblock();
     const where = geo.country ? ` (egress country: ${geo.country})` : "";

--- a/src/utils/polymarket/redeem.ts
+++ b/src/utils/polymarket/redeem.ts
@@ -6,36 +6,60 @@
 //     (redeemPositions credits msg.sender, i.e. the deposit wallet).
 //   - EOA mode: a direct transaction from the EOA (needs POL gas).
 //
-// Target contracts:
-//   - standard binary markets → ConditionalTokens.redeemPositions(collateral,
-//     0x0, conditionId, [1, 2])
-//   - negRisk markets → NegRiskAdapter.redeemPositions(conditionId, [yesAmt,
-//     noAmt]) (adapter must be CTF-approved — done in setup)
-//
-// Collateral note: V2-era conditions settle in pUSD; conditions prepared
-// before the 2026-04-28 cutover may use legacy USDC.e collateral, in which
-// case the standard redeem with pUSD reverts — the error message says so and
-// the relayer batch simply fails without side effects.
+// Target contracts: CTF positions remain backed by legacy USDC.e / NegRisk
+// wrapped collateral, while user balances are pUSD. The V2 collateral adapters
+// are therefore the only valid public redeem entrypoints: they pull and redeem
+// the real ERC-1155 positions, then wrap the resulting USDC.e into pUSD.
 import { createWalletClient, encodeFunctionData, http, type Hex } from "viem";
 import { polygon } from "viem/chains";
-import { getClobClient, getPolymarketAccount } from "./client.js";
+import { getPolymarketAccount } from "./client.js";
 import {
+  CTF_COLLATERAL_ADAPTER,
   CONDITIONAL_TOKENS,
   ERC1155_ABI,
   getSigType,
-  NEG_RISK_ADAPTER,
-  NEG_RISK_ADAPTER_ABI,
-  POLYGON_RPC_URLS,
-  PUSD_COLLATERAL,
+  NEG_RISK_CTF_COLLATERAL_ADAPTER,
+  POLYGON_WRITE_RPC_URL,
   PUSD_DECIMALS,
 } from "./constants.js";
 import type { ToolResult } from "./orders.js";
 import { mapClobError } from "./orders.js";
-import { getFundsAddress } from "./positions.js";
+import { fetchPositions, getFundsAddress, type DataApiPosition } from "./positions.js";
 import { sendWalletBatch } from "./relayer.js";
 import { getPublicClient, getPusdBalance } from "./setup.js";
+import { assertTransactionSucceeded } from "./transactions.js";
 
-interface ClobMarketToken { token_id?: string; outcome?: string; winner?: boolean }
+export function heldOutcomeTokens(positions: DataApiPosition[], conditionId: string): DataApiPosition[] {
+  return positions.filter((position) =>
+    position.conditionId?.toLowerCase() === conditionId.toLowerCase() && Boolean(position.asset),
+  );
+}
+
+/**
+ * Both official V2 collateral adapters intentionally retain the CTF
+ * redeemPositions ABI. The collateral/parent/index-set values are ignored by
+ * the adapter; it derives the real legacy position IDs from conditionId.
+ */
+export function buildRedeemCall(negRisk: boolean, conditionId: Hex): { target: Hex; data: Hex } {
+  return {
+    target: (negRisk ? NEG_RISK_CTF_COLLATERAL_ADAPTER : CTF_COLLATERAL_ADAPTER) as Hex,
+    data: encodeFunctionData({
+      abi: ERC1155_ABI,
+      functionName: "redeemPositions",
+      args: [
+        "0x0000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        conditionId,
+        [],
+      ],
+    }),
+  };
+}
+
+/** A receipt alone is insufficient: a wrong collateral path can be a no-op. */
+export function didRedeemAnyHeldPosition(before: readonly bigint[], after: readonly bigint[]): boolean {
+  return before.some((balance, index) => balance > 0n && (after[index] ?? balance) < balance);
+}
 
 export async function redeemPosition(input: { condition_id?: string; confirm?: boolean }): Promise<ToolResult> {
   if (!input.condition_id) {
@@ -51,16 +75,21 @@ export async function redeemPosition(input: { condition_id?: string; confirm?: b
   }
 
   try {
-    // Market metadata (question, outcome tokens, negRisk) via the CLOB.
-    const clob = await getClobClient();
-    const market = (await clob.getMarket(conditionId)) as {
-      question?: string;
-      neg_risk?: boolean;
-      closed?: boolean;
-      tokens?: ClobMarketToken[];
-    };
-    const tokens = (market?.tokens ?? []).filter((t) => t.token_id);
-    if (!tokens.length) return { text: `No tokens found for condition ${conditionId}.`, isError: true };
+    // Redeem only needs the caller's held token IDs and neg-risk flag. The
+    // Data API supplies both; CLOB market lookup is deliberately avoided here
+    // because some supported egress routes return 404 for market metadata.
+    const heldPositions = heldOutcomeTokens(await fetchPositions(owner), conditionId);
+    if (!heldPositions.length) {
+      return {
+        text: `Could not find held outcome tokens for condition ${conditionId}. ` +
+          `Re-run action:"positions" and pass a condition_id that belongs to this wallet.`,
+        isError: true,
+      };
+    }
+    const tokens = heldPositions.map((position) => ({
+      token_id: position.asset!, outcome: position.outcome, winner: position.redeemable,
+    }));
+    const question = heldPositions[0]?.title;
 
     // Exact on-chain balances per outcome token — the redeem amounts.
     const pc = getPublicClient();
@@ -76,10 +105,10 @@ export async function redeemPosition(input: { condition_id?: string; confirm?: b
       );
     }
     if (balances.every((b) => b === 0n)) {
-      return { text: `Nothing to redeem: ${owner} holds no outcome tokens for "${market?.question ?? conditionId}".`, isError: true };
+      return { text: `Nothing to redeem: ${owner} holds no outcome tokens for "${question ?? conditionId}".`, isError: true };
     }
 
-    const negRisk = Boolean(market?.neg_risk);
+    const negRisk = heldPositions.some((position) => position.negativeRisk === true);
     const held = tokens
       .map((t, i) => ({ outcome: t.outcome, winner: t.winner, shares: Number(balances[i]) / 10 ** PUSD_DECIMALS }))
       .filter((h) => h.shares > 0);
@@ -91,7 +120,7 @@ export async function redeemPosition(input: { condition_id?: string; confirm?: b
       return {
         text: [
           `DRY RUN — nothing redeemed.`,
-          `Market: ${market?.question ?? conditionId}${market?.closed === false ? " ⚠️ (not closed yet — redeem will revert until resolution)" : ""}`,
+          `Market: ${question ?? conditionId}`,
           `Holdings:`,
           heldText,
           ``,
@@ -102,18 +131,7 @@ export async function redeemPosition(input: { condition_id?: string; confirm?: b
       };
     }
 
-    const data = negRisk
-      ? encodeFunctionData({
-          abi: NEG_RISK_ADAPTER_ABI,
-          functionName: "redeemPositions",
-          args: [conditionId, balances],
-        })
-      : encodeFunctionData({
-          abi: ERC1155_ABI,
-          functionName: "redeemPositions",
-          args: [PUSD_COLLATERAL as Hex, "0x0000000000000000000000000000000000000000000000000000000000000000", conditionId, [1n, 2n]],
-        });
-    const target = (negRisk ? NEG_RISK_ADAPTER : CONDITIONAL_TOKENS) as Hex;
+    const { target, data } = buildRedeemCall(negRisk, conditionId);
 
     let txHash: string | undefined;
     if (getSigType() === 3) {
@@ -121,15 +139,50 @@ export async function redeemPosition(input: { condition_id?: string; confirm?: b
       txHash = res.transactionHash;
     } else {
       const account = getPolymarketAccount();
-      const wallet = createWalletClient({ account, chain: polygon, transport: http(POLYGON_RPC_URLS[0]) });
+      const wallet = createWalletClient({ account, chain: polygon, transport: http(POLYGON_WRITE_RPC_URL) });
       txHash = await wallet.sendTransaction({ to: target, data, chain: polygon, account });
-      await pc.waitForTransactionReceipt({ hash: txHash as Hex });
+      assertTransactionSucceeded(await pc.waitForTransactionReceipt({ hash: txHash as Hex }), "Redeem transaction");
     }
 
-    const balanceAfter = await getPusdBalance(owner).catch(() => null);
+    // A receipt can arrive before every public RPC reflects its state. Retry
+    // the read briefly before treating this as an indeterminate verification.
+    let balanceAfter = await getPusdBalance(owner).catch(() => null);
+    let balancesAfter: bigint[] | null = null;
+    for (let attempt = 0; attempt < 3 && balancesAfter === null; attempt++) {
+      balancesAfter = await Promise.all(tokens.map((t) => pc.readContract({
+        address: CONDITIONAL_TOKENS as Hex,
+        abi: ERC1155_ABI,
+        functionName: "balanceOf",
+        args: [owner, BigInt(t.token_id as string)],
+      }))).catch(() => null);
+      if (balancesAfter === null && attempt < 2) await new Promise((resolve) => setTimeout(resolve, 750));
+    }
+    if (balanceAfter === null) balanceAfter = await getPusdBalance(owner).catch(() => null);
+    if (balancesAfter === null) {
+      return {
+        text: [
+          `⚠️ Redeem transaction confirmed, but its token effect could not be verified because the Polygon RPC read failed.`,
+          `Do not retry blindly; inspect the transaction and re-run action:"positions" after the RPC recovers.`,
+          ...(txHash ? [`  tx: https://polygonscan.com/tx/${txHash}`] : []),
+        ].join("\n"),
+        structured: { status: "confirmed_but_unverified", conditionId, negRisk, transactionHash: txHash, pusdBalance: balanceAfter },
+        isError: true,
+      };
+    }
+    if (!didRedeemAnyHeldPosition(balances, balancesAfter)) {
+      return {
+        text: [
+          `⚠️ Redeem transaction confirmed, but held ERC-1155 outcome tokens did not decrease.`,
+          `No payout is being reported. Re-run action:"positions"; this indicates an unexpected collateral route or stale chain state.`,
+          ...(txHash ? [`  tx: https://polygonscan.com/tx/${txHash}`] : []),
+        ].join("\n"),
+        structured: { status: "no_effect_detected", conditionId, negRisk, transactionHash: txHash, pusdBalance: balanceAfter },
+        isError: true,
+      };
+    }
     return {
       text: [
-        `✅ Redeemed "${market?.question ?? conditionId}".`,
+        `✅ Redeemed "${question ?? conditionId}".`,
         heldText,
         ...(txHash ? [`  tx: https://polygonscan.com/tx/${txHash}`] : []),
         ...(balanceAfter !== null ? [`  Funds wallet pUSD balance: $${balanceAfter.toFixed(2)}`] : []),
@@ -138,8 +191,6 @@ export async function redeemPosition(input: { condition_id?: string; confirm?: b
     };
   } catch (err) {
     const base = await mapClobError(err);
-    const legacyHint = ` If this market predates the 2026-04-28 V2 cutover it may settle in legacy ` +
-      `USDC.e collateral, which this tool does not auto-detect yet — redeem it once via the Polymarket UI.`;
-    return { text: `${base}${/revert|execution reverted|failed/i.test(base) ? legacyHint : ""}`, isError: true };
+    return { text: base, isError: true };
   }
 }

--- a/src/utils/polymarket/relayer.ts
+++ b/src/utils/polymarket/relayer.ts
@@ -13,12 +13,13 @@
 import { RelayClient, type DepositWalletCall } from "@polymarket/builder-relayer-client";
 import { BuilderConfig } from "@polymarket/builder-signing-sdk";
 import { ClobClient } from "@polymarket/clob-client-v2";
-import { createWalletClient, http, type Hex } from "viem";
+import { createPublicClient, createWalletClient, fallback, http, type Hex } from "viem";
 import { polygon } from "viem/chains";
 import { getPolymarketAccount } from "./client.js";
-import { CLOB_HOST, POLYGON_CHAIN_ID, POLYGON_RPC_URLS, RELAYER_URL } from "./constants.js";
+import { CLOB_HOST, POLYGON_CHAIN_ID, POLYGON_READ_RPC_URLS, POLYGON_WRITE_RPC_URL, RELAYER_URL } from "./constants.js";
 import { loadBuilderCreds, loadL2Creds, saveBuilderCreds, saveL2Creds } from "./creds.js";
 import { deriveApiCreds } from "./l1-auth-1271.js";
+import { assertTransactionSucceeded } from "./transactions.js";
 
 export type { DepositWalletCall };
 
@@ -58,7 +59,7 @@ async function getOrCreateBuilderCreds(): Promise<{ key: string; secret: string;
     if (!l2) throw new Error("failed to derive CLOB credentials for builder-key creation");
   }
 
-  const wc = createWalletClient({ account, chain: polygon, transport: http(POLYGON_RPC_URLS[0]) });
+  const wc = createWalletClient({ account, chain: polygon, transport: http(POLYGON_WRITE_RPC_URL) });
   const clob = new ClobClient({
     host: CLOB_HOST,
     chain: POLYGON_CHAIN_ID,
@@ -84,7 +85,7 @@ export async function getRelayClient(): Promise<RelayClient> {
   const walletClient = createWalletClient({
     account: getPolymarketAccount(),
     chain: polygon,
-    transport: http(POLYGON_RPC_URLS[0]),
+    transport: http(POLYGON_WRITE_RPC_URL),
   });
   const builderCreds = await getOrCreateBuilderCreds();
   const builderConfig = new BuilderConfig({ localBuilderCreds: builderCreds });
@@ -108,7 +109,7 @@ export async function deriveDepositWalletNoCreds(): Promise<Hex> {
   const walletClient = createWalletClient({
     account: getPolymarketAccount(),
     chain: polygon,
-    transport: http(POLYGON_RPC_URLS[0]),
+    transport: http(POLYGON_WRITE_RPC_URL),
   });
   const client = new RelayClient(RELAYER_URL, POLYGON_CHAIN_ID, walletClient);
   const addr = await client.deriveDepositWalletAddress();
@@ -153,6 +154,13 @@ export async function sendWalletBatch(
     throw new Error(
       `${description}: relayer batch did not confirm (tx ${response.transactionID}). ` +
       `Re-run action:"setup" to check state and retry.`,
+    );
+  }
+  if (confirmed.transactionHash) {
+    const pc = createPublicClient({ chain: polygon, transport: fallback(POLYGON_READ_RPC_URLS.map((url) => http(url))) });
+    assertTransactionSucceeded(
+      await pc.waitForTransactionReceipt({ hash: confirmed.transactionHash as Hex }),
+      description,
     );
   }
   return { transactionHash: confirmed.transactionHash };

--- a/src/utils/polymarket/setup.ts
+++ b/src/utils/polymarket/setup.ts
@@ -26,14 +26,17 @@ import { checkGeoblock, getClobClient, getPolymarketAccount } from "./client.js"
 import {
   assertContractConfig,
   CONDITIONAL_TOKENS,
+  CTF_COLLATERAL_ADAPTER,
   CTF_EXCHANGE_V2,
   ERC1155_ABI,
   ERC20_ABI,
   getBoundedApprovalsUsd,
   getSigType,
   NEG_RISK_ADAPTER,
+  NEG_RISK_CTF_COLLATERAL_ADAPTER,
   NEG_RISK_CTF_EXCHANGE_V2,
-  POLYGON_RPC_URLS,
+  POLYGON_READ_RPC_URLS,
+  POLYGON_WRITE_RPC_URL,
   PUSD_COLLATERAL,
   PUSD_DECIMALS,
 } from "./constants.js";
@@ -48,6 +51,7 @@ import {
   sendWalletBatch,
   type DepositWalletCall,
 } from "./relayer.js";
+import { assertTransactionSucceeded } from "./transactions.js";
 
 let _publicClient: PublicClient | null = null;
 
@@ -55,7 +59,7 @@ export function getPublicClient(): PublicClient {
   if (!_publicClient) {
     _publicClient = createPublicClient({
       chain: polygon,
-      transport: fallback(POLYGON_RPC_URLS.map((u) => http(u))),
+      transport: fallback(POLYGON_READ_RPC_URLS.map((u) => http(u))),
     });
   }
   return _publicClient;
@@ -83,7 +87,8 @@ function pusdApprovalTarget(): bigint {
 /**
  * The approval set Polymarket V2 trading needs from the funds-holding wallet:
  * pUSD spend for buys (both exchanges), CTF operator for sells (both exchanges)
- * plus the NegRisk adapter (negRisk redeem/convert path).
+ * plus both V2 collateral adapters (the only correct pUSD-era redeem paths)
+ * and the legacy NegRisk adapter (convert path).
  */
 async function readApprovals(owner: Hex): Promise<ApprovalItem[]> {
   const pc = getPublicClient();
@@ -94,6 +99,8 @@ async function readApprovals(owner: Hex): Promise<ApprovalItem[]> {
   const erc1155Operators: Array<[string, Hex]> = [
     ["CTF → CTF Exchange V2", CTF_EXCHANGE_V2 as Hex],
     ["CTF → NegRisk Exchange V2", NEG_RISK_CTF_EXCHANGE_V2 as Hex],
+    ["CTF → CTF Collateral Adapter", CTF_COLLATERAL_ADAPTER as Hex],
+    ["CTF → NegRisk Collateral Adapter", NEG_RISK_CTF_COLLATERAL_ADAPTER as Hex],
     ["CTF → NegRisk Adapter", NEG_RISK_ADAPTER as Hex],
   ];
 
@@ -324,7 +331,7 @@ async function runSetupEoa(opts: { confirm: boolean }): Promise<{ text: string; 
     if (pol <= 0) {
       approvalsPending = true;
     } else {
-      const wallet = createWalletClient({ account, chain: polygon, transport: http(POLYGON_RPC_URLS[0]) });
+      const wallet = createWalletClient({ account, chain: polygon, transport: http(POLYGON_WRITE_RPC_URL) });
       const erc20Amount = pusdApprovalTarget(); // honor POLYMARKET_BOUNDED_APPROVALS in EOA mode too
       for (const item of missing) {
         const hash =
@@ -345,7 +352,7 @@ async function runSetupEoa(opts: { confirm: boolean }): Promise<{ text: string; 
                 chain: polygon,
                 account,
               });
-        await pc.waitForTransactionReceipt({ hash });
+        assertTransactionSucceeded(await pc.waitForTransactionReceipt({ hash }), `Approval for ${item.label}`);
         approvalTxHashes.push(hash);
       }
       approvalsPending = false;

--- a/src/utils/polymarket/transactions.ts
+++ b/src/utils/polymarket/transactions.ts
@@ -1,0 +1,13 @@
+/**
+ * viem resolves waitForTransactionReceipt for both successful and reverted
+ * transactions. Treat a receipt as confirmation only after its status is
+ * explicitly checked.
+ */
+export function assertTransactionSucceeded(
+  receipt: { status?: string },
+  description: string,
+): void {
+  if (receipt.status !== "success") {
+    throw new Error(`${description} reverted on Polygon; no state change was applied.`);
+  }
+}

--- a/src/utils/polymarket/withdraw.ts
+++ b/src/utils/polymarket/withdraw.ts
@@ -18,12 +18,14 @@ import {
   BASE_CHAIN_ID,
   BASE_USDC,
   BRIDGE_API_HOST,
+  COLLATERAL_ONRAMP,
   ERC20_ABI,
   getBuilderCode,
   getSigType,
-  POLYGON_RPC_URLS,
+  POLYGON_WRITE_RPC_URL,
   PUSD_COLLATERAL,
   PUSD_DECIMALS,
+  USDCE_COLLATERAL,
 } from "./constants.js";
 import { getPolymarketAccount } from "./client.js";
 import type { ToolResult } from "./orders.js";
@@ -31,14 +33,61 @@ import { mapClobError } from "./orders.js";
 import { getFundsAddress } from "./positions.js";
 import { sendWalletBatch } from "./relayer.js";
 import { getPublicClient } from "./setup.js";
+import { assertTransactionSucceeded } from "./transactions.js";
 
-async function rawPusdBalance(owner: Hex): Promise<bigint> {
+async function rawTokenBalance(token: Hex, owner: Hex): Promise<bigint> {
   return getPublicClient().readContract({
-    address: PUSD_COLLATERAL as Hex,
+    address: token,
     abi: ERC20_ABI,
     functionName: "balanceOf",
     args: [owner],
   });
+}
+
+const COLLATERAL_ONRAMP_ABI = [{
+  type: "function",
+  name: "wrap",
+  stateMutability: "nonpayable",
+  inputs: [
+    { name: "_asset", type: "address" },
+    { name: "_to", type: "address" },
+    { name: "_amount", type: "uint256" },
+  ],
+  outputs: [],
+}] as const;
+
+export function buildLegacyWrapCalls(owner: Hex, amount: bigint): Array<{ target: Hex; value: "0"; data: Hex }> {
+  return [
+    {
+      target: USDCE_COLLATERAL as Hex,
+      value: "0",
+      data: encodeFunctionData({ abi: ERC20_ABI, functionName: "approve", args: [COLLATERAL_ONRAMP as Hex, amount] }),
+    },
+    {
+      target: COLLATERAL_ONRAMP as Hex,
+      value: "0",
+      data: encodeFunctionData({ abi: COLLATERAL_ONRAMP_ABI, functionName: "wrap", args: [USDCE_COLLATERAL as Hex, owner, amount] }),
+    },
+  ];
+}
+
+async function readPusdUntil(owner: Hex, minimum: bigint): Promise<bigint> {
+  let observed = 0n;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    observed = await rawTokenBalance(PUSD_COLLATERAL as Hex, owner);
+    if (observed >= minimum || attempt === 2) return observed;
+    await new Promise((resolve) => setTimeout(resolve, 750));
+  }
+  return observed;
+}
+
+function parseUsdAmount(amount: number): bigint | null {
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+  const scaled = amount * 10 ** PUSD_DECIMALS;
+  const rounded = Math.round(scaled);
+  // Do not silently round a caller's requested withdrawal upward or downward.
+  if (!Number.isSafeInteger(rounded) || Math.abs(scaled - rounded) > 1e-7) return null;
+  return BigInt(rounded);
 }
 
 interface WithdrawInput {
@@ -57,19 +106,26 @@ export async function withdrawFunds(input: WithdrawInput): Promise<ToolResult> {
   const recipient = (input.to_address as Hex) || getPolymarketAccount().address;
 
   try {
-    // Amount: explicit amount_usd, else the full pUSD balance.
-    const balanceRaw = await rawPusdBalance(owner);
-    const balanceUsd = Number(formatUnits(balanceRaw, PUSD_DECIMALS));
-    if (balanceRaw === 0n) {
-      return { text: `No pUSD to withdraw — the deposit wallet ${owner} holds $0. (Redeem/sell a position first.)`, isError: true };
+    // Adapter redemptions return pUSD. Historic direct CTF redemptions can
+    // leave USDC.e, which must be wrapped before this bridge accepts it.
+    const [pusdRaw, usdceRaw] = await Promise.all([
+      rawTokenBalance(PUSD_COLLATERAL as Hex, owner),
+      rawTokenBalance(USDCE_COLLATERAL as Hex, owner),
+    ]);
+    const totalRaw = pusdRaw + usdceRaw;
+    const totalUsd = Number(formatUnits(totalRaw, PUSD_DECIMALS));
+    if (totalRaw === 0n) {
+      return { text: `No pUSD or USDC.e to withdraw — the deposit wallet ${owner} holds $0. (Redeem/sell a position first.)`, isError: true };
     }
-    const amountRaw = input.amount_usd !== undefined
-      ? BigInt(Math.floor(input.amount_usd * 10 ** PUSD_DECIMALS))
-      : balanceRaw;
-    if (amountRaw > balanceRaw) {
-      return { text: `Requested $${input.amount_usd} exceeds the pUSD balance of $${balanceUsd.toFixed(2)}.`, isError: true };
+    const amountRaw = input.amount_usd !== undefined ? parseUsdAmount(input.amount_usd) : totalRaw;
+    if (amountRaw === null) {
+      return { text: `amount_usd must be a positive USD amount with at most ${PUSD_DECIMALS} decimal places.`, isError: true };
+    }
+    if (amountRaw > totalRaw) {
+      return { text: `Requested $${input.amount_usd} exceeds the withdrawable collateral balance of $${totalUsd.toFixed(2)}.`, isError: true };
     }
     const amountUsd = Number(formatUnits(amountRaw, PUSD_DECIMALS));
+    const wrapRaw = amountRaw > pusdRaw ? amountRaw - pusdRaw : 0n;
 
     if (input.confirm !== true) {
       return {
@@ -79,11 +135,30 @@ export async function withdrawFunds(input: WithdrawInput): Promise<ToolResult> {
           `  from deposit wallet: ${owner}`,
           `  to (agent wallet): ${recipient}`,
           ``,
+          ...(wrapRaw > 0n ? [`  First wrap: $${Number(formatUnits(wrapRaw, PUSD_DECIMALS)).toFixed(2)} legacy USDC.e → pUSD`] : []),
           `pUSD is unwrapped to USDC (Uniswap v3 — minor slippage may apply); instant, no Polymarket fee.`,
           `Re-call with confirm:true to execute.`,
         ].join("\n"),
-        structured: { dryRun: true, amountUsd, from: owner, to: recipient, toChainId: BASE_CHAIN_ID, toToken: BASE_USDC },
+        structured: { dryRun: true, amountUsd, from: owner, to: recipient, toChainId: BASE_CHAIN_ID, toToken: BASE_USDC, pusdUsd: Number(formatUnits(pusdRaw, PUSD_DECIMALS)), usdceUsd: Number(formatUnits(usdceRaw, PUSD_DECIMALS)), wrapUsd: Number(formatUnits(wrapRaw, PUSD_DECIMALS)) },
       };
+    }
+
+    if (wrapRaw > 0n) {
+      const [approveCall, wrapCall] = buildLegacyWrapCalls(owner, wrapRaw);
+      if (getSigType() === 3) {
+        await sendWalletBatch([approveCall, wrapCall], owner, "Wrap legacy USDC.e");
+      } else {
+        const account = getPolymarketAccount();
+        const wallet = createWalletClient({ account, chain: polygon, transport: http(POLYGON_WRITE_RPC_URL) });
+        const approveHash = await wallet.sendTransaction({ to: approveCall.target, data: approveCall.data, chain: polygon, account });
+        assertTransactionSucceeded(await getPublicClient().waitForTransactionReceipt({ hash: approveHash }), "USDC.e approval");
+        const wrapHash = await wallet.sendTransaction({ to: wrapCall.target, data: wrapCall.data, chain: polygon, account });
+        assertTransactionSucceeded(await getPublicClient().waitForTransactionReceipt({ hash: wrapHash }), "USDC.e wrap");
+      }
+      const normalizedPusd = await readPusdUntil(owner, amountRaw);
+      if (normalizedPusd < amountRaw) {
+        throw new Error("legacy USDC.e wrap was confirmed but the required pUSD balance was not visible after RPC retries; re-run the withdrawal after checking balances (wrapping is already complete)");
+      }
     }
 
     // 1. Ask the bridge for a one-time deposit address for this withdrawal.
@@ -108,9 +183,9 @@ export async function withdrawFunds(input: WithdrawInput): Promise<ToolResult> {
       txHash = res.transactionHash;
     } else {
       const account = getPolymarketAccount();
-      const wallet = createWalletClient({ account, chain: polygon, transport: http(POLYGON_RPC_URLS[0]) });
+      const wallet = createWalletClient({ account, chain: polygon, transport: http(POLYGON_WRITE_RPC_URL) });
       txHash = await wallet.sendTransaction({ to: PUSD_COLLATERAL as Hex, data, chain: polygon, account });
-      await getPublicClient().waitForTransactionReceipt({ hash: txHash as Hex });
+      assertTransactionSucceeded(await getPublicClient().waitForTransactionReceipt({ hash: txHash as Hex }), "Withdrawal transfer");
     }
 
     return {

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -1,0 +1,41 @@
+const BLOCKRUN_HOSTS = new Set(["blockrun.ai", "www.blockrun.ai", "sol.blockrun.ai"]);
+const INSTALL_MARKER = Symbol.for("blockrun.mcp.userAgentInstalled");
+
+type MarkedGlobal = typeof globalThis & { [INSTALL_MARKER]?: boolean };
+
+function requestUrl(input: RequestInfo | URL): URL | null {
+  try {
+    const raw = input instanceof Request ? input.url : input.toString();
+    return new URL(raw);
+  } catch {
+    return null;
+  }
+}
+
+/** Wrap fetch so every request to a BlockRun gateway is attributable to MCP. */
+export function withBlockrunMcpUserAgent(
+  baseFetch: typeof fetch,
+  version: string,
+): typeof fetch {
+  const userAgent = `blockrun-mcp/${version}`;
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = requestUrl(input);
+    if (!url || !BLOCKRUN_HOSTS.has(url.hostname)) {
+      return baseFetch(input, init);
+    }
+
+    const headers = new Headers(input instanceof Request ? input.headers : undefined);
+    new Headers(init?.headers).forEach((value, key) => headers.set(key, value));
+    // Deliberately override the SDK's blockrun-ts/* identifier: this process is
+    // the MCP product boundary and should be counted as MCP in gateway logs.
+    headers.set("User-Agent", userAgent);
+    return baseFetch(input, { ...init, headers });
+  }) as typeof fetch;
+}
+
+export function installBlockrunMcpUserAgent(version: string): void {
+  const target = globalThis as MarkedGlobal;
+  if (target[INSTALL_MARKER]) return;
+  globalThis.fetch = withBlockrunMcpUserAgent(globalThis.fetch.bind(globalThis), version);
+  target[INSTALL_MARKER] = true;
+}

--- a/test/polymarket-orders.test.ts
+++ b/test/polymarket-orders.test.ts
@@ -76,6 +76,15 @@ test("mapClobError: balance/allowance points at setup, NOT the Base wallet", asy
   assert.doesNotMatch(text, /blockrun_wallet|Base network/);
 });
 
+test("mapClobError: relayer adapter allowlist rejection identifies the required server-side change", async () => {
+  const text = await mapClobError({
+    message: "call blocked: setApprovalForAll operator 0xada100874d00e3331d00f2007a9c336a65009718 is not in the allowed list",
+    status: 400,
+  });
+  assert.match(text, /relayer.*allowlist/i);
+  assert.match(text, /No approval or redemption was sent/);
+});
+
 test("mapClobError: EOA maker rejection points at the deposit-wallet flow", async () => {
   const text = await mapClobError({
     message: "maker address not allowed, please use the deposit wallet flow",

--- a/test/polymarket-redeem.test.ts
+++ b/test/polymarket-redeem.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { decodeFunctionData, type Hex } from "viem";
+import { buildRedeemCall, didRedeemAnyHeldPosition, heldOutcomeTokens } from "../src/utils/polymarket/redeem.js";
+import {
+  CTF_COLLATERAL_ADAPTER,
+  ERC1155_ABI,
+  NEG_RISK_CTF_COLLATERAL_ADAPTER,
+} from "../src/utils/polymarket/constants.js";
+
+const CONDITION = "0x1111111111111111111111111111111111111111111111111111111111111111" as Hex;
+
+test("standard redemption targets the V2 CTF collateral adapter", () => {
+  const { target, data } = buildRedeemCall(false, CONDITION);
+  assert.equal(target.toLowerCase(), CTF_COLLATERAL_ADAPTER.toLowerCase());
+  const decoded = decodeFunctionData({ abi: ERC1155_ABI, data });
+  assert.equal(decoded.functionName, "redeemPositions");
+  assert.equal(decoded.args[2], CONDITION);
+});
+
+test("negative-risk redemption targets the V2 negative-risk collateral adapter", () => {
+  const { target, data } = buildRedeemCall(true, CONDITION);
+  assert.equal(target.toLowerCase(), NEG_RISK_CTF_COLLATERAL_ADAPTER.toLowerCase());
+  const decoded = decodeFunctionData({ abi: ERC1155_ABI, data });
+  assert.equal(decoded.functionName, "redeemPositions");
+  assert.equal(decoded.args[2], CONDITION);
+});
+
+test("redeem only reports a verified effect after consuming a held outcome token", () => {
+  assert.equal(didRedeemAnyHeldPosition([1_000_000n, 0n], [0n, 0n]), true);
+  assert.equal(didRedeemAnyHeldPosition([1_000_000n, 0n], [1_000_000n, 0n]), false);
+  assert.equal(didRedeemAnyHeldPosition([0n, 0n], [0n, 0n]), false);
+});
+
+test("redeem takes token IDs and neg-risk state from the wallet's Data-API positions", () => {
+  const tokens = heldOutcomeTokens([
+    { conditionId: "0xother", asset: "111" },
+    { conditionId: CONDITION, asset: "222", negativeRisk: false },
+  ], CONDITION);
+  assert.equal(tokens.length, 1);
+  assert.equal(tokens[0]?.asset, "222");
+  assert.equal(heldOutcomeTokens([], CONDITION).length, 0);
+});

--- a/test/polymarket-transactions.test.ts
+++ b/test/polymarket-transactions.test.ts
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { assertTransactionSucceeded } from "../src/utils/polymarket/transactions.js";
+
+test("a reverted receipt is never treated as a confirmed state change", () => {
+  assert.doesNotThrow(() => assertTransactionSucceeded({ status: "success" }, "test"));
+  assert.throws(() => assertTransactionSucceeded({ status: "reverted" }, "USDC.e wrap"), /reverted/);
+  assert.throws(() => assertTransactionSucceeded({}, "withdrawal"), /reverted/);
+});

--- a/test/polymarket-withdraw.test.ts
+++ b/test/polymarket-withdraw.test.ts
@@ -5,10 +5,13 @@
 // network/RPC.
 import { test, mock } from "node:test";
 import assert from "node:assert/strict";
+import { decodeFunctionData } from "viem";
+import { COLLATERAL_ONRAMP, ERC20_ABI, USDCE_COLLATERAL } from "../src/utils/polymarket/constants.js";
 
 const DEPOSIT = "0x5d3eaa66AE01F1a907c8e0970D1D021C6Ff8EB26";
 const AGENT = "0xCC8c44AD3dc2A58D841c3EB26131E49b22665EF8";
-let balanceRaw = 7_500_000n; // $7.50 pUSD (6 decimals)
+let pusdRaw = 7_500_000n; // $7.50 pUSD (6 decimals)
+let usdceRaw = 0n;
 
 mock.module("../src/utils/polymarket/positions.js", {
   namedExports: { getFundsAddress: () => DEPOSIT },
@@ -16,7 +19,8 @@ mock.module("../src/utils/polymarket/positions.js", {
 mock.module("../src/utils/polymarket/setup.js", {
   namedExports: {
     getPublicClient: () => ({
-      readContract: async () => balanceRaw,
+      readContract: async ({ address }: { address: string }) =>
+        address.toLowerCase() === "0x2791bca1f2de4661ed88a30c99a7a9449aa84174" ? usdceRaw : pusdRaw,
       waitForTransactionReceipt: async () => ({}),
     }),
   },
@@ -34,10 +38,11 @@ mock.module("../src/utils/polymarket/client.js", {
   },
 });
 
-const { withdrawFunds } = await import("../src/utils/polymarket/withdraw.js");
+const { buildLegacyWrapCalls, withdrawFunds } = await import("../src/utils/polymarket/withdraw.js");
 
 test("no confirm → dry-run previews full balance to the agent wallet on Base", async () => {
-  balanceRaw = 7_500_000n;
+  pusdRaw = 7_500_000n;
+  usdceRaw = 0n;
   const res = await withdrawFunds({});
   assert.equal(res.isError, undefined, res.text);
   assert.match(res.text, /DRY RUN/);
@@ -49,28 +54,70 @@ test("no confirm → dry-run previews full balance to the agent wallet on Base",
 });
 
 test("amount_usd caps the withdrawal to that amount", async () => {
-  balanceRaw = 7_500_000n;
+  pusdRaw = 7_500_000n;
+  usdceRaw = 0n;
   const res = await withdrawFunds({ amount_usd: 3 });
   assert.match(res.text, /\$3\.00/);
 });
 
 test("amount above balance is rejected", async () => {
-  balanceRaw = 7_500_000n;
+  pusdRaw = 7_500_000n;
+  usdceRaw = 0n;
   const res = await withdrawFunds({ amount_usd: 10 });
   assert.equal(res.isError, true);
-  assert.match(res.text, /exceeds the pUSD balance/);
+  assert.match(res.text, /exceeds the withdrawable collateral balance/);
 });
 
 test("nothing to withdraw when balance is zero", async () => {
-  balanceRaw = 0n;
+  pusdRaw = 0n;
+  usdceRaw = 0n;
   const res = await withdrawFunds({});
   assert.equal(res.isError, true);
-  assert.match(res.text, /No pUSD to withdraw/);
+  assert.match(res.text, /No pUSD or USDC\.e to withdraw/);
 });
 
 test("custom to_address overrides the destination", async () => {
-  balanceRaw = 5_000_000n;
+  pusdRaw = 5_000_000n;
+  usdceRaw = 0n;
   const other = "0x1111111111111111111111111111111111111111";
   const res = await withdrawFunds({ to_address: other });
   assert.match(res.text, new RegExp(other));
+});
+
+test("legacy USDC.e is included and previewed as a pUSD wrap before withdrawal", async () => {
+  pusdRaw = 2_000_000n;
+  usdceRaw = 3_000_000n;
+  const res = await withdrawFunds({});
+  assert.equal(res.isError, undefined, res.text);
+  assert.match(res.text, /\$5\.00/);
+  assert.match(res.text, /First wrap: \$3\.00 legacy USDC\.e → pUSD/);
+  assert.equal((res.structured as { wrapUsd?: number }).wrapUsd, 3);
+});
+
+test("rejects non-positive and over-precision withdrawal amounts before creating a bridge request", async () => {
+  pusdRaw = 7_500_000n;
+  usdceRaw = 0n;
+  for (const amount_usd of [0, -1, 1.0000001]) {
+    const res = await withdrawFunds({ amount_usd });
+    assert.equal(res.isError, true);
+    assert.match(res.text, /positive USD amount/);
+  }
+});
+
+test("legacy wrapping batches approval before the exact USDC.e → pUSD wrap", () => {
+  const amount = 3_000_000n;
+  const [approve, wrap] = buildLegacyWrapCalls(DEPOSIT, amount);
+  assert.equal(approve.target.toLowerCase(), USDCE_COLLATERAL.toLowerCase());
+  assert.equal(wrap.target.toLowerCase(), COLLATERAL_ONRAMP.toLowerCase());
+  const decodedApprove = decodeFunctionData({ abi: ERC20_ABI, data: approve.data });
+  assert.equal(decodedApprove.functionName, "approve");
+  assert.deepEqual(decodedApprove.args, [COLLATERAL_ONRAMP, amount]);
+  const decodedWrap = decodeFunctionData({
+    abi: [{ type: "function", name: "wrap", stateMutability: "nonpayable", inputs: [
+      { name: "_asset", type: "address" }, { name: "_to", type: "address" }, { name: "_amount", type: "uint256" },
+    ], outputs: [] }] as const,
+    data: wrap.data,
+  });
+  assert.equal(decodedWrap.functionName, "wrap");
+  assert.deepEqual(decodedWrap.args, [USDCE_COLLATERAL, DEPOSIT, amount]);
 });

--- a/test/user-agent.test.ts
+++ b/test/user-agent.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withBlockrunMcpUserAgent } from "../src/utils/user-agent.js";
+
+function recorder() {
+  const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+  const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ input, init });
+    return new Response("ok");
+  }) as typeof fetch;
+  return { calls, fetcher };
+}
+
+test("overrides SDK user-agent on BlockRun gateway requests", async () => {
+  const { calls, fetcher } = recorder();
+  const wrapped = withBlockrunMcpUserAgent(fetcher, "0.30.0");
+  await wrapped("https://blockrun.ai/api/v1/chat/completions", {
+    headers: { "User-Agent": "blockrun-ts/3.5.1", "X-Test": "kept" },
+  });
+
+  const headers = new Headers(calls[0].init?.headers);
+  assert.equal(headers.get("user-agent"), "blockrun-mcp/0.30.0");
+  assert.equal(headers.get("x-test"), "kept");
+});
+
+test("marks Solana gateway requests as MCP", async () => {
+  const { calls, fetcher } = recorder();
+  const wrapped = withBlockrunMcpUserAgent(fetcher, "0.30.0");
+  await wrapped("https://sol.blockrun.ai/api/v1/chat/completions");
+  assert.equal(
+    new Headers(calls[0].init?.headers).get("user-agent"),
+    "blockrun-mcp/0.30.0",
+  );
+});
+
+test("does not alter third-party requests", async () => {
+  const { calls, fetcher } = recorder();
+  const wrapped = withBlockrunMcpUserAgent(fetcher, "0.30.0");
+  await wrapped("https://registry.npmjs.org/@blockrun/mcp/latest", {
+    headers: { "User-Agent": "original" },
+  });
+  assert.equal(
+    new Headers(calls[0].init?.headers).get("user-agent"),
+    "original",
+  );
+});


### PR DESCRIPTION
## Summary

- route redemptions through Polymarket V2 collateral adapters and add their required ERC-1155 operator approvals
- verify successful receipts, distinguish unverified RPC state from a true no-op, and retry post-transaction reads
- sweep legacy USDC.e through the collateral onramp before withdrawal
- separate Polygon read fallbacks from the explicit write RPC; replace unavailable default read endpoints
- add regression tests and bounded local-wallet E2E scripts

## Root cause

The previous redemption route targeted legacy contracts while CTF positions use legacy collateral and wallet balances use pUSD. It also lacked the ERC-1155 adapter approvals required for adapter-mediated redemption.

## Validation

- `npm run typecheck`
- `npm test` — 160 passing
- `npm run build`
- local-wallet read-only preflight confirmed a redeemable zero-value position and a valid withdrawal preview

## Live verification status

- adapter approval was correctly formed but Polymarket's relayer rejected it because the two official V2 collateral adapters are absent from its server-side allowlist; no approval or redemption was sent
- the bounded $2 withdrawal reached the bridge-address request but the bridge API timed out before any pUSD transfer was sent

The PR surfaces the relayer allowlist failure explicitly. Full live redeem/withdraw verification should be rerun after the relayer allowlist and bridge API are available.
