### PR TITLE
0.32.9 — close the external-review backlog: withdraw double-spend window, USDC.e sweep, and six more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 All notable changes to BlockRun MCP will be documented in this file.
 
+## 0.32.9
+
+Closes the external-review backlog: all 8 findings from the Kimi K3 review
+(#72) and both unabsorbed pieces of @KillerQueen-Z's #59/#66 (#71).
+
+- **`fix(polymarket)` — the withdraw retry double-spend window is closed
+  (#72.1).** The relayer SDK's `wait()` polls 200s and returns `undefined` for
+  BOTH an on-chain failure and a timeout, while the signed batch stays
+  executable until its 300s deadline — and our error text said "re-run",
+  an instruction that could double-send a partial withdrawal. Now:
+  `sendWalletBatch` asks the relayer which case it is and says so (a failure
+  is retry-safe; a pending batch gets "Do NOT retry" + the remaining window);
+  every withdrawal batch is tracked in the state file while in flight, and
+  `action:"withdraw"` refuses to sign a second transfer until the previous one
+  resolves or its deadline passes (unreachable relayer counts as pending —
+  the conservative side). Per-operation guidance replaces the hardcoded
+  "re-run setup" advice everywhere (#72.5).
+- **`feat(polymarket)` — withdrawals sweep legacy USDC.e (#71).** Withdrawable
+  balance is now pUSD + USDC.e; any shortfall beyond the pUSD on hand is
+  wrapped through the collateral onramp first (`wrap(asset, to, amount)`
+  signature verified against the onramp's Sourcify exact-match source).
+  Sweep design from #59/#66, with the wrap preview in the dry-run and the
+  post-wrap balance re-read before bridging.
+- **`fix(polymarket)` — `amount_usd` parsing no longer truncates through float
+  noise.** `BigInt(Math.floor(usd * 1e6))` sent $19.989999 for a $19.99
+  request; amounts now round to the exact micro-dollar and over-precision /
+  non-positive values are rejected. (The #66 draft's absolute 1e-7 tolerance
+  sat below the float-noise floor and rejected honest amounts like $1234.56;
+  0.01 micro separates noise from genuine violations.)
+- **`fix(polymarket)` — redeem refuses to guess the adapter (#72.3).** A
+  missing `neg_risk` field now falls back to the order book and errors out if
+  both sources are silent, instead of silently treating "missing" as
+  "standard market" — the wrong adapter is the no-op redeem class. The
+  confirm path also now refuses unresolved markets up front (#72.6) instead
+  of submitting a batch that reverts on-chain.
+- **`fix(polymarket)` — setup verifies the deploy landed at the DERIVED
+  address (#72.4)** by reading contract code on-chain (3×750ms) before
+  recording `deployed:true`, so a relayer factory/salt divergence can never
+  point approvals and funding at a nonexistent wallet.
+- **`fix(polymarket)` — ClobClient cache key includes the deposit wallet
+  (#72.2)**, so a wallet change within the process lifetime can't keep
+  building orders against the old `funderAddress`.
+- **`fix(polymarket)` — `roundToTick` absorbs float-division noise (#72.7).**
+  `0.58/0.001 = 579.9999…` floored a buy to 0.579 (one tick under the stated
+  limit); on-grid prices now survive unchanged, off-grid still rounds
+  conservatively by side.
+- **`fix` — creds/state writes are atomic (#72.8)** (tmp + rename), so a
+  crash mid-write can't corrupt the credentials or deposit-wallet mapping
+  that reads then silently swallow to null.
+- **Bounded e2e scripts from #66 are in-tree (#71)**: `npm run
+  e2e:polymarket:{readonly,approvals,approve,withdraw,live}` — readonly and
+  approvals verified live against the local wallet today.
+- 250 tests (17 new: batch-state disambiguation, double-spend guard
+  lifecycle, sweep preview + calldata pinning, amount parsing, tick
+  rounding), typecheck, build green.
+
 ## 0.32.8
 
 Paid chat calls now stream. A non-streaming request to a slow reasoning model

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.32.8",
+  "version": "0.32.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/mcp",
-      "version": "0.32.8",
+      "version": "0.32.9",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.32.8",
+  "version": "0.32.9",
   "mcpName": "io.github.BlockRunAI/blockrun-mcp",
   "description": "BlockRun MCP Server - Give your AI agent web search, deep research, prediction markets, and crypto data. Paid via x402 micropayments.",
   "type": "module",
@@ -21,7 +21,12 @@
     "typecheck": "tsc --noEmit",
     "test": "tsx --experimental-test-module-mocks --test test/*.test.ts",
     "prepublishOnly": "npm run build",
-    "verify:prices": "tsx scripts/verify-prices.ts"
+    "verify:prices": "tsx scripts/verify-prices.ts",
+    "e2e:polymarket:readonly": "tsx scripts/polymarket-e2e-readonly.ts",
+    "e2e:polymarket:approvals": "tsx scripts/polymarket-e2e-verify-approvals.ts",
+    "e2e:polymarket:approve": "tsx scripts/polymarket-e2e-approve.ts",
+    "e2e:polymarket:withdraw": "tsx scripts/polymarket-e2e-withdraw.ts",
+    "e2e:polymarket:live": "tsx scripts/polymarket-e2e-live.ts"
   },
   "keywords": [
     "mcp",

--- a/scripts/polymarket-e2e-approve.ts
+++ b/scripts/polymarket-e2e-approve.ts
@@ -1,0 +1,22 @@
+/**
+ * One-time preflight for the bounded live redeem test: signs the approval
+ * batch (including the two collateral-adapter operators redeem requires),
+ * then re-reads the resulting on-chain state. Prints no wallet address or
+ * transaction id. From @KillerQueen-Z's #66.
+ */
+import { runSetup } from "../src/utils/polymarket/setup.js";
+
+try {
+  const submitted = await runSetup({ confirm: true });
+  const verified = await runSetup({ confirm: false });
+  const approvals = verified.structured.approvals as Array<{ label: string; granted: boolean }>;
+  console.log(JSON.stringify({
+    approvalBatchSubmitted: !submitted.structured.approvalsPending,
+    adaptersApproved: approvals.filter(({ label }) => label.includes("Collateral Adapter")),
+    approvalsPending: verified.structured.approvalsPending,
+  }, null, 2));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(JSON.stringify({ failed: true, error: message.replace(/0x[a-fA-F0-9]{40,}/g, "<redacted>") }));
+  process.exitCode = 1;
+}

--- a/scripts/polymarket-e2e-live.ts
+++ b/scripts/polymarket-e2e-live.ts
@@ -1,0 +1,37 @@
+/**
+ * A deliberately narrow live verification of redeem + withdraw. Preconditions
+ * prevent it from redeeming a valuable position (≤ $0.001 current value) or
+ * moving more than $2.00. Wallet addresses and transaction IDs are never
+ * printed. From @KillerQueen-Z's #66; success check updated for the tri-state
+ * redeem statuses main ships (only status:"redeemed" counts).
+ */
+import { fetchPositions, getFundsAddress } from "../src/utils/polymarket/positions.js";
+import { redeemPosition } from "../src/utils/polymarket/redeem.js";
+import { withdrawFunds } from "../src/utils/polymarket/withdraw.js";
+
+const owner = getFundsAddress();
+const positions = await fetchPositions(owner);
+const target = positions.find((position) =>
+  position.redeemable === true &&
+  (position.currentValue ?? Number.POSITIVE_INFINITY) <= 0.001 &&
+  Boolean(position.conditionId),
+);
+
+if (!target?.conditionId) {
+  throw new Error("No zero-value redeemable position is available for the bounded live redeem test.");
+}
+
+const redeem = await redeemPosition({ condition_id: target.conditionId, confirm: true });
+if (redeem.isError || redeem.structured?.status !== "redeemed") {
+  throw new Error(`Redeem verification did not complete cleanly: ${redeem.text.replace(/0x[a-fA-F0-9]{64}/g, "<tx>")}`);
+}
+
+const withdrawal = await withdrawFunds({ amount_usd: 2, confirm: true });
+if (withdrawal.isError) {
+  throw new Error(`Withdrawal submission failed: ${withdrawal.text.replace(/0x[a-fA-F0-9]{64}/g, "<tx>")}`);
+}
+
+console.log(JSON.stringify({
+  redeem: { verified: true, market: target.title, outcome: target.outcome, sharesBurned: target.size },
+  withdrawal: { submitted: true, amountUsd: 2, destinationChainId: withdrawal.structured?.toChainId },
+}, null, 2));

--- a/scripts/polymarket-e2e-readonly.ts
+++ b/scripts/polymarket-e2e-readonly.ts
@@ -1,0 +1,46 @@
+/**
+ * Read-only local-wallet preflight for Polymarket redeem/withdraw changes.
+ * Never supplies confirm:true; never emits a wallet address, private key, or
+ * transaction identifier. From @KillerQueen-Z's #66.
+ */
+import { listPositions } from "../src/utils/polymarket/positions.js";
+import { withdrawFunds } from "../src/utils/polymarket/withdraw.js";
+
+const [positionsResult, withdrawalResult] = await Promise.all([
+  listPositions(),
+  withdrawFunds({}),
+]);
+
+const positions = ((positionsResult.structured as {
+  positions?: Array<{
+    title?: string;
+    outcome?: string;
+    size?: number;
+    currentValue?: number;
+    redeemable?: boolean;
+    negativeRisk?: boolean;
+    conditionId?: string;
+  }>;
+} | undefined)?.positions ?? []).map((position) => ({
+  title: position.title,
+  outcome: position.outcome,
+  size: position.size,
+  currentValue: position.currentValue,
+  redeemable: position.redeemable,
+  negativeRisk: position.negativeRisk,
+  condition: position.conditionId ? `${position.conditionId.slice(0, 10)}…` : undefined,
+}));
+
+console.log(JSON.stringify({
+  positions,
+  withdrawalPreview: withdrawalResult.isError
+    ? withdrawalResult.text.replace(/0x[a-fA-F0-9]{40}/g, "<wallet>")
+    : {
+      dryRun: withdrawalResult.structured?.dryRun,
+      amountUsd: withdrawalResult.structured?.amountUsd,
+      pusdUsd: withdrawalResult.structured?.pusdUsd,
+      usdceUsd: withdrawalResult.structured?.usdceUsd,
+      wrapUsd: withdrawalResult.structured?.wrapUsd,
+      toChainId: withdrawalResult.structured?.toChainId,
+    },
+}, null, 2));

--- a/scripts/polymarket-e2e-verify-approvals.ts
+++ b/scripts/polymarket-e2e-verify-approvals.ts
@@ -1,0 +1,9 @@
+/** Read-only: report the on-chain approval state for the local wallet. */
+import { runSetup } from "../src/utils/polymarket/setup.js";
+
+const result = await runSetup({ confirm: false });
+const approvals = result.structured.approvals as Array<{ label: string; granted: boolean }>;
+console.log(JSON.stringify({
+  adaptersApproved: approvals.filter(({ label }) => label.includes("Collateral Adapter")),
+  approvalsPending: result.structured.approvalsPending,
+}, null, 2));

--- a/scripts/polymarket-e2e-withdraw.ts
+++ b/scripts/polymarket-e2e-withdraw.ts
@@ -1,0 +1,12 @@
+/** Bounded live withdrawal check ($2 cap), independent of the approval flow. From #66. */
+import { withdrawFunds } from "../src/utils/polymarket/withdraw.js";
+
+const result = await withdrawFunds({ amount_usd: 2, confirm: true });
+if (result.isError) {
+  throw new Error(result.text.replace(/0x[a-fA-F0-9]{64}/g, "<tx>"));
+}
+console.log(JSON.stringify({
+  submitted: true,
+  amountUsd: result.structured?.amountUsd,
+  destinationChainId: result.structured?.toChainId,
+}, null, 2));

--- a/src/utils/polymarket/client.ts
+++ b/src/utils/polymarket/client.ts
@@ -178,7 +178,10 @@ export async function getClobClient(): Promise<ClobClient> {
   // bind creds to the deposit wallet via an ERC-7739-wrapped L1 ClobAuth is what
   // the CLOB rejects with "Invalid L1 Request headers" — issue #65 misdiagnosed
   // the fix as wrapping L1 auth; the real path keeps L1 auth as the EOA.
-  const cacheKey = `${sigType}:${account.address.toLowerCase()}`;
+  // The deposit wallet is part of the key: funderAddress is baked into the
+  // cached client, so a wallet change within the process lifetime (re-setup,
+  // state file rewritten) must not keep building orders against the old funder.
+  const cacheKey = `${sigType}:${account.address.toLowerCase()}:${(depositWallet ?? "").toLowerCase()}`;
   if (_clobClient && _clobClientKey === cacheKey) return _clobClient;
 
   let creds = loadL2Creds(account.address, 0);

--- a/src/utils/polymarket/constants.ts
+++ b/src/utils/polymarket/constants.ts
@@ -34,6 +34,12 @@ export const PUSD_COLLATERAL = "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB";
 export const CTF_COLLATERAL_ADAPTER = "0xAdA100Db00Ca00073811820692005400218FcE1f";
 export const NEG_RISK_CTF_COLLATERAL_ADAPTER = "0xadA2005600Dec949baf300f4C6120000bDB6eAab";
 export const COLLATERAL_ONRAMP = "0x93070a847efEf7F70739046A929D47a521F5B8ee";
+// USDC.e — the legacy collateral CTF position ids are keyed to. Withdrawals
+// sweep any residue of it (historic direct-CTF redemptions paid out USDC.e)
+// through the onramp's wrap(asset, to, amount) — signature verified against the
+// Sourcify exact-match source of COLLATERAL_ONRAMP, 2026-07-21 — since the
+// bridge only accepts pUSD.
+export const USDCE_COLLATERAL = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
 export const DEPOSIT_WALLET_FACTORY = "0x00000000000Fb5C9ADea0298D729A0CB3823Cc07";
 
 /**

--- a/src/utils/polymarket/creds.ts
+++ b/src/utils/polymarket/creds.ts
@@ -48,6 +48,13 @@ export interface PolymarketState {
   signer?: string;
   deployed?: boolean;
   approvalsDone?: boolean;
+  /**
+   * A withdrawal batch whose relayer confirmation timed out. Its EIP-712
+   * signature stays executable until `deadline` (unix seconds), so a fresh
+   * withdrawal signed before then can DOUBLE-SEND — withdraw refuses to sign
+   * while this is set and unresolved. Cleared on confirm/failure.
+   */
+  pendingWithdraw?: { transactionID: string; deadline: number };
 }
 
 function readJsonFile<T>(file: string): T | null {
@@ -62,7 +69,13 @@ function readJsonFile<T>(file: string): T | null {
 
 function writeJsonFile(file: string, value: unknown): void {
   fs.mkdirSync(BLOCKRUN_DIR, { recursive: true });
-  fs.writeFileSync(file, JSON.stringify(value, null, 2), { mode: 0o600 });
+  // tmp + rename: a crash mid-write must never leave a half-written creds or
+  // state file — reads swallow parse errors to null, so corruption would
+  // silently drop credentials (and the deposit-wallet mapping) instead of
+  // failing loudly. rename(2) on the same filesystem is atomic.
+  const tmp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(value, null, 2), { mode: 0o600 });
+  fs.renameSync(tmp, file);
 }
 
 function credsKey(address: string, sigType: number): string {

--- a/src/utils/polymarket/orders.ts
+++ b/src/utils/polymarket/orders.ts
@@ -59,7 +59,13 @@ function commitBet(): void {
 export function roundToTick(price: number, tickSize: string, side: "buy" | "sell" = "buy"): number {
   const tick = parseFloat(tickSize);
   const decimals = Math.max(0, (tickSize.split(".")[1] ?? "").length);
-  const steps = side === "buy" ? Math.floor(price / tick) : Math.ceil(price / tick);
+  // The epsilon absorbs float-division noise on prices ALREADY on the grid:
+  // 0.58/0.001 is 579.9999…, which floor alone turns into 0.579 (a buy signed
+  // one tick below the stated limit), and 0.42/0.01 is 42.000…01, which ceil
+  // alone turns into 0.43 (a sell one tick above). 1e-9 is far below half a
+  // tick for every real tick size, so genuine off-grid prices still round in
+  // the conservative direction (issue #72 finding 7).
+  const steps = side === "buy" ? Math.floor(price / tick + 1e-9) : Math.ceil(price / tick - 1e-9);
   return Number((steps * tick).toFixed(decimals));
 }
 

--- a/src/utils/polymarket/redeem.ts
+++ b/src/utils/polymarket/redeem.ts
@@ -119,7 +119,26 @@ export async function redeemPosition(input: { condition_id?: string; confirm?: b
       return { text: `Nothing to redeem: ${owner} holds no outcome tokens for "${market?.question ?? conditionId}".`, isError: true };
     }
 
-    const negRisk = Boolean(market?.neg_risk);
+    // negRisk picks WHICH adapter redeems — the wrong one is the silent
+    // no-op this module was rewritten to kill. A missing field is not "false":
+    // if the market payload omits it (API shape drift), cross-check the order
+    // book, and refuse rather than guess if that's missing too. Guessing wrong
+    // is caught post-hoc by no_effect_detected, but only after burning a
+    // relayer transaction and confusing the caller (issue #72 finding 3).
+    let negRiskRaw: boolean | undefined = market?.neg_risk;
+    if (negRiskRaw === undefined) {
+      const book = (await clob.getOrderBook(tokens[0].token_id as string).catch(() => null)) as { neg_risk?: boolean } | null;
+      negRiskRaw = book?.neg_risk;
+    }
+    if (typeof negRiskRaw !== "boolean") {
+      return {
+        text: `Cannot determine whether "${market?.question ?? conditionId}" is a neg-risk market (neither the ` +
+          `market metadata nor the order book carries neg_risk) — refusing to guess, because the wrong collateral ` +
+          `adapter redeems 0. Retry shortly; if this persists, report it.`,
+        isError: true,
+      };
+    }
+    const negRisk = negRiskRaw;
     const held = tokens
       .map((t, i) => ({ outcome: t.outcome, winner: t.winner, shares: Number(balances[i]) / 10 ** PUSD_DECIMALS }))
       .filter((h) => h.shares > 0);
@@ -142,6 +161,18 @@ export async function redeemPosition(input: { condition_id?: string; confirm?: b
       };
     }
 
+    // The dry-run only WARNED about an unresolved market; the confirm path
+    // then happily submitted a batch that reverts on-chain (CTF requires
+    // payoutDenominator > 0). No fund risk, but a wasted relayer transaction
+    // and a confusing failure — refuse up front instead (issue #72 finding 6).
+    if (market?.closed === false) {
+      return {
+        text: `"${market?.question ?? conditionId}" is not closed/resolved yet — redeeming now would revert ` +
+          `on-chain. Wait for resolution, then re-run action:"redeem".`,
+        isError: true,
+      };
+    }
+
     const { target, data } = buildRedeemCall(negRisk, conditionId);
 
     // Balance BEFORE the tx so the success message can report the actual
@@ -151,7 +182,9 @@ export async function redeemPosition(input: { condition_id?: string; confirm?: b
 
     let txHash: string | undefined;
     if (getSigType() === 3) {
-      const res = await sendWalletBatch([{ target, value: "0", data }], owner, "Redeem");
+      const res = await sendWalletBatch([{ target, value: "0", data }], owner, "Redeem", {
+        guidance: 're-run action:"positions" to see whether the position was consumed before retrying',
+      });
       txHash = res.transactionHash;
     } else {
       const account = getPolymarketAccount();

--- a/src/utils/polymarket/relayer.ts
+++ b/src/utils/polymarket/relayer.ts
@@ -17,7 +17,7 @@ import { createWalletClient, http, type Hex } from "viem";
 import { polygon } from "viem/chains";
 import { getPolymarketAccount } from "./client.js";
 import { CLOB_HOST, POLYGON_CHAIN_ID, POLYGON_WRITE_RPC_URL, RELAYER_URL } from "./constants.js";
-import { loadBuilderCreds, loadL2Creds, saveBuilderCreds, saveL2Creds } from "./creds.js";
+import { loadBuilderCreds, loadL2Creds, saveBuilderCreds, saveL2Creds, saveState } from "./creds.js";
 import { deriveApiCreds } from "./l1-auth-1271.js";
 
 export type { DepositWalletCall };
@@ -108,27 +108,72 @@ export async function deployDepositWallet(): Promise<{ transactionHash?: string 
   return { transactionHash: confirmed.transactionHash };
 }
 
+/** How long a signed batch stays executable by the relayer, in seconds. */
+export const BATCH_DEADLINE_SECS = 300;
+
+/** Terminal relayer states — the batch can no longer land after these. */
+const TERMINAL_FAILURE_STATES = ["STATE_FAILED", "STATE_INVALID"];
+
+/** Current relayer-side state of a submitted batch, or undefined if unreachable. */
+export async function getRelayerTransactionState(transactionID: string): Promise<string | undefined> {
+  try {
+    const txns = await (await getRelayClient()).getTransaction(transactionID);
+    return txns?.[0]?.state;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Execute a signed WALLET batch from the deposit wallet (approvals, redeem…).
  * The SDK fetches the nonce, EIP-712-signs the Batch with the local key, and
  * submits; we wait for confirmation.
+ *
+ * `wait()` returns undefined for BOTH an on-chain failure and a poll timeout
+ * (100×2s < the 300s signature deadline), and those need OPPOSITE advice: a
+ * failed batch is safe to retry, a timed-out one is NOT — its signature stays
+ * executable until the deadline, so re-signing a money movement can
+ * double-execute (the withdraw double-spend window from issue #72). On
+ * undefined we ask the relayer which case it is and say so explicitly.
+ *
+ * opts.guidance replaces the generic "re-run setup" advice with per-operation
+ * instructions. opts.trackPendingWithdraw persists the in-flight batch to the
+ * state file so withdraw can refuse to sign a second transfer while the first
+ * may still land (cleared on confirmation or terminal failure).
  */
 export async function sendWalletBatch(
   calls: DepositWalletCall[],
   depositWallet: string,
   description: string,
+  opts?: { guidance?: string; trackPendingWithdraw?: boolean },
 ): Promise<{ transactionHash?: string }> {
-  const deadline = String(Math.floor(Date.now() / 1000) + 300);
-  const response = await (await getRelayClient()).executeDepositWalletBatch(calls, depositWallet, deadline);
+  const deadlineSec = Math.floor(Date.now() / 1000) + BATCH_DEADLINE_SECS;
+  const response = await (await getRelayClient()).executeDepositWalletBatch(calls, depositWallet, String(deadlineSec));
+  if (opts?.trackPendingWithdraw) {
+    saveState({ pendingWithdraw: { transactionID: response.transactionID, deadline: deadlineSec } });
+  }
   const confirmed = await response.wait();
   if (!confirmed) {
-    // wait() returns undefined for BOTH an on-chain failure and a timeout —
-    // "failed" must appear in this message so callers' revert-hint regexes
-    // (e.g. redeem's missing-approval hint) fire on it.
+    const state = await getRelayerTransactionState(response.transactionID);
+    if (state && TERMINAL_FAILURE_STATES.includes(state)) {
+      if (opts?.trackPendingWithdraw) saveState({ pendingWithdraw: undefined });
+      // "failed" must appear here so callers' revert-hint regexes (e.g.
+      // redeem's missing-approval hint) fire on it. Safe to retry.
+      throw new Error(
+        `${description}: relayer batch failed on-chain (tx ${response.transactionID}). ` +
+        `${opts?.guidance ?? 'Re-run action:"setup" to check state and retry.'}`,
+      );
+    }
+    // Unknown or still-pending: the signed batch may STILL land. Deliberately
+    // no "failed"/"revert" wording (this is not a revert), and deliberately
+    // anti-retry advice — pendingWithdraw stays persisted when tracked.
     throw new Error(
-      `${description}: relayer batch failed on-chain or did not confirm (tx ${response.transactionID}). ` +
-      `Re-run action:"setup" to check state and retry.`,
+      `${description}: relayer batch did not confirm within the polling window ` +
+      `(tx ${response.transactionID}, relayer state: ${state ?? "unreachable"}). It may still land — the signed ` +
+      `batch stays executable until its ${BATCH_DEADLINE_SECS / 60}-minute deadline. Do NOT retry yet: wait for ` +
+      `the deadline to pass, then ${opts?.guidance ?? 're-run action:"setup" to re-check state'}.`,
     );
   }
+  if (opts?.trackPendingWithdraw) saveState({ pendingWithdraw: undefined });
   return { transactionHash: confirmed.transactionHash };
 }

--- a/src/utils/polymarket/setup.ts
+++ b/src/utils/polymarket/setup.ts
@@ -267,7 +267,24 @@ async function runSetupDepositWallet(opts: { confirm: boolean }): Promise<{ text
   if (!deployed) {
     const res = await deployDepositWallet();
     deployTxHash = res.transactionHash;
-    deployed = true;
+    // The relayer deployed *something*; only contract code at the CREATE2
+    // address WE derived proves it deployed THIS wallet. If factory/salt ever
+    // diverge between derive and deploy, recording deployed:true here would
+    // point approvals and funding at an address that doesn't exist — stranding
+    // real money (issue #72 finding 4). Retry the read across RPC lag.
+    for (let attempt = 0; attempt < 3 && !deployed; attempt++) {
+      if (attempt > 0) await new Promise((r) => setTimeout(r, 750));
+      const code = await getPublicClient().getCode({ address: depositWallet }).catch(() => undefined);
+      deployed = typeof code === "string" && code !== "0x";
+    }
+    if (!deployed) {
+      throw new Error(
+        `Deposit wallet deploy confirmed (tx ${deployTxHash}) but no contract code is visible at the derived ` +
+        `address ${depositWallet} after 3 reads. Either the RPCs are lagging (re-run action:"setup" in a minute — ` +
+        `it re-checks) or the relayer deployed a different address than we derived, in which case do NOT fund ` +
+        `this wallet until that is resolved.`,
+      );
+    }
   }
   saveState({ deployed: true });
 

--- a/src/utils/polymarket/withdraw.ts
+++ b/src/utils/polymarket/withdraw.ts
@@ -1,8 +1,8 @@
 // src/utils/polymarket/withdraw.ts
 //
-// Cash out: pUSD in the deposit wallet → native USDC on Base, delivered to the
-// BlockRun agent wallet (the same key/address that pays x402 AI fees) — closing
-// the loop. Flow (Polymarket bridge):
+// Cash out: collateral in the deposit wallet → native USDC on Base, delivered
+// to the BlockRun agent wallet (the same key/address that pays x402 AI fees) —
+// closing the loop. Flow (Polymarket bridge):
 //   1. POST /withdraw {address, toChainId, toTokenAddress, recipientAddr} → a
 //      one-time EVM bridge address.
 //   2. Transfer pUSD FROM the deposit wallet TO that bridge address (gasless
@@ -11,6 +11,13 @@
 //   3. The bridge unwraps pUSD → USDC (Collateral Offramp + Uniswap v3) and
 //      sends it to recipientAddr on Base. Instant, no Polymarket fee (minor
 //      swap slippage may apply).
+//
+// Legacy USDC.e: adapter redemptions pay pUSD, but historic direct-CTF
+// redemptions left USDC.e in the wallet, which the bridge does not accept and
+// which action:"withdraw" previously could not see at all. Withdrawable
+// balance is now pUSD + USDC.e; any shortfall beyond the pUSD on hand is
+// wrapped to pUSD through the collateral onramp first (sweep design from
+// @KillerQueen-Z's #59/#66, tracked in #71).
 import axios from "axios";
 import { encodeFunctionData, formatUnits, http, createWalletClient, type Hex } from "viem";
 import { polygon } from "viem/chains";
@@ -18,29 +25,101 @@ import {
   BASE_CHAIN_ID,
   BASE_USDC,
   BRIDGE_API_HOST,
+  COLLATERAL_ONRAMP,
   ERC20_ABI,
   getBuilderCode,
   getSigType,
   POLYGON_WRITE_RPC_URL,
   PUSD_COLLATERAL,
   PUSD_DECIMALS,
+  USDCE_COLLATERAL,
 } from "./constants.js";
 import { getPolymarketAccount } from "./client.js";
 import { assertTransactionSucceeded } from "./transactions.js";
 import type { ToolResult } from "./orders.js";
 import { mapClobError } from "./orders.js";
 import { getFundsAddress } from "./positions.js";
-import { sendWalletBatch } from "./relayer.js";
+import { loadState, saveState } from "./creds.js";
+import { getRelayerTransactionState, sendWalletBatch } from "./relayer.js";
 import { getPublicClient } from "./setup.js";
 
-async function rawPusdBalance(owner: Hex): Promise<bigint> {
+async function rawTokenBalance(token: Hex, owner: Hex): Promise<bigint> {
   return getPublicClient().readContract({
-    address: PUSD_COLLATERAL as Hex,
+    address: token,
     abi: ERC20_ABI,
     functionName: "balanceOf",
     args: [owner],
   });
 }
+
+// wrap(_asset, _to, _amount) — verified against the Sourcify exact-match
+// source of COLLATERAL_ONRAMP (2026-07-21). Pulls `_amount` of `_asset` from
+// the caller (needs the ERC-20 approval batched before it) and mints pUSD to
+// `_to`.
+const COLLATERAL_ONRAMP_ABI = [{
+  type: "function",
+  name: "wrap",
+  stateMutability: "nonpayable",
+  inputs: [
+    { name: "_asset", type: "address" },
+    { name: "_to", type: "address" },
+    { name: "_amount", type: "uint256" },
+  ],
+  outputs: [],
+}] as const;
+
+/** Approve-then-wrap calls for sweeping legacy USDC.e into pUSD. Exported for tests. */
+export function buildLegacyWrapCalls(owner: Hex, amount: bigint): Array<{ target: Hex; value: "0"; data: Hex }> {
+  return [
+    {
+      target: USDCE_COLLATERAL as Hex,
+      value: "0",
+      data: encodeFunctionData({ abi: ERC20_ABI, functionName: "approve", args: [COLLATERAL_ONRAMP as Hex, amount] }),
+    },
+    {
+      target: COLLATERAL_ONRAMP as Hex,
+      value: "0",
+      data: encodeFunctionData({ abi: COLLATERAL_ONRAMP_ABI, functionName: "wrap", args: [USDCE_COLLATERAL as Hex, owner, amount] }),
+    },
+  ];
+}
+
+/**
+ * Parse a dollar amount into micro-pUSD without silently changing what the
+ * caller asked for. The old `BigInt(Math.floor(usd * 1e6))` truncated float
+ * noise downward — `19.99 * 1e6` is 19_989_999.999…, i.e. a cent less than
+ * requested. Round to the nearest micro-dollar and reject anything that isn't
+ * representable (over-precision, negatives, NaN). Exported for tests.
+ */
+export function parseUsdAmount(amount: number): bigint | null {
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+  const scaled = amount * 10 ** PUSD_DECIMALS;
+  const rounded = Math.round(scaled);
+  // 0.01 micro-dollars separates the two populations cleanly: float noise on a
+  // representable amount is ≤ ~1e-4 micro even at $1M (ulp-scale), while a
+  // genuine 7th-decimal digit is ≥ 0.1 micro. An absolute 1e-7 bound (the
+  // first draft) sat BELOW the noise floor and rejected honest amounts like
+  // $1234.56 (noise 2.4e-7); a relative bound sat above real violations.
+  if (!Number.isSafeInteger(rounded) || rounded <= 0 || Math.abs(scaled - rounded) > 0.01) {
+    return null;
+  }
+  return BigInt(rounded);
+}
+
+/** Re-read pUSD until it reaches `minimum` (post-wrap RPC lag), 3×750ms. */
+async function readPusdUntil(owner: Hex, minimum: bigint): Promise<bigint> {
+  let observed = 0n;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, 750));
+    observed = await rawTokenBalance(PUSD_COLLATERAL as Hex, owner);
+    if (observed >= minimum) return observed;
+  }
+  return observed;
+}
+
+const WITHDRAW_GUIDANCE =
+  'check the pUSD balance with action:"setup" and the bridge status endpoint before ANY retry — ' +
+  "a resubmitted withdrawal signs a SECOND transfer and can double-send";
 
 interface WithdrawInput {
   amount_usd?: number;
@@ -58,33 +137,98 @@ export async function withdrawFunds(input: WithdrawInput): Promise<ToolResult> {
   const recipient = (input.to_address as Hex) || getPolymarketAccount().address;
 
   try {
-    // Amount: explicit amount_usd, else the full pUSD balance.
-    const balanceRaw = await rawPusdBalance(owner);
-    const balanceUsd = Number(formatUnits(balanceRaw, PUSD_DECIMALS));
-    if (balanceRaw === 0n) {
-      return { text: `No pUSD to withdraw — the deposit wallet ${owner} holds $0. (Redeem/sell a position first.)`, isError: true };
+    // Refuse to sign while an earlier withdrawal batch may still land: its
+    // signature stays executable until its deadline, and a second signed
+    // transfer on top of it double-sends (issue #72 finding 1). Resolved
+    // states clear the guard; the balance reads below then reflect reality.
+    const pending = loadState().pendingWithdraw;
+    if (pending && input.confirm === true) {
+      const graceSec = 60; // relayer can mine right at the deadline; don't race it
+      if (Math.floor(Date.now() / 1000) < pending.deadline + graceSec) {
+        const state = await getRelayerTransactionState(pending.transactionID);
+        if (state === "STATE_MINED" || state === "STATE_CONFIRMED" || state === "STATE_FAILED" || state === "STATE_INVALID") {
+          saveState({ pendingWithdraw: undefined });
+        } else {
+          const waitSecs = pending.deadline + graceSec - Math.floor(Date.now() / 1000);
+          return {
+            text: `A previous withdrawal (relayer tx ${pending.transactionID}, state: ${state ?? "unreachable"}) ` +
+              `may still execute — its signed transfer stays valid for up to ~${waitSecs}s more. Signing another ` +
+              `one now could double-send. Re-run after that window, when the balance reads will show what happened.`,
+            isError: true,
+          };
+        }
+      } else {
+        saveState({ pendingWithdraw: undefined }); // deadline long past — expired, safe
+      }
     }
-    const amountRaw = input.amount_usd !== undefined
-      ? BigInt(Math.floor(input.amount_usd * 10 ** PUSD_DECIMALS))
-      : balanceRaw;
-    if (amountRaw > balanceRaw) {
-      return { text: `Requested $${input.amount_usd} exceeds the pUSD balance of $${balanceUsd.toFixed(2)}.`, isError: true };
+
+    // Withdrawable = pUSD + legacy USDC.e (wrapped on demand below).
+    const [pusdRaw, usdceRaw] = await Promise.all([
+      rawTokenBalance(PUSD_COLLATERAL as Hex, owner),
+      rawTokenBalance(USDCE_COLLATERAL as Hex, owner),
+    ]);
+    const totalRaw = pusdRaw + usdceRaw;
+    const totalUsd = Number(formatUnits(totalRaw, PUSD_DECIMALS));
+    if (totalRaw === 0n) {
+      return { text: `No pUSD or USDC.e to withdraw — the deposit wallet ${owner} holds $0. (Redeem/sell a position first.)`, isError: true };
+    }
+    const amountRaw = input.amount_usd !== undefined ? parseUsdAmount(input.amount_usd) : totalRaw;
+    if (amountRaw === null) {
+      return { text: `amount_usd must be a positive USD amount with at most ${PUSD_DECIMALS} decimal places.`, isError: true };
+    }
+    if (amountRaw > totalRaw) {
+      return { text: `Requested $${input.amount_usd} exceeds the withdrawable collateral balance of $${totalUsd.toFixed(2)}.`, isError: true };
     }
     const amountUsd = Number(formatUnits(amountRaw, PUSD_DECIMALS));
+    const wrapRaw = amountRaw > pusdRaw ? amountRaw - pusdRaw : 0n;
 
     if (input.confirm !== true) {
       return {
         text: [
           `DRY RUN — nothing withdrawn.`,
-          `Withdraw $${amountUsd.toFixed(2)} pUSD → native USDC on Base`,
+          `Withdraw $${amountUsd.toFixed(2)} → native USDC on Base`,
           `  from deposit wallet: ${owner}`,
           `  to (agent wallet): ${recipient}`,
+          ...(wrapRaw > 0n
+            ? [``, `  First wrap: $${Number(formatUnits(wrapRaw, PUSD_DECIMALS)).toFixed(2)} legacy USDC.e → pUSD (collateral onramp, same wallet)`]
+            : []),
           ``,
           `pUSD is unwrapped to USDC (Uniswap v3 — minor slippage may apply); instant, no Polymarket fee.`,
           `Re-call with confirm:true to execute.`,
         ].join("\n"),
-        structured: { dryRun: true, amountUsd, from: owner, to: recipient, toChainId: BASE_CHAIN_ID, toToken: BASE_USDC },
+        structured: {
+          dryRun: true, amountUsd, from: owner, to: recipient, toChainId: BASE_CHAIN_ID, toToken: BASE_USDC,
+          pusdUsd: Number(formatUnits(pusdRaw, PUSD_DECIMALS)),
+          usdceUsd: Number(formatUnits(usdceRaw, PUSD_DECIMALS)),
+          wrapUsd: Number(formatUnits(wrapRaw, PUSD_DECIMALS)),
+        },
       };
+    }
+
+    // 0. Sweep legacy USDC.e → pUSD when the pUSD on hand can't cover the
+    //    amount. Wrapping keeps funds in the SAME wallet (a re-run after a
+    //    partial failure is safe), so this batch is not double-spend-tracked.
+    if (wrapRaw > 0n) {
+      const [approveCall, wrapCall] = buildLegacyWrapCalls(owner, wrapRaw);
+      if (getSigType() === 3) {
+        await sendWalletBatch([approveCall, wrapCall], owner, "Wrap legacy USDC.e", {
+          guidance: 're-run action:"withdraw" — wrapping keeps funds in your wallet, so retrying is safe',
+        });
+      } else {
+        const account = getPolymarketAccount();
+        const wallet = createWalletClient({ account, chain: polygon, transport: http(POLYGON_WRITE_RPC_URL) });
+        const approveHash = await wallet.sendTransaction({ to: approveCall.target, data: approveCall.data, chain: polygon, account });
+        assertTransactionSucceeded(await getPublicClient().waitForTransactionReceipt({ hash: approveHash }), "USDC.e approval", approveHash);
+        const wrapHash = await wallet.sendTransaction({ to: wrapCall.target, data: wrapCall.data, chain: polygon, account });
+        assertTransactionSucceeded(await getPublicClient().waitForTransactionReceipt({ hash: wrapHash }), "USDC.e wrap", wrapHash);
+      }
+      const normalizedPusd = await readPusdUntil(owner, amountRaw);
+      if (normalizedPusd < amountRaw) {
+        throw new Error(
+          "The USDC.e wrap confirmed but the required pUSD balance is not yet visible after 3 reads. " +
+          "Your funds are in your wallet (wrapping moves nothing out) — re-run action:\"withdraw\" in a minute.",
+        );
+      }
     }
 
     // 1. Ask the bridge for a one-time deposit address for this withdrawal.
@@ -105,7 +249,10 @@ export async function withdrawFunds(input: WithdrawInput): Promise<ToolResult> {
     const data = encodeFunctionData({ abi: ERC20_ABI, functionName: "transfer", args: [bridgeEvm, amountRaw] });
     let txHash: string | undefined;
     if (getSigType() === 3) {
-      const res = await sendWalletBatch([{ target: PUSD_COLLATERAL, value: "0", data }], owner, "Withdraw");
+      const res = await sendWalletBatch([{ target: PUSD_COLLATERAL, value: "0", data }], owner, "Withdraw", {
+        guidance: WITHDRAW_GUIDANCE,
+        trackPendingWithdraw: true,
+      });
       txHash = res.transactionHash;
     } else {
       const account = getPolymarketAccount();
@@ -115,8 +262,8 @@ export async function withdrawFunds(input: WithdrawInput): Promise<ToolResult> {
       // Discarding the receipt meant a REVERTED pUSD transfer still printed
       // "✅ Withdrawal submitted … the bridge delivers USDC to Base" with a link
       // to the failed tx and no isError, so the user waited for money that was
-      // never sent and blamed the bridge. redeem.ts:148 and setup.ts:379 both
-      // assert status; this path was the one that did not.
+      // never sent and blamed the bridge. redeem.ts and setup.ts both assert
+      // status; this path was the one that did not.
       assertTransactionSucceeded(
         await getPublicClient().waitForTransactionReceipt({ hash: txHash as Hex }),
         "pUSD transfer",
@@ -126,7 +273,8 @@ export async function withdrawFunds(input: WithdrawInput): Promise<ToolResult> {
 
     return {
       text: [
-        `✅ Withdrawal submitted: $${amountUsd.toFixed(2)} pUSD → USDC on Base`,
+        `✅ Withdrawal submitted: $${amountUsd.toFixed(2)} → USDC on Base`,
+        ...(wrapRaw > 0n ? [`  (included wrapping $${Number(formatUnits(wrapRaw, PUSD_DECIMALS)).toFixed(2)} legacy USDC.e → pUSD first)`] : []),
         `  to your agent wallet: ${recipient}`,
         ...(txHash ? [`  pUSD transfer tx: https://polygonscan.com/tx/${txHash}`] : []),
         `  The bridge unwraps + delivers USDC to Base (usually within a minute).`,
@@ -135,6 +283,7 @@ export async function withdrawFunds(input: WithdrawInput): Promise<ToolResult> {
       structured: {
         amountUsd, from: owner, to: recipient, toChainId: BASE_CHAIN_ID, toToken: BASE_USDC,
         bridgeAddress: bridgeEvm, transactionHash: txHash,
+        ...(wrapRaw > 0n ? { wrappedUsdceUsd: Number(formatUnits(wrapRaw, PUSD_DECIMALS)) } : {}),
       },
     };
   } catch (err) {

--- a/test/polymarket-orders.test.ts
+++ b/test/polymarket-orders.test.ts
@@ -90,3 +90,17 @@ test("mapClobError: resolved market suggests positions/redeem; FOK suggests FAK"
   assert.match(await mapClobError({ message: "market is closed" }), /positions.*redeem/s);
   assert.match(await mapClobError({ message: "FOK order not filled" }), /FAK|limit order/);
 });
+
+// Float-division noise regression (issue #72 finding 7): prices ALREADY on the
+// tick grid must survive rounding unchanged. 0.58/0.001 is 579.9999… (floor
+// alone → 0.579, one tick below the stated buy limit) and 0.42/0.01 is
+// 42.000…01 (ceil alone → 0.43, one tick above the stated sell limit).
+test("roundToTick leaves on-grid prices unchanged despite float noise", () => {
+  assert.equal(roundToTick(0.58, "0.001", "buy"), 0.58);
+  assert.equal(roundToTick(0.42, "0.01", "sell"), 0.42);
+  assert.equal(roundToTick(0.58, "0.001", "sell"), 0.58);
+  assert.equal(roundToTick(0.42, "0.01", "buy"), 0.42);
+  // Genuine off-grid prices still round conservatively by side.
+  assert.equal(roundToTick(0.5849, "0.001", "buy"), 0.584);
+  assert.equal(roundToTick(0.4251, "0.01", "sell"), 0.43);
+});

--- a/test/polymarket-relayer-batch.test.ts
+++ b/test/polymarket-relayer-batch.test.ts
@@ -1,0 +1,124 @@
+// Pins sendWalletBatch's disambiguation of `wait()` returning undefined
+// (issue #72 finding 1): the SDK returns undefined for BOTH an on-chain
+// failure and a poll timeout, and those need OPPOSITE advice — a failed batch
+// is safe to retry, a timed-out one is NOT (its signature stays executable
+// until the 300s deadline, so re-signing a withdrawal can double-send). Also
+// pins the pendingWithdraw tracking lifecycle the withdraw guard depends on.
+import { test, mock } from "node:test";
+import assert from "node:assert/strict";
+
+let waitResult: { transactionHash?: string } | undefined;
+let txnState: string | undefined;
+let getTransactionThrows = false;
+let stateFile: Record<string, unknown> = {};
+const saveStateCalls: Array<Record<string, unknown>> = [];
+
+class FakeRelayClient {
+  async executeDepositWalletBatch() {
+    return {
+      transactionID: "batch-1",
+      wait: async () => waitResult,
+      getTransaction: async () => [],
+    };
+  }
+  async getTransaction() {
+    if (getTransactionThrows) throw new Error("relayer 502");
+    return txnState ? [{ state: txnState, transactionHash: "0x" + "cd".repeat(32) }] : [];
+  }
+}
+
+mock.module("@polymarket/builder-relayer-client", {
+  namedExports: { RelayClient: FakeRelayClient },
+});
+mock.module("../src/utils/polymarket/client.js", {
+  namedExports: {
+    getPolymarketAccount: () => ({ address: "0xCC8c44AD3dc2A58D841c3EB26131E49b22665EF8" }),
+    checkGeoblock: async () => ({ orderPlacement: "permitted", country: "FI", ip: null, raw: {} }),
+    getClobClient: async () => { throw new Error("not used"); },
+    resetClobClient: () => {},
+    getClobProxyAgent: () => null,
+    installUnderscoreHeaderBridge: () => {},
+  },
+});
+mock.module("../src/utils/polymarket/creds.js", {
+  namedExports: {
+    // Cached builder creds → getRelayClient never touches the CLOB.
+    loadBuilderCreds: () => ({ key: "k", secret: "s", passphrase: "p", createdAt: "" }),
+    saveBuilderCreds: () => {},
+    loadL2Creds: () => null,
+    saveL2Creds: () => {},
+    invalidateL2Creds: () => {},
+    loadDepositWalletForSigner: () => undefined,
+    loadState: () => ({ ...stateFile }),
+    saveState: (patch: Record<string, unknown>) => {
+      saveStateCalls.push(patch);
+      stateFile = { ...stateFile, ...patch };
+      return stateFile;
+    },
+  },
+});
+
+const { sendWalletBatch } = await import("../src/utils/polymarket/relayer.js");
+const DEPOSIT = "0x5d3eaa66AE01F1a907c8e0970D1D021C6Ff8EB26";
+const CALLS = [{ target: DEPOSIT, value: "0", data: "0x" }] as never;
+
+function reset() {
+  waitResult = undefined;
+  txnState = undefined;
+  getTransactionThrows = false;
+  stateFile = {};
+  saveStateCalls.length = 0;
+}
+
+test("a confirmed batch returns its hash and clears tracked pending state", async () => {
+  reset();
+  waitResult = { transactionHash: "0x" + "ab".repeat(32) };
+  const res = await sendWalletBatch(CALLS, DEPOSIT, "Withdraw", { trackPendingWithdraw: true });
+  assert.equal(res.transactionHash, "0x" + "ab".repeat(32));
+  // Tracked while in flight (so a crash mid-wait leaves the guard armed)…
+  assert.ok(saveStateCalls.some((p) => (p.pendingWithdraw as { transactionID?: string })?.transactionID === "batch-1"));
+  // …and cleared on confirmation.
+  assert.equal(stateFile.pendingWithdraw, undefined);
+});
+
+test("STATE_FAILED reads as a failure — retry-safe wording, guidance included, tracking cleared", async () => {
+  reset();
+  txnState = "STATE_FAILED";
+  await assert.rejects(
+    sendWalletBatch(CALLS, DEPOSIT, "Withdraw", { trackPendingWithdraw: true, guidance: "custom guidance here" }),
+    (err: Error) => {
+      assert.match(err.message, /failed on-chain/);
+      assert.match(err.message, /custom guidance here/);
+      return true;
+    },
+  );
+  assert.equal(stateFile.pendingWithdraw, undefined, "a dead batch must not keep blocking withdrawals");
+});
+
+test("a poll timeout with the batch still pending says DO NOT retry and keeps the guard armed", async () => {
+  reset();
+  txnState = "STATE_NEW";
+  await assert.rejects(
+    sendWalletBatch(CALLS, DEPOSIT, "Withdraw", { trackPendingWithdraw: true }),
+    (err: Error) => {
+      assert.match(err.message, /did not confirm within the polling window/);
+      assert.match(err.message, /Do NOT retry/);
+      assert.doesNotMatch(err.message, /failed/, "pending is not a failure — 'failed' would fire revert-hint regexes");
+      return true;
+    },
+  );
+  assert.ok(stateFile.pendingWithdraw, "the in-flight batch must stay tracked");
+});
+
+test("an unreachable relayer after timeout is treated as pending — the conservative side", async () => {
+  reset();
+  getTransactionThrows = true;
+  await assert.rejects(
+    sendWalletBatch(CALLS, DEPOSIT, "Redeem"),
+    (err: Error) => {
+      assert.match(err.message, /relayer state: unreachable/);
+      assert.match(err.message, /Do NOT retry/);
+      return true;
+    },
+  );
+});

--- a/test/polymarket-withdraw.test.ts
+++ b/test/polymarket-withdraw.test.ts
@@ -1,14 +1,21 @@
 // Run with: npm test  (tsx --experimental-test-module-mocks --test)
 //
-// Withdraw dry-run + amount validation (the confirm path hits the bridge/relayer
-// and is exercised in the live integration run, not here). Deps are mocked so no
-// network/RPC.
+// Withdraw dry-run, amount validation, the legacy USDC.e sweep, and the
+// double-spend guard (the confirm path's bridge/relayer calls are exercised in
+// the live e2e scripts, not here). Deps are mocked so no network/RPC.
 import { test, mock } from "node:test";
 import assert from "node:assert/strict";
+import { decodeFunctionData } from "viem";
+import { COLLATERAL_ONRAMP, ERC20_ABI, USDCE_COLLATERAL } from "../src/utils/polymarket/constants.js";
 
 const DEPOSIT = "0x5d3eaa66AE01F1a907c8e0970D1D021C6Ff8EB26";
 const AGENT = "0xCC8c44AD3dc2A58D841c3EB26131E49b22665EF8";
-let balanceRaw = 7_500_000n; // $7.50 pUSD (6 decimals)
+let pusdRaw = 7_500_000n; // $7.50 pUSD (6 decimals)
+let usdceRaw = 0n;
+
+// Mutable state-file + relayer doubles so the double-spend guard is testable.
+let stateFile: Record<string, unknown> = {};
+let relayerState: string | undefined;
 
 mock.module("../src/utils/polymarket/positions.js", {
   namedExports: { getFundsAddress: () => DEPOSIT },
@@ -16,9 +23,11 @@ mock.module("../src/utils/polymarket/positions.js", {
 mock.module("../src/utils/polymarket/setup.js", {
   namedExports: {
     getPublicClient: () => ({
-      readContract: async () => balanceRaw,
-      waitForTransactionReceipt: async () => ({}),
+      readContract: async ({ address }: { address: string }) =>
+        address.toLowerCase() === USDCE_COLLATERAL.toLowerCase() ? usdceRaw : pusdRaw,
+      waitForTransactionReceipt: async () => ({ status: "success" }),
     }),
+    getPusdBalance: async () => Number(pusdRaw) / 1e6,
   },
 });
 // client.js is imported (transitively via orders.js/relayer.js) for several
@@ -33,11 +42,38 @@ mock.module("../src/utils/polymarket/client.js", {
     installUnderscoreHeaderBridge: () => {},
   },
 });
+mock.module("../src/utils/polymarket/creds.js", {
+  namedExports: {
+    loadState: () => ({ ...stateFile }),
+    saveState: (patch: Record<string, unknown>) => { stateFile = { ...stateFile, ...patch }; return stateFile; },
+    loadDepositWalletForSigner: () => DEPOSIT,
+    loadL2Creds: () => null,
+    saveL2Creds: () => {},
+    invalidateL2Creds: () => {},
+    loadBuilderCreds: () => null,
+    saveBuilderCreds: () => {},
+  },
+});
+mock.module("../src/utils/polymarket/relayer.js", {
+  namedExports: {
+    sendWalletBatch: async () => ({ transactionHash: "0x" + "ab".repeat(32) }),
+    getRelayerTransactionState: async () => relayerState,
+    BATCH_DEADLINE_SECS: 300,
+  },
+});
+// The confirm path's first network touch is the bridge POST — fail it loudly
+// so tests can prove the guard LET a call through without real I/O.
+mock.module("axios", {
+  defaultExport: {
+    post: async () => { throw new Error("bridge offline (test)"); },
+    get: async () => { throw new Error("bridge offline (test)"); },
+  },
+});
 
-const { withdrawFunds } = await import("../src/utils/polymarket/withdraw.js");
+const { buildLegacyWrapCalls, parseUsdAmount, withdrawFunds } = await import("../src/utils/polymarket/withdraw.js");
 
 test("no confirm → dry-run previews full balance to the agent wallet on Base", async () => {
-  balanceRaw = 7_500_000n;
+  pusdRaw = 7_500_000n; usdceRaw = 0n; stateFile = {};
   const res = await withdrawFunds({});
   assert.equal(res.isError, undefined, res.text);
   assert.match(res.text, /DRY RUN/);
@@ -49,28 +85,143 @@ test("no confirm → dry-run previews full balance to the agent wallet on Base",
 });
 
 test("amount_usd caps the withdrawal to that amount", async () => {
-  balanceRaw = 7_500_000n;
+  pusdRaw = 7_500_000n; usdceRaw = 0n; stateFile = {};
   const res = await withdrawFunds({ amount_usd: 3 });
   assert.match(res.text, /\$3\.00/);
 });
 
 test("amount above balance is rejected", async () => {
-  balanceRaw = 7_500_000n;
+  pusdRaw = 7_500_000n; usdceRaw = 0n; stateFile = {};
   const res = await withdrawFunds({ amount_usd: 10 });
   assert.equal(res.isError, true);
-  assert.match(res.text, /exceeds the pUSD balance/);
+  assert.match(res.text, /exceeds the withdrawable collateral balance/);
 });
 
-test("nothing to withdraw when balance is zero", async () => {
-  balanceRaw = 0n;
+test("nothing to withdraw when both balances are zero", async () => {
+  pusdRaw = 0n; usdceRaw = 0n; stateFile = {};
   const res = await withdrawFunds({});
   assert.equal(res.isError, true);
-  assert.match(res.text, /No pUSD to withdraw/);
+  assert.match(res.text, /No pUSD or USDC\.e to withdraw/);
 });
 
 test("custom to_address overrides the destination", async () => {
-  balanceRaw = 5_000_000n;
+  pusdRaw = 5_000_000n; usdceRaw = 0n; stateFile = {};
   const other = "0x1111111111111111111111111111111111111111";
   const res = await withdrawFunds({ to_address: other });
   assert.match(res.text, new RegExp(other));
+});
+
+// --- Legacy USDC.e sweep (issue #71, design from #59/#66) ---
+
+test("legacy USDC.e counts toward the balance and previews as a wrap", async () => {
+  pusdRaw = 2_000_000n; usdceRaw = 3_000_000n; stateFile = {};
+  const res = await withdrawFunds({});
+  assert.equal(res.isError, undefined, res.text);
+  assert.match(res.text, /\$5\.00/);
+  assert.match(res.text, /First wrap: \$3\.00 legacy USDC\.e → pUSD/);
+  assert.equal((res.structured as { wrapUsd?: number }).wrapUsd, 3);
+  assert.equal((res.structured as { pusdUsd?: number }).pusdUsd, 2);
+  assert.equal((res.structured as { usdceUsd?: number }).usdceUsd, 3);
+});
+
+test("no wrap is previewed when pUSD alone covers the amount", async () => {
+  pusdRaw = 5_000_000n; usdceRaw = 3_000_000n; stateFile = {};
+  const res = await withdrawFunds({ amount_usd: 4 });
+  assert.equal(res.isError, undefined, res.text);
+  assert.doesNotMatch(res.text, /First wrap/);
+  assert.equal((res.structured as { wrapUsd?: number }).wrapUsd, 0);
+});
+
+test("the wrap batch is approve → exact-amount wrap, pinned by calldata", () => {
+  const amount = 3_000_000n;
+  const [approve, wrap] = buildLegacyWrapCalls(DEPOSIT, amount);
+  assert.equal(approve.target.toLowerCase(), USDCE_COLLATERAL.toLowerCase());
+  assert.equal(wrap.target.toLowerCase(), COLLATERAL_ONRAMP.toLowerCase());
+  const decodedApprove = decodeFunctionData({ abi: ERC20_ABI, data: approve.data });
+  assert.equal(decodedApprove.functionName, "approve");
+  assert.deepEqual(decodedApprove.args, [COLLATERAL_ONRAMP, amount]);
+  const decodedWrap = decodeFunctionData({
+    abi: [{ type: "function", name: "wrap", stateMutability: "nonpayable", inputs: [
+      { name: "_asset", type: "address" }, { name: "_to", type: "address" }, { name: "_amount", type: "uint256" },
+    ], outputs: [] }] as const,
+    data: wrap.data,
+  });
+  assert.equal(decodedWrap.functionName, "wrap");
+  assert.deepEqual(decodedWrap.args, [USDCE_COLLATERAL, DEPOSIT, amount]);
+});
+
+// --- Amount parsing (precision must never silently change the request) ---
+
+test("parseUsdAmount rounds to the exact micro-dollar, not down through float noise", () => {
+  // 19.99 * 1e6 is 19_989_999.999…; the old floor lost a cent.
+  assert.equal(parseUsdAmount(19.99), 19_990_000n);
+  assert.equal(parseUsdAmount(2), 2_000_000n);
+  assert.equal(parseUsdAmount(0.000001), 1n);
+});
+
+test("rejects non-positive and over-precision amounts before any network call", async () => {
+  pusdRaw = 7_500_000n; usdceRaw = 0n; stateFile = {};
+  for (const amount_usd of [0, -1, 1.0000001, Number.NaN]) {
+    const res = await withdrawFunds({ amount_usd });
+    assert.equal(res.isError, true, `amount ${amount_usd} should be rejected`);
+    assert.match(res.text, /positive USD amount/);
+  }
+});
+
+// --- Double-spend guard (issue #72 finding 1) ---
+
+const futureDeadline = () => Math.floor(Date.now() / 1000) + 200;
+
+test("an unresolved in-flight withdrawal blocks signing a second one", async () => {
+  pusdRaw = 7_500_000n; usdceRaw = 0n;
+  stateFile = { pendingWithdraw: { transactionID: "relayer-tx-1", deadline: futureDeadline() } };
+  relayerState = "STATE_NEW"; // still executable
+  const res = await withdrawFunds({ amount_usd: 2, confirm: true });
+  assert.equal(res.isError, true);
+  assert.match(res.text, /may still execute/);
+  assert.match(res.text, /double-send/);
+});
+
+test("an unreachable relayer counts as unresolved — conservative side", async () => {
+  pusdRaw = 7_500_000n; usdceRaw = 0n;
+  stateFile = { pendingWithdraw: { transactionID: "relayer-tx-1", deadline: futureDeadline() } };
+  relayerState = undefined;
+  const res = await withdrawFunds({ amount_usd: 2, confirm: true });
+  assert.equal(res.isError, true);
+  assert.match(res.text, /double-send/);
+});
+
+test("a resolved (mined) in-flight withdrawal clears the guard and proceeds", async () => {
+  pusdRaw = 7_500_000n; usdceRaw = 0n;
+  stateFile = { pendingWithdraw: { transactionID: "relayer-tx-1", deadline: futureDeadline() } };
+  relayerState = "STATE_MINED";
+  const res = await withdrawFunds({ amount_usd: 2, confirm: true });
+  // Proceeding means reaching the bridge POST, which the axios mock fails loudly.
+  assert.equal(res.isError, true);
+  assert.match(res.text, /bridge offline \(test\)/);
+  assert.equal(stateFile.pendingWithdraw, undefined, "guard must be cleared");
+});
+
+test("an expired deadline clears the guard and proceeds", async () => {
+  pusdRaw = 7_500_000n; usdceRaw = 0n;
+  stateFile = { pendingWithdraw: { transactionID: "relayer-tx-1", deadline: Math.floor(Date.now() / 1000) - 3600 } };
+  relayerState = "STATE_NEW";
+  const res = await withdrawFunds({ amount_usd: 2, confirm: true });
+  assert.match(res.text, /bridge offline \(test\)/);
+  assert.equal(stateFile.pendingWithdraw, undefined);
+});
+
+test("the guard never blocks dry-runs", async () => {
+  pusdRaw = 7_500_000n; usdceRaw = 0n;
+  stateFile = { pendingWithdraw: { transactionID: "relayer-tx-1", deadline: futureDeadline() } };
+  relayerState = "STATE_NEW";
+  const res = await withdrawFunds({});
+  assert.equal(res.isError, undefined, res.text);
+  assert.match(res.text, /DRY RUN/);
+});
+
+test("parseUsdAmount accepts amounts whose float noise exceeds a naive absolute bound", () => {
+  // 1234.56 * 1e6 = 1_234_559_999.9999998 — noise 2.4e-7 micro, which a 1e-7
+  // absolute threshold (the #66 draft) wrongly rejected as over-precision.
+  assert.equal(parseUsdAmount(1234.56), 1_234_560_000n);
 });


### PR DESCRIPTION
Closes #71, closes #72.

## #72 (Kimi K3 review findings, all 8)

1. **Withdraw retry double-spend window (HIGH).** \`wait()\` returns undefined for both failure and timeout while the signed batch stays executable until its 300s deadline — and our error advised "re-run". Now \`sendWalletBatch\` queries the relayer state and answers precisely (failure = retry-safe; pending = "Do NOT retry" + remaining window), withdrawal batches are tracked in the state file, and \`action:"withdraw"\` refuses to sign a second transfer while one may still land. Unreachable relayer counts as pending — the conservative side.
2. ClobClient cache key includes the deposit wallet (stale \`funderAddress\` after a wallet change).
3. Redeem no longer treats a missing \`neg_risk\` as "standard": cross-checks the order book, refuses to guess if both are silent.
4. Setup verifies contract code exists at the DERIVED CREATE2 address (3×750ms) before recording \`deployed:true\`.
5. Per-operation guidance replaces the hardcoded 're-run setup' in batch failure messages.
6. Redeem confirm path refuses unresolved markets up front (previously submitted a guaranteed on-chain revert).
7. \`roundToTick\` epsilon: on-grid prices survive float-division noise (0.58@0.001 no longer signs as 0.579).
8. Creds/state writes are atomic (tmp+rename).

## #71 (unabsorbed pieces of @KillerQueen-Z's #59/#66)

- **Legacy USDC.e sweep on withdraw**: withdrawable = pUSD + USDC.e, shortfall wrapped through the collateral onramp first. \`wrap(address,address,uint256)\` verified against the onramp's Sourcify exact-match source (2026-07-21). Includes the #66 amount-parsing fix, with the tolerance corrected: the draft's absolute 1e-7 bound sat below the float-noise floor and rejected honest amounts like \$1234.56 (noise 2.4e-7); 0.01 micro-dollars cleanly separates noise (≤1e-4) from genuine over-precision (≥0.1).
- **Bounded e2e scripts** in-tree as \`npm run e2e:polymarket:{readonly,approvals,approve,withdraw,live}\` (live script's success check updated for the tri-state redeem statuses).

## Verification

- 250/250 tests (17 new: batch-state disambiguation + tracking lifecycle, double-spend guard incl. unreachable-relayer and expired-deadline cases, sweep preview + calldata pinning, amount parsing, tick rounding), typecheck, build green.
- Live: \`e2e:polymarket:readonly\` and \`e2e:polymarket:approvals\` ran against the local wallet — both agree with the independently verified on-chain state (empty wallet, redeem adapters 5/5).