### PR TITLE
ci: the PR gate never built, and never loaded what it built

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,29 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      # publish.yml runs build alongside typecheck and test, and this gate is
+      # meant to move that same trio earlier — the header above says as much —
+      # but build was missing, so a tsup/dts break still only surfaced on main
+      # mid-release.
+      - name: Build
+        run: npm run build
+
       - name: Test
         run: npm test
+
+      # 0.32.3 shipped with sharp imported at the top level. sharp is an
+      # optionalDependency, so wherever it is absent — musl, unusual arch,
+      # offline CI, --no-optional — ESM resolution failed before main() ran and
+      # all 19 tools went with it, while build, typecheck and test stayed green.
+      # Loading the built entrypoint is the only thing that catches that class.
+      #
+      # sharp is deleted rather than installed around with --omit=optional:
+      # that also strips rollup's platform binary, so tsup cannot run at all,
+      # which is a failure of the build toolchain rather than of this package.
+      - name: CLI loads without sharp
+        run: |
+          rm -rf node_modules/sharp
+          test "$(node dist/index.js --version)" = "$(node -p 'require("./package.json").version')"
 
       # Fails when a number in the docs disagrees with brand-numbers.json.
       # Offline by design: it reads the committed snapshot and never fetches, so


### PR DESCRIPTION
#77 landed the pull-request gate on main, which was the important half — until
then `publish.yml` was the only thing running build, typecheck and test, and only
on push to main, i.e. **after** a merge. (That gap was live earlier today: #78
was opened against main and no check ran at all.)

But the gate that landed runs typecheck, test and brand-numbers. **It never
builds, and it never loads what it builds.**

## `build`

`publish.yml` runs `npm run build` alongside typecheck and test, and this gate
exists to move that same trio earlier — the header comment in the workflow says
as much. Without it, a tsup/dts break still only surfaces on main, mid-release,
which is the exact failure mode the gate was written to prevent.

## CLI load smoke

0.32.3 shipped with `sharp` imported at the top level. `sharp` is an
`optionalDependency`, so wherever it is absent — musl, unusual arch, offline CI,
`--no-optional` — ESM resolution failed before `main()` ran and all 19 tools went
with it. **Build, typecheck and test were green the entire time.** Loading the
built entrypoint is the only step that catches that class — and it is a class
this repo has actually shipped, not a hypothetical.

The smoke deletes `node_modules/sharp` rather than installing with
`--omit=optional`. That was tried first and fails for an unrelated reason: it
also strips rollup's platform binary (`@rollup/rollup-darwin-arm64`), so `tsup`
cannot run at all. That is a failure of the build toolchain rather than of the
package under test, and it would have made the step a permanent false red.

## Verification

The whole sequence was replayed against the **current main baseline** in a clean
worktree before this was opened — shipping an unrun CI config is precisely what
this gate exists to prevent:

| step | result |
|---|---|
| `npm ci` | clean |
| `npm run typecheck` | clean |
| `npm run build` | clean |
| `npm test` | 254/254 |
| `sync-brand-numbers.mjs --check` | up to date (3 keys in use) |
| CLI loads without sharp | returns the `package.json` version, exit 0 |

Rebased onto main after #77 merged; the brand-numbers step is kept as-is, so
this is purely additive.
