### PR TITLE
0.32.10 — take the two Polymarket SDK majors, on one verified baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,10 @@ CLOB module and Franklin's port of it share one baseline again.
 
 Neither upgrade adds a transitive dependency: clob-client-v2's dependency set is
 identical between the two versions, and builder-signing-sdk's is strictly
-smaller. 250 tests, typecheck and build green, plus a CLI load smoke
-(`node dist/index.js --version`) since a broken module graph is exactly the class
-of failure 0.32.3 shipped.
+smaller. 282 tests, typecheck, build and brand-numbers `--check` green, plus an
+MCP stdio smoke (20 tools listed) and the CLI load smoke without `sharp` — which
+CI now runs on every pull request rather than only here, since a broken module
+graph is exactly the class of failure 0.32.3 shipped.
 
 ## 0.36.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 All notable changes to BlockRun MCP will be documented in this file.
 
+## 0.37.0
+
+Takes the two Polymarket SDK majors that had been sitting unreviewed, so the
+CLOB module and Franklin's port of it share one baseline again.
+
+- **`chore(deps)` — `@polymarket/clob-client-v2` 1.0.8 → 1.1.0.** `postOrder`
+  gained `waitForResolvedTrades`: when an order matches, the client now
+  back-fills the settlement transaction hashes of its fills, and the return type
+  tightens from `Promise<any>` to `Promise<OrderResponse>`. `orders.ts` already
+  read `transactionsHashes` and `tradeIDs` off the response, so this makes an
+  existing display path more often correct rather than changing it — `filled` and
+  the `tx:` line now resolve on matched orders instead of only when the server
+  happened to include them.
+
+  Verified against the shipped bundle rather than the release notes, because no
+  test here places an order: an unmatched order returns untouched with zero polls
+  and zero added latency (the resting-limit path is unaffected); a response that
+  already carries hashes short-circuits; `FAILED` trades are filtered out, so a
+  failed fill can never be reported as a settlement hash; and the worst case —
+  `getTrades` failing persistently — was measured end to end at **30.1 s**
+  (`RESOLVE_TRADES_TIMEOUT_MS`, 250 ms poll), after which it degrades and returns
+  the placed order rather than throwing. The added latency lands only on matched
+  orders, and it is bounded.
+
+- **`chore(deps)` — `@polymarket/builder-signing-sdk` 0.0.8 → 1.0.0, with an
+  override.** 1.0.0 is a pure CJS→ESM port: every non-import change in the bundle
+  is `exports.X` → `export` boilerplate, the HMAC signing logic is untouched, and
+  it drops `tslib` plus a stale `@types/node ^18` that should never have been a
+  runtime dependency.
+
+  It needs an `overrides` entry because `@polymarket/builder-relayer-client`
+  still pins `^0.0.8`, and a caret on `0.0.x` is patch-only under npm semver — so
+  without it npm installs a second copy, and both `BuilderConfig` declarations
+  carry a private `ensureValid`, which TypeScript compares nominally. Collapsing
+  to one copy is safe for a specific reason worth recording: relayer-client
+  **never requires the signing SDK at runtime**. It is a type-only dependency,
+  consumed by duck-typing (`builderConfig.generateBuilderHeaders()`,
+  `.isValid()`), with no `instanceof` check anywhere in its bundle, and nothing
+  else in the tree requires it either. The CJS/ESM seam was then exercised for
+  real: a 1.0.0 `BuilderConfig` handed to the CJS `RelayClient` produced correct
+  `POLY_BUILDER_*` headers across the boundary.
+
+  Note that npm `overrides` do not propagate to consumers, so an installed
+  `@blockrun/mcp` gets both copies on disk. That is harmless for the same reason
+  — nothing loads the nested one.
+
+Neither upgrade adds a transitive dependency: clob-client-v2's dependency set is
+identical between the two versions, and builder-signing-sdk's is strictly
+smaller. 250 tests, typecheck and build green, plus a CLI load smoke
+(`node dist/index.js --version`) since a broken module graph is exactly the class
+of failure 0.32.3 shipped.
+
 ## 0.36.0
 
 Live-probes the three pre-payment rules 0.33.0 shipped on inference rather than

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/mcp",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
         "@blockrun/llm": "^3.8.4",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@polymarket/builder-relayer-client": "^0.0.10",
-        "@polymarket/builder-signing-sdk": "0.0.8",
-        "@polymarket/clob-client-v2": "1.0.8",
+        "@polymarket/builder-signing-sdk": "1.0.0",
+        "@polymarket/clob-client-v2": "1.1.0",
         "@solana/spl-token": "^0.4.14",
         "@solana/web3.js": "^1.98.4",
         "axios": "^1.18.1",
@@ -1896,35 +1896,18 @@
       }
     },
     "node_modules/@polymarket/builder-signing-sdk": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@polymarket/builder-signing-sdk/-/builder-signing-sdk-0.0.8.tgz",
-      "integrity": "sha512-rZLCFxEdYahl5FiJmhe22RDXysS1ibFJlWz4NT0s3itJRYq3XJzXXHXEZkAQplU+nIS1IlbbKjA4zDQaeCyYtg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@polymarket/builder-signing-sdk/-/builder-signing-sdk-1.0.0.tgz",
+      "integrity": "sha512-LNHc8Ox+2ITM6+VIEH5LH3SVh9ScE2mOUAJI789YfyNqhF4n1cNulk35Hb6IZfy1xtNfcEfNotanPLa/U8dCaw==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^18.7.18",
-        "axios": "^1.12.2",
-        "tslib": "^2.8.1"
+        "axios": "^1.12.2"
       }
-    },
-    "node_modules/@polymarket/builder-signing-sdk/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@polymarket/builder-signing-sdk/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/@polymarket/clob-client-v2": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@polymarket/clob-client-v2/-/clob-client-v2-1.0.8.tgz",
-      "integrity": "sha512-3oMoNJB5/3o46/QCvJjjJwq+kQZ8blLqzLaNsZaYvB7C3WyDOULvWh2lQ62j3xIWQTYbWwolRhbCbeP8fVJwFw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@polymarket/clob-client-v2/-/clob-client-v2-1.1.0.tgz",
+      "integrity": "sha512-hVeKSZCIG4T3tmgmVHjd9FAo9Iq7K2bCLTtxlFrnASjOZmTre6Y60QNgcZ+wREMC4Wur7S+7YaMcmTRyTmeCvg==",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/providers": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "mcpName": "io.github.BlockRunAI/blockrun-mcp",
   "description": "BlockRun MCP Server - Give your AI agent web search, deep research, prediction markets, and crypto data. Paid via x402 micropayments.",
   "type": "module",
@@ -56,8 +56,8 @@
     "@blockrun/llm": "^3.8.4",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@polymarket/builder-relayer-client": "^0.0.10",
-    "@polymarket/builder-signing-sdk": "0.0.8",
-    "@polymarket/clob-client-v2": "1.0.8",
+    "@polymarket/builder-signing-sdk": "1.0.0",
+    "@polymarket/clob-client-v2": "1.1.0",
     "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.98.4",
     "axios": "^1.18.1",
@@ -74,7 +74,8 @@
   "overrides": {
     "viem": {
       "ws": "8.21.0"
-    }
+    },
+    "@polymarket/builder-signing-sdk": "1.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
Both Polymarket SDK majors had been sitting unreviewed. Franklin's port of this
module just took them in 3.38.0, so landing them here puts the two repos back on
a single baseline — the source is byte-faithful between them, and only the pins
had diverged.

Neither upgrade adds a transitive dependency: clob-client-v2's dependency set is
identical between the two versions, and builder-signing-sdk's is strictly smaller
(it drops `tslib` and a stale `@types/node ^18` that should never have been a
runtime dependency).

## `@polymarket/clob-client-v2` 1.0.8 → 1.1.0

`postOrder` gained `waitForResolvedTrades`: a matched order now gets the
settlement transaction hashes of its fills back-filled, and the return type
tightens from `Promise<any>` to `Promise<OrderResponse>`. `orders.ts` already
read `transactionsHashes` and `tradeIDs` off the response, so this makes an
existing display path more often correct rather than changing it — `filled` and
the `tx:` line now resolve on matched orders instead of only when the server
happened to include them.

This is the order path and no test here places an order, so it was verified
against the shipped bundle rather than the release notes:

| case | result |
|---|---|
| unmatched order (`tradeIDs` empty) | returned untouched, zero polls, zero added latency — the resting-limit path is unaffected |
| response already carries hashes | short-circuits, no poll |
| matched order | `transactionsHashes` filled from the resolved trade |
| `FAILED` trade | excluded — a failed fill can never be reported as a settlement hash |
| `getTrades` failing persistently (worst case) | **measured 30.1 s**, then degrades and returns the placed order rather than throwing |

The added latency lands only on matched orders and is bounded by
`RESOLVE_TRADES_TIMEOUT_MS` (30 s, 250 ms poll).

## `@polymarket/builder-signing-sdk` 0.0.8 → 1.0.0, with an override

1.0.0 is a pure CJS→ESM port: every non-import change in the bundle is
`exports.X` → `export` boilerplate, and the HMAC signing logic is untouched.

It needs an `overrides` entry because `@polymarket/builder-relayer-client` still
pins `^0.0.8`, and a caret on `0.0.x` is patch-only under npm semver — so without
it npm installs a second copy, and both `BuilderConfig` declarations carry a
private `ensureValid`, which TypeScript compares nominally.

Collapsing to one copy is safe for a specific reason worth recording:
**`builder-relayer-client` never requires the signing SDK at runtime.** It is a
type-only dependency, consumed by duck-typing
(`builderConfig.generateBuilderHeaders()`, `.isValid()`), with no `instanceof`
check anywhere in its bundle — and nothing else in the tree requires it either.
The CJS/ESM seam was then exercised for real: a 1.0.0 `BuilderConfig` handed to
the CJS `RelayClient` produced correct `POLY_BUILDER_*` headers across the
boundary.

One caveat recorded in the CHANGELOG: npm `overrides` do not propagate to
consumers, so an installed `@blockrun/mcp` gets both copies on disk. Harmless for
the same reason — nothing loads the nested one.

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean
- `npm test` — 250/250
- `node dist/index.js --version` → `0.32.10`, exit 0 (a broken module graph is
  exactly the class of failure 0.32.3 shipped)
- runtime seam check against the installed bundles — no order signed, no relayer
  transaction sent
