### PR TITLE
0.32.8 — paid chat calls stream, so slow reasoning models stop 524ing after payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to BlockRun MCP will be documented in this file.
 
+## 0.32.8
+
+Paid chat calls now stream. A non-streaming request to a slow reasoning model
+(Kimi K3 with a large prompt generates for minutes) moves ZERO bytes between
+"request accepted" and "body ready", so the edge in front of the gateway kills
+the idle connection at ~100s and returns 524 — AFTER the x402 payment settled.
+Charged, nothing delivered. Observed live 2026-07-21, twice.
+
+- **`fix(chat)` — paid EVM paths use SSE streaming and assemble server-side.**
+  All three paid call shapes (explicit model, multi-turn `messages`, paid
+  routing tiers) switch to the SDK's `chatCompletionStream` and concatenate
+  deltas; bytes flow from the first chunk (reasoning models emit keepalive
+  chunks while thinking), so the idle timer never fires. Verified live: a
+  125s kimi-k3 generation that 524'd on the old path completes. The free
+  NVIDIA tier keeps the non-streaming client whose short timeout its
+  deadline loop depends on; Solana clients have no streaming API and keep
+  the old path (capability-checked, not assumed).
+- **Empty answer + `finish_reason:"length"` is now an explicit error.**
+  Reasoning tokens count toward `max_tokens`; a hard task with a small budget
+  can burn the whole budget thinking and emit zero visible text (measured:
+  kimi-k3, 8000 max_tokens, 0 chars). That surfaced as a silent empty reply —
+  indistinguishable from success. It now throws with the cause and the fix
+  (raise `max_tokens`).
+- Guards that keep the stream honest: a non-SSE response (a route that ignores
+  `stream:true`) is parsed as a plain JSON completion instead of yielding "";
+  an in-band `error` event throws instead of returning partial text; a stream
+  with no data for 120s aborts with a stall error (the SDK clears its fetch
+  timeout once headers arrive, so this idle guard is the only backstop).
+- x402 accounting is unchanged: the SDK's streaming method runs the same
+  payment flow and increments the same spend counter the budget ledger reads.
+- 234 tests (11 new pinning SSE assembly, fallbacks, stall, and the
+  reasoning-exhaustion diagnosis), typecheck, build green. Server-side half
+  (settle-on-success / refund on 5xx at the gateway) is tracked separately.
+
 ## 0.32.7
 
 Setup's approval report now shows the post-transaction chain state, not the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.32.7",
+  "version": "0.32.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/mcp",
-      "version": "0.32.7",
+      "version": "0.32.8",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.32.7",
+  "version": "0.32.8",
   "mcpName": "io.github.BlockRunAI/blockrun-mcp",
   "description": "BlockRun MCP Server - Give your AI agent web search, deep research, prediction markets, and crypto data. Paid via x402 micropayments.",
   "type": "module",

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -2,6 +2,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { buildClient, buildClientWithTimeout, getAnthropicClient, baseOnlyMessage } from "../utils/wallet.js";
+import { streamChatText, supportsStreaming, type StreamChatMessage } from "../utils/chat-stream.js";
 import { handleAnthropicNative, isAnthropicModel } from "./chat-anthropic.js";
 import { extractErrorMessage, formatError } from "../utils/errors.js";
 import { MODEL_TIERS, FREE_MODEL_TIMEOUT_MS, FREE_TIER_DEADLINE_MS, FREE_TIER_MAX_PROMPT_CHARS, type RoutingMode } from "../utils/constants.js";
@@ -284,13 +285,31 @@ Run blockrun_models to see all available models with pricing.`,
           // forwards `messages` verbatim and accepts image_url content arrays
           // for vision-capable models — so a multimodal array is runtime-valid.
           // (claude-* with history is already handled by the native branch above.)
-          const { result, settledUsd } = await withSettledCost(llm(), () => llm().chatCompletion(targetModel, fullMessages as unknown as Parameters<ReturnType<typeof llm>["chatCompletion"]>[1], {
-            maxTokens: max_tokens,
-            temperature,
-            responseFormat,
-            stop,
-          }));
-          const reply = result.choices?.[0]?.message?.content || "";
+          //
+          // Paid calls STREAM and assemble (see utils/chat-stream.ts): a slow
+          // reasoning model generating for minutes over a non-streaming request
+          // moves zero bytes, and the edge in front of the gateway 524s the idle
+          // connection AFTER the x402 payment settled — charged, no reply
+          // (observed live with moonshot/kimi-k3, 2026-07-21). Solana clients
+          // have no streaming API and keep the old path.
+          const { result: reply, settledUsd } = await withSettledCost(llm(), async () => {
+            const client = llm();
+            if (supportsStreaming(client)) {
+              return streamChatText(client, targetModel, fullMessages as unknown as StreamChatMessage[], {
+                maxTokens: max_tokens,
+                temperature,
+                responseFormat,
+                stop,
+              });
+            }
+            const r = await client.chatCompletion(targetModel, fullMessages as unknown as Parameters<ReturnType<typeof llm>["chatCompletion"]>[1], {
+              maxTokens: max_tokens,
+              temperature,
+              responseFormat,
+              stop,
+            });
+            return r.choices?.[0]?.message?.content || "";
+          });
           recordActualSpend(budget, settledUsd, estimatedCost, agent_id);
           const note = freeTierTruncationNote(promptChars, targetModel);
           return {
@@ -302,16 +321,26 @@ Run blockrun_models to see all available models with pricing.`,
         }
       }
 
-      // If specific model provided, use it directly
+      // If specific model provided, use it directly — streamed when the client
+      // supports it (same 524 rationale as the multi-turn path above).
       if (model) {
         try {
-          const { result: response, settledUsd } = await withSettledCost(llm(), () => llm().chat(model, message, {
-            system,
-            maxTokens: max_tokens,
-            temperature,
-            responseFormat,
-            stop,
-          }));
+          const { result: response, settledUsd } = await withSettledCost(llm(), async () => {
+            const client = llm();
+            if (supportsStreaming(client)) {
+              return streamChatText(client, model, [
+                ...(system ? [{ role: "system" as const, content: system }] : []),
+                { role: "user" as const, content: message },
+              ], { maxTokens: max_tokens, temperature, responseFormat, stop });
+            }
+            return client.chat(model, message, {
+              system,
+              maxTokens: max_tokens,
+              temperature,
+              responseFormat,
+              stop,
+            });
+          });
           recordActualSpend(budget, settledUsd, estimatedCost, agent_id);
           return { content: [{ type: "text", text: `${response}${freeTierTruncationNote(promptChars, model) ?? ""}` }] };
         } catch (error) {
@@ -344,13 +373,25 @@ Run blockrun_models to see all available models with pricing.`,
           break;
         }
         try {
-          const { result: response, settledUsd } = await withSettledCost(routingClient, () => routingClient.chat(m, message, {
-            system,
-            maxTokens: max_tokens,
-            temperature,
-            responseFormat,
-            stop,
-          }));
+          // Paid tiers stream (frontier primaries can generate for minutes —
+          // same 524 class as the explicit-model path). The free tier stays on
+          // the non-streaming client whose short timeout the deadline loop
+          // depends on to fail fast through its eight candidates.
+          const { result: response, settledUsd } = await withSettledCost(routingClient, async () => {
+            if (!freeClient && supportsStreaming(routingClient)) {
+              return streamChatText(routingClient, m, [
+                ...(system ? [{ role: "system" as const, content: system }] : []),
+                { role: "user" as const, content: message },
+              ], { maxTokens: max_tokens, temperature, responseFormat, stop });
+            }
+            return routingClient.chat(m, message, {
+              system,
+              maxTokens: max_tokens,
+              temperature,
+              responseFormat,
+              stop,
+            });
+          });
           recordActualSpend(budget, settledUsd, estimatedCost, agent_id);
           const note = freeTierTruncationNote(promptChars, m);
           return {

--- a/src/utils/chat-stream.ts
+++ b/src/utils/chat-stream.ts
@@ -1,0 +1,165 @@
+// src/utils/chat-stream.ts
+//
+// Stream-and-assemble for paid chat completions.
+//
+// Why: a non-streaming /v1/chat/completions call to a slow reasoning model
+// (Kimi K3 with a large prompt takes minutes) moves ZERO bytes between
+// "request accepted" and "body ready", so the edge in front of the gateway
+// kills the idle connection at ~100s and returns 524 — after the x402 payment
+// already settled. Charged, nothing delivered. Streaming keeps tokens flowing
+// from the first chunk, so the idle timer never fires; the MCP assembles the
+// full text and returns it exactly like the non-streaming path did.
+//
+// The SDK's fetchWithTimeout clears its abort timer once response HEADERS
+// arrive, so reading the body has no client-side deadline — the idle guard
+// here (readWithIdleTimeout) is therefore the ONLY thing standing between a
+// stalled stream and hanging forever.
+import type { ApiClient } from "./wallet.js";
+
+/** Chat message shape the gateway accepts (content may be multimodal parts). */
+export interface StreamChatMessage {
+  role: "user" | "assistant" | "system";
+  content: unknown;
+}
+
+export interface StreamChatOptions {
+  maxTokens?: number;
+  temperature?: number;
+  responseFormat?: { type: "text" | "json_object" };
+  stop?: string[];
+}
+
+/** Narrow an ApiClient to one that can stream (SolanaLLMClient cannot). */
+export function supportsStreaming(
+  client: ApiClient,
+): client is ApiClient & { chatCompletionStream: (model: string, messages: unknown, options?: unknown) => Promise<Response> } {
+  return typeof (client as { chatCompletionStream?: unknown }).chatCompletionStream === "function";
+}
+
+async function readWithIdleTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  ms: number,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  let timer: NodeJS.Timeout | undefined;
+  const stall = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`stream stalled: no data from the gateway for ${Math.round(ms / 1000)}s`)),
+      ms,
+    );
+  });
+  try {
+    return await Promise.race([reader.read(), stall]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Assemble the complete reply from an OpenAI-compatible SSE body.
+ *
+ * - Concatenates `choices[0].delta.content`; `reasoning_content` is collected
+ *   separately and used only as a fallback when no content ever arrives, so a
+ *   provider that splits reasoning out doesn't produce an empty answer.
+ * - An `error` object mid-stream throws (the gateway reports upstream failures
+ *   in-band once headers are already 200).
+ * - A JSON parse failure on a single data line skips that line; SSE comment/
+ *   keepalive lines (":…") and blank lines are ignored by the data: filter.
+ *
+ * Exported for tests.
+ */
+export async function assembleSseChatStream(
+  resp: { body: ReadableStream<Uint8Array> | null },
+  idleTimeoutMs = 120_000,
+): Promise<{ text: string; finishReason: string | null }> {
+  if (!resp.body) throw new Error("streaming response had no body");
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let text = "";
+  let reasoning = "";
+  let finishReason: string | null = null;
+
+  const finish = () => ({ text: text || reasoning, finishReason });
+
+  try {
+    for (;;) {
+      const chunk = await readWithIdleTimeout(reader, idleTimeoutMs);
+      if (chunk.done) return finish();
+      buffer += decoder.decode(chunk.value, { stream: true });
+      let nl: number;
+      while ((nl = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, nl).trimEnd(); // tolerates \r\n framing
+        buffer = buffer.slice(nl + 1);
+        if (!line.startsWith("data:")) continue;
+        const payload = line.slice(5).trim();
+        if (payload === "[DONE]") return finish();
+        let event: unknown;
+        try {
+          event = JSON.parse(payload);
+        } catch {
+          continue; // malformed single line — never abandon the whole stream for it
+        }
+        const ev = event as {
+          error?: { message?: string } | string;
+          choices?: Array<{
+            delta?: { content?: unknown; reasoning_content?: unknown };
+            message?: { content?: unknown };
+            finish_reason?: string | null;
+          }>;
+        };
+        if (ev?.error) {
+          const msg = typeof ev.error === "string" ? ev.error : ev.error.message ?? JSON.stringify(ev.error);
+          throw new Error(`upstream error mid-stream: ${msg}`);
+        }
+        const choice = ev?.choices?.[0];
+        // Some providers put the final text in `message` on the last chunk
+        // instead of a delta; treat both, delta first.
+        const content = choice?.delta?.content ?? choice?.message?.content;
+        if (typeof content === "string") text += content;
+        const rc = choice?.delta?.reasoning_content;
+        if (typeof rc === "string") reasoning += rc;
+        if (choice?.finish_reason) finishReason = choice.finish_reason;
+      }
+    }
+  } catch (err) {
+    // Free the connection on any failure path (stall, mid-stream error).
+    await reader.cancel().catch(() => undefined);
+    throw err;
+  }
+}
+
+/**
+ * Streamed equivalent of `client.chat(...)` / `client.chatCompletion(...)`:
+ * returns the assembled reply text. The caller decides WHEN to stream
+ * (paid EVM paths); this decides HOW.
+ */
+export async function streamChatText(
+  client: ApiClient & { chatCompletionStream: (model: string, messages: unknown, options?: unknown) => Promise<Response> },
+  model: string,
+  messages: StreamChatMessage[],
+  options: StreamChatOptions,
+): Promise<string> {
+  const resp = await client.chatCompletionStream(model, messages, options);
+  // A provider/route that ignores `stream:true` answers with a plain JSON
+  // completion. Feeding that to the SSE parser would "succeed" with an empty
+  // string — the silent-truncation failure shape this module must never add.
+  const contentType = (resp.headers?.get?.("content-type") ?? "").toLowerCase();
+  if (!contentType.includes("text/event-stream")) {
+    const data = (await resp.json()) as { choices?: Array<{ message?: { content?: string } }> };
+    return data.choices?.[0]?.message?.content ?? "";
+  }
+  const { text, finishReason } = await assembleSseChatStream(resp);
+  // Reasoning models stream their hidden thinking as empty-content keepalive
+  // chunks, and those tokens COUNT toward max_tokens. A hard task with a small
+  // budget can burn the whole budget reasoning and emit zero visible text —
+  // finish_reason "length" with an empty answer (measured live: kimi-k3,
+  // 4000 max_tokens, 125s of keepalives, 0 chars). Returning "" would be
+  // indistinguishable from success; say what happened and what to change.
+  if (!text && finishReason === "length") {
+    throw new Error(
+      `${model} spent the entire max_tokens budget on internal reasoning and produced no visible answer. ` +
+      `Raise max_tokens (reasoning tokens count against it) or simplify the request.`,
+    );
+  }
+  return text;
+}

--- a/test/chat-stream.test.ts
+++ b/test/chat-stream.test.ts
@@ -1,0 +1,140 @@
+// Pins the SSE assembly that lets paid chat calls stream instead of holding a
+// silent connection open: a slow reasoning model over a non-streaming request
+// moves zero bytes until done, the edge 524s the idle connection, and the x402
+// payment has already settled — charged, nothing delivered (observed live with
+// moonshot/kimi-k3, 2026-07-21). The parser here must (a) assemble exactly the
+// text a non-streaming call would have returned and (b) never turn a transport
+// or upstream failure into a quiet empty string.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { assembleSseChatStream, supportsStreaming } from "../src/utils/chat-stream.js";
+import type { ApiClient } from "../src/utils/wallet.js";
+
+const enc = new TextEncoder();
+
+/** Build a ReadableStream body from raw string chunks (arbitrary boundaries). */
+function bodyFrom(chunks: string[], opts?: { hangAfter?: boolean }): { body: ReadableStream<Uint8Array> } {
+  let i = 0;
+  return {
+    body: new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (i < chunks.length) {
+          controller.enqueue(enc.encode(chunks[i++]));
+          return;
+        }
+        if (opts?.hangAfter) return; // never close, never enqueue — a stalled stream
+        controller.close();
+      },
+    }),
+  };
+}
+
+const chunk = (payload: unknown) => `data: ${JSON.stringify(payload)}\n\n`;
+const delta = (content: string) => chunk({ choices: [{ delta: { content } }] });
+
+test("assembles deltas across arbitrary chunk boundaries", async () => {
+  const full = delta("Hel") + delta("lo ") + delta("world");
+  // Split mid-line so JSON and SSE framing straddle chunk boundaries.
+  const chunks = [full.slice(0, 17), full.slice(17, 40), full.slice(40)];
+  const { text } = await assembleSseChatStream(bodyFrom(chunks));
+  assert.equal(text, "Hello world");
+});
+
+test("[DONE] terminates and finish_reason is surfaced", async () => {
+  const { text, finishReason } = await assembleSseChatStream(bodyFrom([
+    delta("hi"),
+    chunk({ choices: [{ delta: {}, finish_reason: "stop" }] }),
+    "data: [DONE]\n\n",
+    delta("IGNORED — after DONE"),
+  ]));
+  assert.equal(text, "hi");
+  assert.equal(finishReason, "stop");
+});
+
+test("CRLF framing and keepalive comment lines are tolerated", async () => {
+  const { text } = await assembleSseChatStream(bodyFrom([
+    ": keep-alive\r\n\r\n",
+    `data: ${JSON.stringify({ choices: [{ delta: { content: "ok" } }] })}\r\n\r\n`,
+    "data: [DONE]\r\n\r\n",
+  ]));
+  assert.equal(text, "ok");
+});
+
+test("reasoning_content is a fallback, never an addition", async () => {
+  // Reasoning + answer: only the answer comes back (matches non-streaming).
+  const both = await assembleSseChatStream(bodyFrom([
+    chunk({ choices: [{ delta: { reasoning_content: "thinking…" } }] }),
+    delta("answer"),
+  ]));
+  assert.equal(both.text, "answer");
+  // Reasoning only: better the reasoning than an empty reply.
+  const only = await assembleSseChatStream(bodyFrom([
+    chunk({ choices: [{ delta: { reasoning_content: "all I have" } }] }),
+  ]));
+  assert.equal(only.text, "all I have");
+});
+
+test("a final chunk carrying message instead of delta still counts", async () => {
+  const { text } = await assembleSseChatStream(bodyFrom([
+    chunk({ choices: [{ message: { content: "whole reply" }, finish_reason: "stop" }] }),
+  ]));
+  assert.equal(text, "whole reply");
+});
+
+test("an in-band error event throws instead of returning partial text", async () => {
+  await assert.rejects(
+    assembleSseChatStream(bodyFrom([
+      delta("partial "),
+      chunk({ error: { message: "upstream exploded" } }),
+    ])),
+    /upstream exploded/,
+  );
+});
+
+test("one malformed data line is skipped, the stream continues", async () => {
+  const { text } = await assembleSseChatStream(bodyFrom([
+    "data: {not json\n\n",
+    delta("survived"),
+  ]));
+  assert.equal(text, "survived");
+});
+
+test("a stalled stream throws the idle-timeout error, not a hang", async () => {
+  await assert.rejects(
+    assembleSseChatStream(bodyFrom([delta("start")], { hangAfter: true }), 50),
+    /stream stalled/,
+  );
+});
+
+test("a bodyless response throws loudly", async () => {
+  await assert.rejects(assembleSseChatStream({ body: null }), /no body/);
+});
+
+// The Solana client has no chatCompletionStream — the capability check is what
+// keeps those callers on the old non-streaming path instead of crashing.
+test("supportsStreaming distinguishes streaming-capable clients", () => {
+  assert.equal(supportsStreaming({ chatCompletionStream: async () => new Response() } as unknown as ApiClient), true);
+  assert.equal(supportsStreaming({ chat: async () => "" } as unknown as ApiClient), false);
+});
+
+// A reasoning model can burn the whole max_tokens budget thinking and emit
+// zero visible text (finish_reason "length", empty content). streamChatText
+// must throw a diagnosis, not hand back "" as if the model answered nothing.
+test("empty text + finish_reason length throws a max_tokens diagnosis", async () => {
+  const { streamChatText } = await import("../src/utils/chat-stream.js");
+  const sse = [
+    `data: ${JSON.stringify({ choices: [{ delta: { role: "assistant", content: "" } }] })}\n\n`,
+    `data: ${JSON.stringify({ choices: [{ delta: { content: "" }, finish_reason: "length" }] })}\n\n`,
+    "data: [DONE]\n\n",
+  ];
+  const fakeClient = {
+    chatCompletionStream: async () =>
+      new Response(new ReadableStream<Uint8Array>({
+        start(c) { for (const s of sse) c.enqueue(enc.encode(s)); c.close(); },
+      }), { headers: { "content-type": "text/event-stream" } }),
+  };
+  await assert.rejects(
+    streamChatText(fakeClient as never, "moonshot/kimi-k3", [{ role: "user", content: "hi" }], {}),
+    /entire max_tokens budget on internal reasoning/,
+  );
+});


### PR DESCRIPTION
## What

Two paid \`blockrun_chat\` calls to \`moonshot/kimi-k3\` today returned \`API error after payment: 524\` — charged, nothing delivered. Root cause: non-streaming requests move zero bytes while a reasoning model generates for minutes, and the edge in front of the gateway kills the idle connection at ~100s. The x402 payment settles before generation starts, so the failure costs real money.

## How

- All three paid EVM call shapes (explicit model, multi-turn \`messages\`, paid routing tiers) switch to the SDK's \`chatCompletionStream\` (public API, same x402 flow, same spend counter) and assemble SSE deltas server-side. Bytes flow from the first chunk — reasoning models emit keepalive chunks while thinking — so the idle timer never fires.
- The free NVIDIA tier keeps its non-streaming client (its fail-fast timeout drives the deadline loop); Solana clients have no streaming API and keep the old path via a capability check.
- Honesty guards: non-SSE response → parsed as plain JSON completion (never a silent \`""\`); in-band \`error\` event → throws; 120s with no data → stall error (the SDK clears its fetch abort timer once headers arrive, so this is the only backstop); empty answer + \`finish_reason:"length"\` → explicit "reasoning burned the whole max_tokens budget" error (measured live: 8000 max_tokens, 0 visible chars).

## Verification

- Live: a 125.1s kimi-k3 generation over the new path — previously a guaranteed 524 — completes with payment booked ($0.0088).
- Live: normal task streams 2,673 chars in 58.4s, spend counter delta intact.
- Live: reasoning-exhaustion case throws the new diagnosis instead of returning "".
- 234/234 tests (11 new), typecheck, build green.

Server-side half (settle-on-success / refund on 5xx at the gateway) is a separate task in the main blockrun repo.