### PR TITLE
0.32.7 — setup reports the post-transaction approval state, not the pre-batch snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to BlockRun MCP will be documented in this file.
 
+## 0.32.7
+
+Setup's approval report now shows the post-transaction chain state, not the
+pre-transaction snapshot. Found live: a `setup confirm:true` that successfully
+granted 4 approvals returned every one of them as `granted:false`.
+
+- **`fix(polymarket)` — setup re-reads approvals after the batch lands.** Both
+  modes (deposit-wallet batch and per-tx EOA) built their report from the
+  approvals snapshot taken BEFORE signing, then flipped `approvalsPending` to
+  false without a single re-read. So the response contradicted itself
+  (`approvalsPending:false` + `granted:false`), and the inverse failure — a
+  batch tx that lands but leaves an approval missing — was reported as success.
+  Same 0.32.6 principle, applied to setup: a transaction landing proves it was
+  mined, not that it did anything. `verifyApprovalsLanded` re-reads on-chain
+  (3 attempts, 750ms, matching redeem's post-transaction reads) and only a
+  fresh read showing every approval granted counts; an empty read can never
+  fake success, and `approvalsDone` is persisted only after verification. When
+  the tx landed but the chain doesn't confirm, the report says so explicitly
+  (`approvalsUnverified:true` + a ⚠️ line) instead of ✅.
+- `structured` now carries `approvalsTxHash` (deposit-wallet) /
+  `approvalTxHashes` (EOA), so callers can link the batch without parsing text.
+- 223 tests, typecheck and build green.
+
 ## 0.32.6
 
 Redeem now proves the position was actually consumed, not just that a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.31.6",
+  "version": "0.32.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/mcp",
-      "version": "0.31.6",
+      "version": "0.32.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.32.6",
+  "version": "0.32.7",
   "mcpName": "io.github.BlockRunAI/blockrun-mcp",
   "description": "BlockRun MCP Server - Give your AI agent web search, deep research, prediction markets, and crypto data. Paid via x402 micropayments.",
   "type": "module",

--- a/src/utils/polymarket/setup.ts
+++ b/src/utils/polymarket/setup.ts
@@ -86,12 +86,43 @@ async function withRpcRetry<T>(fn: () => Promise<T>, attempts = 4): Promise<T> {
   throw lastErr;
 }
 
-interface ApprovalItem {
+export interface ApprovalItem {
   label: string;
   token: Hex;
   spender: Hex;
   kind: "erc20" | "erc1155";
   granted: boolean;
+}
+
+/**
+ * An approval transaction landing is not the same as the approvals being on
+ * the books — re-read the chain (retrying across RPC propagation lag, the same
+ * 3×750ms shape as redeem's post-transaction reads) and believe ONLY what it
+ * says. An empty read can never count as granted, so a truncated RPC response
+ * cannot fake success. Throws if every read attempt fails; the caller decides
+ * how to report "chain state unknown". `readFn` is injected so tests can pin
+ * the retry/verdict logic without an RPC.
+ */
+export async function verifyApprovalsLanded(
+  readFn: () => Promise<ApprovalItem[]>,
+  attempts = 3,
+  delayMs = 750,
+): Promise<{ approvals: ApprovalItem[]; allGranted: boolean }> {
+  let latest: ApprovalItem[] | null = null;
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      latest = await readFn();
+      if (latest.length > 0 && latest.every((a) => a.granted)) {
+        return { approvals: latest, allGranted: true };
+      }
+    } catch (err) {
+      lastErr = err;
+    }
+    if (i < attempts - 1) await new Promise((r) => setTimeout(r, delayMs));
+  }
+  if (latest === null) throw lastErr;
+  return { approvals: latest, allGranted: false };
 }
 
 /**
@@ -242,18 +273,33 @@ async function runSetupDepositWallet(opts: { confirm: boolean }): Promise<{ text
 
   // 3. Funds + approvals state.
   const balance = await getPusdBalance(depositWallet);
-  const approvals = await readApprovals(depositWallet);
+  let approvals = await readApprovals(depositWallet);
   const missing = approvals.filter((a) => !a.granted);
 
   // 4. Approvals batch — the first real signature; confirm-gated with preview.
   let approvalsTxHash: string | undefined;
   let approvalsPending = missing.length > 0;
+  let approvalsUnverified = false;
   if (missing.length > 0 && opts.confirm) {
     const calls = buildApprovalCalls(missing);
     const res = await sendWalletBatch(calls, depositWallet, "Approval batch");
     approvalsTxHash = res.transactionHash;
-    approvalsPending = false;
-    saveState({ approvalsDone: true });
+    // The batch landing proves it was MINED, not that the approvals are on the
+    // books. The response used to carry the pre-batch snapshot here, so every
+    // item the batch had just granted still read granted:false — and the
+    // inverse failure (relayer claims success, chain disagrees) was invisible.
+    try {
+      const verified = await verifyApprovalsLanded(() => readApprovals(depositWallet));
+      if (verified.approvals.length > 0) approvals = verified.approvals;
+      approvalsPending = !verified.allGranted;
+      approvalsUnverified = !verified.allGranted;
+    } catch {
+      // Chain state unknown after the tx landed — keep the pre-batch snapshot
+      // and report unverified rather than claiming success.
+      approvalsPending = true;
+      approvalsUnverified = true;
+    }
+    if (!approvalsPending) saveState({ approvalsDone: true });
   } else if (missing.length === 0) {
     saveState({ approvalsDone: true });
   }
@@ -309,6 +355,14 @@ async function runSetupDepositWallet(opts: { confirm: boolean }): Promise<{ text
           `   batch via the relayer). Re-run action:"setup" with confirm:true to sign.`,
         ]
       : []),
+    ...(approvalsUnverified
+      ? [
+          ``,
+          `   ⚠️ The approval batch landed but the chain does not (yet) show every`,
+          `   approval granted — treat them as NOT granted. Re-run action:"setup"`,
+          `   to re-check before trading or redeeming.`,
+        ]
+      : []),
     `${credsReady ? "✅" : "❌"} CLOB API credentials${credsNote}`,
     ...(balanceCacheWarned
       ? [`   ⚠️ Balance cache not pre-warmed (${balanceCacheWarned}) — your first buy refreshes it automatically.`]
@@ -330,6 +384,8 @@ async function runSetupDepositWallet(opts: { confirm: boolean }): Promise<{ text
       pusdBalance: balance,
       approvals: approvals.map((a) => ({ label: a.label, granted: a.granted })),
       approvalsPending,
+      ...(approvalsTxHash ? { approvalsTxHash } : {}),
+      ...(approvalsUnverified ? { approvalsUnverified: true } : {}),
       credsReady,
       ready,
     },
@@ -340,16 +396,18 @@ async function runSetupEoa(opts: { confirm: boolean }): Promise<{ text: string; 
   const account = getPolymarketAccount();
   const pc = getPublicClient();
 
-  const [balance, polWei, approvals] = await Promise.all([
+  const [balance, polWei, initialApprovals] = await Promise.all([
     getPusdBalance(account.address),
     pc.getBalance({ address: account.address }),
     readApprovals(account.address),
   ]);
+  let approvals = initialApprovals;
   const pol = Number(formatUnits(polWei, 18));
   const missing = approvals.filter((a) => !a.granted);
 
   // EOA mode sends its own approval transactions — needs POL for gas.
   let approvalsPending = missing.length > 0;
+  let approvalsUnverified = false;
   const approvalTxHashes: string[] = [];
   if (missing.length > 0 && opts.confirm) {
     if (pol <= 0) {
@@ -383,7 +441,17 @@ async function runSetupEoa(opts: { confirm: boolean }): Promise<{ text: string; 
         );
         approvalTxHashes.push(hash);
       }
-      approvalsPending = false;
+      // Same rule as the deposit-wallet batch: report the post-transaction
+      // chain state, not the pre-transaction snapshot the report was built on.
+      try {
+        const verified = await verifyApprovalsLanded(() => readApprovals(account.address));
+        if (verified.approvals.length > 0) approvals = verified.approvals;
+        approvalsPending = !verified.allGranted;
+        approvalsUnverified = !verified.allGranted;
+      } catch {
+        approvalsPending = true;
+        approvalsUnverified = true;
+      }
     }
   }
 
@@ -415,6 +483,13 @@ async function runSetupEoa(opts: { confirm: boolean }): Promise<{ text: string; 
       : approvalsPending && pol <= 0
         ? [``, `   Cannot send approvals: the EOA has no POL for gas. Send a little POL first.`]
         : []),
+    ...(approvalsUnverified
+      ? [
+          ``,
+          `   ⚠️ The approval transactions landed but the chain does not (yet) show every`,
+          `   approval granted — treat them as NOT granted. Re-run action:"setup" to re-check.`,
+        ]
+      : []),
     `${credsReady ? "✅" : "❌"} CLOB API credentials${credsNote}`,
     geo,
     ``,
@@ -435,6 +510,8 @@ async function runSetupEoa(opts: { confirm: boolean }): Promise<{ text: string; 
       polBalance: pol,
       approvals: approvals.map((a) => ({ label: a.label, granted: a.granted })),
       approvalsPending,
+      ...(approvalTxHashes.length ? { approvalTxHashes } : {}),
+      ...(approvalsUnverified ? { approvalsUnverified: true } : {}),
       credsReady,
       ready,
     },

--- a/test/polymarket-setup-verify.test.ts
+++ b/test/polymarket-setup-verify.test.ts
@@ -1,0 +1,87 @@
+// Pins the post-approval verification introduced after 0.32.6 shipped: the
+// setup response used to echo the PRE-batch approvals snapshot after signing
+// the batch, so every item it had just granted still read granted:false — and
+// the inverse failure (relayer claims success, chain disagrees) was invisible
+// because approvalsPending was flipped to false without a single re-read.
+// verifyApprovalsLanded is the one place that decides "granted" after a
+// transaction, and it may only believe a fresh chain read.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { verifyApprovalsLanded, type ApprovalItem } from "../src/utils/polymarket/setup.js";
+
+const item = (label: string, granted: boolean): ApprovalItem => ({
+  label,
+  token: "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB",
+  spender: "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296",
+  kind: "erc20",
+  granted,
+});
+
+const allGranted = [item("a", true), item("b", true)];
+const oneMissing = [item("a", true), item("b", false)];
+
+test("a first read showing everything granted is believed immediately", async () => {
+  let reads = 0;
+  const res = await verifyApprovalsLanded(async () => {
+    reads++;
+    return allGranted;
+  }, 3, 1);
+  assert.equal(res.allGranted, true);
+  assert.equal(reads, 1, "no pointless re-reads once the chain confirms");
+  assert.deepEqual(res.approvals, allGranted);
+});
+
+test("RPC propagation lag is retried, and the eventual granted read wins", async () => {
+  let reads = 0;
+  const res = await verifyApprovalsLanded(async () => {
+    reads++;
+    return reads < 3 ? oneMissing : allGranted;
+  }, 3, 1);
+  assert.equal(res.allGranted, true);
+  assert.equal(reads, 3);
+});
+
+test("a batch that never shows up on-chain is NOT granted, after exactly `attempts` reads", async () => {
+  let reads = 0;
+  const res = await verifyApprovalsLanded(async () => {
+    reads++;
+    return oneMissing;
+  }, 3, 1);
+  assert.equal(res.allGranted, false);
+  assert.equal(reads, 3);
+  assert.deepEqual(res.approvals, oneMissing, "the caller gets the freshest snapshot to report");
+});
+
+// Conservative on a short read, mirroring didRedeemAnyHeldPosition: an empty
+// approvals array (truncated/garbled RPC response) can never count as granted.
+test("an empty read cannot fake success", async () => {
+  const res = await verifyApprovalsLanded(async () => [], 2, 1);
+  assert.equal(res.allGranted, false);
+});
+
+// Every read failing means chain state is UNKNOWN — that must surface as a
+// throw for the caller to report "unverified", never as a silent verdict.
+test("a read that always throws propagates instead of inventing a verdict", async () => {
+  let reads = 0;
+  await assert.rejects(
+    verifyApprovalsLanded(async () => {
+      reads++;
+      throw new Error("rpc down");
+    }, 3, 1),
+    /rpc down/,
+  );
+  assert.equal(reads, 3, "all attempts are used before giving up");
+});
+
+// One flaky read in the middle must not abort verification — the next
+// successful read still decides.
+test("a transient read failure mid-verification is retried through", async () => {
+  let reads = 0;
+  const res = await verifyApprovalsLanded(async () => {
+    reads++;
+    if (reads === 1) throw new Error("rpc hiccup");
+    return allGranted;
+  }, 3, 1);
+  assert.equal(res.allGranted, true);
+  assert.equal(reads, 2);
+});


### PR DESCRIPTION
## What

\`action:"setup" confirm:true\` returned a response that contradicted itself: \`approvalsPending:false\` alongside \`granted:false\` for every approval it had just granted. Found live today — a batch that granted the 4 missing approvals (verified independently on-chain: operator 5/5, allowance 4/4) came back looking like it had done nothing.

## Why

Both setup modes read approvals once, signed the transactions, and then built the report from that **pre-transaction snapshot**, flipping \`approvalsPending\` to false without a single re-read. That also hid the inverse failure: a relayer batch that lands but leaves an approval missing was reported as ✅.

## How

Same principle as 0.32.6's redeem fix, applied to setup: a transaction landing proves it was mined, not that it did anything.

- \`verifyApprovalsLanded()\` re-reads the chain after the batch (3 attempts, 750ms — the same shape as redeem's post-transaction reads) and only a fresh read showing every approval granted counts.
- An empty/truncated read can never fake success; if every read fails, the report says **unverified** (⚠️ line + \`approvalsUnverified:true\`) instead of claiming ✅.
- \`approvalsDone\` is persisted only after on-chain verification.
- \`structured\` now carries \`approvalsTxHash\` / \`approvalTxHashes\`.

## Testing

- 6 new tests pinning the verify logic (immediate-believe, lag-retry, never-lands, empty-read, all-reads-fail, transient-failure).
- 223/223 tests, typecheck, build green.