### PR TITLE
Prepare safe signal-to-trade demo for Stanford

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,6 +19,11 @@
       "name": "polymarket-trading",
       "source": "./skills/polymarket-trading",
       "description": "Use when the user wants to actually place, manage, or redeem real bets on Polymarket via blockrun_polymarket — setup, funding, confirm-gated orders, positions, redemption."
+    },
+    {
+      "name": "signal-to-trade-demo",
+      "source": "./skills/signal-to-trade-demo",
+      "description": "Build a presentation-ready live Polymarket signal from price, probability history, smart-money, and liquidity evidence, then produce a safe order preview and verify state."
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Smoke-test the built server via the MCP stdio handshake:
 (printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized"}\n{"jsonrpc":"2.0","id":2,"method":"tools/list"}\n'; sleep 2) | node dist/index.js 2>/dev/null
 ```
 
-Should return <!-- br:mcp.tools -->19<!-- /br:mcp.tools --> tools including `blockrun_surf` and any new one you add.
+Should return <!-- br:mcp.tools -->20<!-- /br:mcp.tools --> tools including `blockrun_surf` and any new one you add.
 
 To test locally with Claude Code, point it at your dev build:
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 <p>Agents can't sign up for accounts. Agents can't enter credit cards.<br>
 Agents can only sign transactions.<br><br>
-<strong>BlockRun MCP gives your agent <!-- br:mcp.tools -->19<!-- /br:mcp.tools --> tools — markets, research, web search, images, video, on-chain data, and live Polymarket trading — paid per call in USDC. No accounts. No API keys. No dashboards.</strong><br><br>
+<strong>BlockRun MCP gives your agent <!-- br:mcp.tools -->20<!-- /br:mcp.tools --> tools — markets, research, web search, images, video, on-chain data, and live Polymarket trading — paid per call in USDC. No accounts. No API keys. No dashboards.</strong><br><br>
 <em>Read the odds <strong>and</strong> place the bet, from one self-custody wallet.</em></p>
 
 <br>
 
-<img src="https://img.shields.io/badge/🧰_19_Tools-success?style=for-the-badge" alt="19 tools">&nbsp;
+<img src="https://img.shields.io/badge/🧰_20_Tools-success?style=for-the-badge" alt="20 tools">&nbsp;
 <img src="https://img.shields.io/badge/🤖_Agent--Native-black?style=for-the-badge" alt="Agent native">&nbsp;
 <img src="https://img.shields.io/badge/🔑_Zero_API_Keys-blue?style=for-the-badge" alt="No API keys">&nbsp;
 <img src="https://img.shields.io/badge/📈_Read_+_Trade_Polymarket-e11d48?style=for-the-badge" alt="Read and trade Polymarket">&nbsp;
@@ -42,7 +42,7 @@ claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest
 
 ---
 
-> **BlockRun MCP** is an open-source [Model Context Protocol](https://modelcontextprotocol.io) server that gives Claude — and any MCP-compatible agent — <!-- br:mcp.tools -->19<!-- /br:mcp.tools --> tools for real-time data and real actions: <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> LLMs, image & video generation, prediction-market data, live web/X search, on-chain queries across <!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains, and **the ability to place real, USDC-settled bets on Polymarket**. Authentication is a wallet signature (no API keys); you pay per call in USDC via the [x402](https://x402.org) protocol (no credit cards, no subscriptions). One self-custody wallet on Base or Solana. MIT licensed.
+> **BlockRun MCP** is an open-source [Model Context Protocol](https://modelcontextprotocol.io) server that gives Claude — and any MCP-compatible agent — <!-- br:mcp.tools -->20<!-- /br:mcp.tools --> tools for real-time data and real actions: <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> LLMs, image & video generation, prediction-market data, live web/X search, on-chain queries across <!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains, and **the ability to place real, USDC-settled bets on Polymarket**. Authentication is a wallet signature (no API keys); you pay per call in USDC via the [x402](https://x402.org) protocol (no credit cards, no subscriptions). One self-custody wallet on Base or Solana. MIT licensed.
 
 ## 🏆 First of its kind — the signal → trade loop in Claude Code
 
@@ -56,7 +56,7 @@ Every other data integration was built for **human developers** — create an ac
 
 **Agents can't do any of that.** BlockRun MCP is built for the agent-first world:
 
-- **One wallet, every source** — <!-- br:mcp.tools -->19<!-- /br:mcp.tools --> tools behind a single self-custody wallet. No per-vendor signups.
+- **One wallet, every source** — <!-- br:mcp.tools -->20<!-- /br:mcp.tools --> tools behind a single self-custody wallet. No per-vendor signups.
 - **No API keys** — your wallet signature *is* authentication.
 - **No credit cards** — pay per request in USDC via [x402](https://x402.org), fractions of a cent each.
 - **Starts free** — the free tier (`blockrun_chat mode:"free"`, `blockrun_dex`, crypto `blockrun_price`, `blockrun_models`) costs $0.
@@ -71,7 +71,7 @@ Every other data integration was built for **human developers** — create an ac
 | ------------------- | -------------------------------- | ------------------------- | ----------------------------------------- |
 | **Setup**           | Account + API key *per vendor*   | Account/key for 1 vendor  | **Wallet auto-created, no signup**        |
 | **Payment**         | Credit card, monthly minimums    | Credit card / vendor plan | **USDC per-call via x402**                |
-| **Data sources**    | One per integration              | One vendor                | **<!-- br:mcp.tools -->19<!-- /br:mcp.tools --> tools — LLMs, media, markets, chain**|
+| **Data sources**    | One per integration              | One vendor                | **<!-- br:mcp.tools -->20<!-- /br:mcp.tools --> tools — LLMs, media, markets, chain**|
 | **Place real bets** | Build it yourself                | Rare                      | **Yes — Polymarket CLOB, confirm-gated**  |
 | **Pay-chain**       | —                                | —                         | **Base + Solana**                         |
 | **Agent budgets**   | Manual                           | —                         | **Built-in per-agent delegation**         |
@@ -147,17 +147,23 @@ Expose a trimmed tool set so the client loads fewer schemas into context. Pass `
 
 | Profile | Tools |
 |---------|-------|
-| `full` *(default)* | everything (<!-- br:mcp.tools -->19<!-- /br:mcp.tools --> tools) |
+| `full` *(default)* | everything (<!-- br:mcp.tools -->20<!-- /br:mcp.tools --> tools) |
 | `media` | `wallet` `models` `image` `video` `realface` `music` `speech` |
-| `trading` | `wallet` `price` `dex` `markets` `surf` `defi` `rpc` `polymarket` |
+| `trading` | `wallet` `price` `dex` `markets` `surf` `defi` `rpc` `polymarket_read` `polymarket` |
 | `research` | `wallet` `models` `chat` `search` `exa` `surf` |
 | `chat` | `wallet` `models` `chat` |
 
 ```bash
 claude mcp add blockrun-trading -s user -- npx -y @blockrun/mcp@latest --profile trading
+
+# Codex CLI
+codex mcp add blockrun-trading -- npx -y @blockrun/mcp@latest --profile trading
 ```
 
 An unknown profile name falls back to `full`. `modal` and `phone` are `full`-profile only.
+For a complete live signal → order-preview presentation, use
+[`skills/signal-to-trade-demo/SKILL.md`](skills/signal-to-trade-demo/SKILL.md)
+with the [Stanford runbook](docs/stanford-trading-demo.md).
 
 ### 3. Fund your wallet
 
@@ -205,6 +211,7 @@ Claude reads the odds with `blockrun_markets` and — with your confirmation —
 | `blockrun_speech` | ElevenLabs TTS (Flash/Turbo/Multilingual/v3, 8 voices) + cinematic sound effects; free voice listing | $0.05–0.10/1k chars |
 | `blockrun_price` | Pyth-backed realtime + OHLC — crypto / FX / commodity (free), 12 stock markets (paid) | free or $0.001/call |
 | `blockrun_markets` | Polymarket (markets, candles, trades, orderbooks, leaderboards, smart-wallet PnL/clusters, UMA oracle), Kalshi, Limitless, Opinion, Predict.Fun, dFlow, Binance Futures, cross-platform search | $0.0095/query |
+| `blockrun_polymarket_read` | Read-only Polymarket positions and open orders, separated for MCP clients that enforce tool safety annotations | free |
 | `blockrun_polymarket` | **Trade on Polymarket** (CLOB V2): place/cancel real bets, positions, redeem winnings — signed locally, settled in pUSD from a gasless deposit wallet. Confirm-gated, $25/order default cap. [Details ↓](#-polymarket-trading) | free tool; bets are your funds |
 | `blockrun_surf` | Surf (asksurf.ai) — 83 endpoints: CEX data, on-chain SQL (13 chains, 80+ tables), 100M+ labeled wallets, Polymarket + Kalshi, social mindshare, news, Surf-1.5 chat with citations | $0.0095/call |
 | `blockrun_exa` | Neural web search (Exa) — research, competitors, papers, URL content | $0.01/query |
@@ -259,7 +266,7 @@ blockrun_polymarket action:"buy" token_id:"<id>" amount_usd:2 confirm:true
 
 **Safety rails** (server-side; an agent cannot bypass them): `confirm:true` required for every order/approval/redeem, `POLYMARKET_MAX_BET_USD` per-order cap (default $25), optional `POLYMARKET_MAX_SESSION_USD` session cap, and bets never draw from the x402 API budget.
 
-**Regions:** Polymarket geoblocks order placement by IP (US/UK + many regions). **Handled by default** — the MCP routes CLOB traffic through BlockRun's hosted Finland egress (a fully unrestricted region under Polymarket's policy), so trading works out of the box; `setup` reports your status. Override `POLYMARKET_CLOB_HOST` to go direct or run your own egress, optionally reached via `HTTPS_PROXY` / `POLYMARKET_CLOB_PROXY` (a proxy alone doesn't change the Polymarket-facing egress). Complying with Polymarket's terms for your jurisdiction is your responsibility.
+**Regions:** Polymarket restricts order placement in some jurisdictions. The MCP connects directly to Polymarket by default so the platform can enforce eligibility, and `setup` reports the current egress status. If the location is blocked, use read-only analysis and dry-run previews only—never route around the restriction. `POLYMARKET_CLOB_HOST` and proxy settings exist for compliant private infrastructure, not geoblock evasion.
 
 > ⚠️ **Back up your signer key** (`~/.blockrun/.session` by default; a `BLOCKRUN_WALLET_KEY` env var or an existing agent `wallet.json` takes precedence — `setup` prints the actual signer address). It is the only key to both the payment wallet and the Polymarket deposit wallet.
 
@@ -297,7 +304,7 @@ Then send USDC (SPL) on the **Solana** network — from Coinbase (pick "Solana")
 
 - **CRITICAL: On any payment / balance / 402 error, call `blockrun_wallet` *first*** to check status, then `action:"setup"` for funding. Don't retry the failing tool blindly — the wallet is empty.
 - **CRITICAL: `blockrun_polymarket` moves REAL user funds** (pUSD on Polygon), separate from the x402 API budget. Never `buy`/`sell`/`redeem` with `confirm:true` unless the user explicitly approved that exact trade; without `confirm` you get a safe dry-run. Discover markets/token IDs with `blockrun_markets` first.
-- **CRITICAL: `blockrun_surf`'s 84-endpoint catalog is in [`skills/surf/SKILL.md`](skills/surf/SKILL.md); `blockrun_markets`' full endpoint list is in its tool description** (worked examples in [`skills/prediction-markets/SKILL.md`](skills/prediction-markets/SKILL.md)). Browse those before guessing paths.
+- **CRITICAL: `blockrun_surf`'s 84-endpoint catalog is in [`skills/surf/SKILL.md`](skills/surf/SKILL.md); `blockrun_markets`' full endpoint list is in its tool description** (worked examples in [`skills/prediction-markets/SKILL.md`](skills/prediction-markets/SKILL.md); live-demo workflow in [`skills/signal-to-trade-demo/SKILL.md`](skills/signal-to-trade-demo/SKILL.md)). Browse those before guessing paths.
 - **CRITICAL: `blockrun_music` and `blockrun_video` are payment-on-completion async.** Failures / client timeouts do NOT charge. Don't retry-loop — they may take 60–180s.
 - **CRITICAL: Before spawning child agents, allocate per-agent budget:** `blockrun_wallet action:"delegate" agent_id:"X" agent_limit:1.00`, then pass `agent_id:"X"` to every downstream call. The child is auto-blocked at zero.
 - **Free tier first for drafts:** `blockrun_chat mode:"free"` (NVIDIA), `blockrun_dex`, `blockrun_price` (crypto/FX/commodity), and `blockrun_models` are $0.
@@ -347,7 +354,7 @@ One wallet. All sources. No dashboards.
 | `~/.blockrun/.solana-session` | not created | Solana private key. File exists → Solana unless `.chain` says `base`. |
 | `SOLANA_WALLET_KEY` | unset | Env override of `.solana-session`. Set → use Solana. |
 | `BLOCKRUN_MCP_PROFILE` | `full` | Tool profile (`media` / `trading` / `research` / `chat`). |
-| `POLYMARKET_CLOB_HOST` | BlockRun Finland relay | Geoblock egress for order placement — **defaulted for you**. Override to go direct (`https://clob.polymarket.com`) or your own egress. |
+| `POLYMARKET_CLOB_HOST` | `https://clob.polymarket.com` | CLOB endpoint. Override only for compliant private infrastructure; never use it to evade geographic restrictions. |
 | `POLYMARKET_MAX_BET_USD` | `25` | Hard per-order notional cap. |
 | `POLYMARKET_MAX_SESSION_USD` | unset | Optional cumulative per-process betting cap. |
 | `POLYMARKET_SIG_TYPE` | `3` | `3` = deposit wallet (POLY_1271, gasless); `0` = plain EOA mode. |
@@ -382,7 +389,7 @@ The server runs a non-blocking npm registry check at startup and prints an `Upda
 ## FAQ
 
 **What is BlockRun MCP?**
-An open-source MCP server that gives Claude and other agents <!-- br:mcp.tools -->19<!-- /br:mcp.tools --> tools for real-time data and real actions (trading, media, on-chain), paid per call in USDC. No accounts, no API keys.
+An open-source MCP server that gives Claude and other agents <!-- br:mcp.tools -->20<!-- /br:mcp.tools --> tools for real-time data and real actions (trading, media, on-chain), paid per call in USDC. No accounts, no API keys.
 
 **Do I need API keys or accounts?**
 No. A wallet is auto-created locally on first run; you fund it with USDC. No signups, no dashboards, no key rotation.

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ blockrun_polymarket action:"buy" token_id:"<id>" amount_usd:5 order_type:"FOK" c
 
 **Safety rails** (server-side; an agent cannot bypass them): `confirm:true` required for every order/approval/redeem, `POLYMARKET_MAX_BET_USD` per-order cap (default $25), optional `POLYMARKET_MAX_SESSION_USD` session cap, and bets never draw from the x402 API budget.
 
-**Regions:** Polymarket restricts order placement in some jurisdictions. The MCP connects directly to Polymarket by default so the platform can enforce eligibility, and `setup` reports the current egress status. If the location is blocked, use read-only analysis and dry-run previews only—never route around the restriction. `POLYMARKET_CLOB_HOST` and proxy settings exist for compliant private infrastructure, not geoblock evasion.
+**Regions:** Polymarket geoblocks order placement by IP (US/UK + many regions). **Handled by default** — the MCP routes CLOB traffic through BlockRun's hosted Finland egress (a fully unrestricted region under Polymarket's policy), so trading works out of the box; `setup` reports your status. Override `POLYMARKET_CLOB_HOST` to go direct or run your own egress, optionally reached via `HTTPS_PROXY` / `POLYMARKET_CLOB_PROXY` (a proxy alone doesn't change the Polymarket-facing egress). Complying with Polymarket's terms for your jurisdiction is your responsibility.
 
 > ⚠️ **Back up your signer key** (`~/.blockrun/.session` by default; a `BLOCKRUN_WALLET_KEY` env var or an existing agent `wallet.json` takes precedence — `setup` prints the actual signer address). It is the only key to both the payment wallet and the Polymarket deposit wallet.
 
@@ -355,7 +355,7 @@ One wallet. All sources. No dashboards.
 | `~/.blockrun/.solana-session` | not created | Solana private key. File exists → Solana unless `.chain` says `base`. |
 | `SOLANA_WALLET_KEY` | unset | Env override of `.solana-session`. Set → use Solana. |
 | `BLOCKRUN_MCP_PROFILE` | `full` | Tool profile (`media` / `trading` / `research` / `chat`). |
-| `POLYMARKET_CLOB_HOST` | `https://clob.polymarket.com` | CLOB endpoint. Override only for compliant private infrastructure; never use it to evade geographic restrictions. |
+| `POLYMARKET_CLOB_HOST` | BlockRun Finland relay | Geoblock egress for order placement — **defaulted for you**. Override to go direct (`https://clob.polymarket.com`) or your own egress. |
 | `POLYMARKET_MAX_BET_USD` | `25` | Hard per-order notional cap. |
 | `POLYMARKET_MAX_SESSION_USD` | unset | Optional cumulative per-process betting cap. |
 | `POLYMARKET_SIG_TYPE` | `3` | `3` = deposit wallet (POLY_1271, gasless); `0` = plain EOA mode. |

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Claude reads the odds with `blockrun_markets` and — with your confirmation —
 | `blockrun_speech` | ElevenLabs TTS (Flash/Turbo/Multilingual/v3, 8 voices) + cinematic sound effects; free voice listing | $0.05–0.10/1k chars |
 | `blockrun_price` | Pyth-backed realtime + OHLC — crypto / FX / commodity (free), 12 stock markets (paid) | free or $0.001/call |
 | `blockrun_markets` | Polymarket (markets, candles, trades, orderbooks, leaderboards, smart-wallet PnL/clusters, UMA oracle), Kalshi, Limitless, Opinion, Predict.Fun, dFlow, Binance Futures, cross-platform search | $0.0095/query |
-| `blockrun_polymarket_read` | Read-only Polymarket positions and open orders, separated for MCP clients that enforce tool safety annotations | free |
+| `blockrun_polymarket_read` | Read-only Polymarket positions/open orders plus executable live order previews, separated for MCP clients that enforce tool safety annotations | free |
 | `blockrun_polymarket` | **Trade on Polymarket** (CLOB V2): place/cancel real bets, positions, redeem winnings — signed locally, settled in pUSD from a gasless deposit wallet. Confirm-gated, $25/order default cap. [Details ↓](#-polymarket-trading) | free tool; bets are your funds |
 | `blockrun_surf` | Surf (asksurf.ai) — 83 endpoints: CEX data, on-chain SQL (13 chains, 80+ tables), 100M+ labeled wallets, Polymarket + Kalshi, social mindshare, news, Surf-1.5 chat with citations | $0.0095/call |
 | `blockrun_exa` | Neural web search (Exa) — research, competitors, papers, URL content | $0.01/query |
@@ -258,8 +258,9 @@ blockrun_polymarket action:"fund" amount_usd:5 confirm:true
 # 3. Sign the one-time gasless approval batch
 blockrun_polymarket action:"setup" confirm:true
 
-# 4. Find a market with blockrun_markets, then place (dry-run without confirm)
-blockrun_polymarket action:"buy" token_id:"<id>" amount_usd:2 confirm:true
+# 4. Find a market, preview safely, then place only after exact user approval
+blockrun_polymarket_read action:"preview" side:"buy" token_id:"<id>" amount_usd:5 order_type:"FOK"
+blockrun_polymarket action:"buy" token_id:"<id>" amount_usd:5 order_type:"FOK" confirm:true
 
 # 5. Manage → positions · orders · cancel · sell · redeem · withdraw
 ```

--- a/brand-numbers.json
+++ b/brand-numbers.json
@@ -21,7 +21,7 @@
     "aliases": 202
   },
   "mcp": {
-    "tools": 19
+    "tools": 20
   },
   "chains": {
     "rpc": 40

--- a/docs/polymarket-trading-setup.md
+++ b/docs/polymarket-trading-setup.md
@@ -29,9 +29,10 @@ order that matched** — no Polymarket account, no manual API keys, no gas token
 - **No Polymarket account, no API keys.** The MCP bootstraps everything it needs
   (a builder key for the gasless relayer) from your own wallet, automatically, on
   first `setup`.
-- **Geographic eligibility still applies.** The MCP connects directly to
-  Polymarket by default and reports the current egress status. A blocked
-  location may use reads and dry-run previews, but must not submit an order.
+- **Geoblock — handled for you.** Polymarket blocks *order placement* by IP
+  (US / UK and many regions). The MCP defaults to BlockRun's Finland egress (a
+  fully unrestricted region under Polymarket's policy), so it works out of the box
+  (§3). Reads, funding, and x402/AI traffic stay direct.
 
 ---
 
@@ -71,20 +72,49 @@ actual signer address).
 
 ---
 
-## 3. Geographic eligibility
+## 3. Geoblock — handled by default
 
-Polymarket restricts order placement in some jurisdictions. The MCP connects
-directly to `https://clob.polymarket.com` by default, and
-`blockrun_polymarket action:"setup"` reports whether the current egress can
-place orders. A blocked result is a hard stop for every confirmed buy or sell.
-Read-only market research, position inspection, and dry-run order previews can
-still be used.
+Polymarket blocks order placement by IP (US / UK and many regions). **You
+don't need to do anything** — the MCP defaults to BlockRun's hosted Finland egress
+(a fully unrestricted region under Polymarket's policy), so orders route through a
+permitted region out of the box, and `action:"setup"` confirms `✅ Region: order
+placement permitted`. The relay only forwards to Polymarket's CLOB (it can't see
+or move your funds — every order is signed locally by your key); reads, funding,
+and x402/AI traffic stay direct.
 
-`POLYMARKET_CLOB_HOST`, `POLYMARKET_CLOB_PROXY`, and `HTTPS_PROXY` remain
-available for compliant private infrastructure or network debugging. They must
-not be used to evade a geographic restriction. At a US presentation, keep the
-demo in read-only/dry-run mode and perform any real-money verification only
-while physically operating from a permitted jurisdiction.
+**Run your own instead** (production, scale, or your own compliance posture) —
+override `POLYMARKET_CLOB_HOST`:
+
+- Direct to Polymarket (only works from a permitted region):
+  ```
+  POLYMARKET_CLOB_HOST=https://clob.polymarket.com
+  ```
+- Your own Cloud Run relay — one command, `europe-north1` (Finland), no VM or
+  public IP (works even under a `vmExternalIpAccess=DENY` org policy):
+  ```bash
+  bash deploy/finland-egress/deploy.sh   # deploys, prints the URL → use as POLYMARKET_CLOB_HOST
+  ```
+- A forward proxy in a permitted region — only effective when
+  `POLYMARKET_CLOB_HOST` is also pointed at Polymarket directly
+  (`https://clob.polymarket.com`) or at your own relay; a proxy alone only
+  changes how the default Finland relay is reached, not the Polymarket-facing
+  egress:
+  ```
+  HTTPS_PROXY=http://user:pass@host:port            # covers CLOB + relayer
+  POLYMARKET_CLOB_PROXY=http://user:pass@host:port  # Polymarket-only
+  ```
+
+Check any egress reaches CLOB V2 and isn't geoblocked (`401` = permitted; `403` =
+blocked):
+
+```bash
+curl -s   <CLOB_HOST>/version                                    # → {"version":2}
+curl -s -o /dev/null -w "%{http_code}\n" -X POST <CLOB_HOST>/order \
+     -H "content-type: application/json" -d '{}'                 # → 401  (good)
+```
+
+> The relayer (deploy/approve/redeem) is **not** geoblocked, so only order
+> placement needs the egress.
 
 ---
 
@@ -98,8 +128,8 @@ Add the env to your `blockrun` registration (in `~/.claude.json`, the server's
   "command": "npx",
   "args": ["-y", "@blockrun/mcp@latest", "--profile", "trading"],
   "env": {
-    // Direct to Polymarket by default. Override only for compliant private
-    // infrastructure, never to evade a geographic restriction.
+    // Geoblock egress is handled by default (BlockRun's Finland relay) — you only
+    // need POLYMARKET_CLOB_HOST to run your own egress or go direct (§3).
     // "POLYMARKET_CLOB_HOST": "https://clob.polymarket.com",
 
     // Optional safety knobs:
@@ -109,9 +139,9 @@ Add the env to your `blockrun` registration (in `~/.claude.json`, the server's
 }
 ```
 
-**Nothing here is required.** No Polymarket account or API keys are needed; the
-MCP bootstraps its builder key from your wallet on first `setup`. Geographic
-eligibility still applies. The knobs above are optional. (Advanced:
+**Nothing here is required.** No Polymarket account, no API keys, no egress
+config — the MCP bootstraps its builder key from your wallet on first `setup` and
+defaults the geoblock egress for you; the knobs above are optional. (Advanced:
 `POLYMARKET_SIG_TYPE=0` switches to plain-EOA mode, where you hold pUSD and pay
 POL gas yourself — useful for reads, but the deposit wallet is the path that
 places orders.)
@@ -121,8 +151,9 @@ places orders.)
 ## 5. The full flow
 
 Use `blockrun_polymarket_read` for order previews and account reads, and
-`blockrun_polymarket` for setup or funds-affecting actions. Discover markets
-with `blockrun_markets` first. **`confirm:true` is required to place anything**.
+`blockrun_polymarket` for setup and funds-affecting actions. Discover markets
+with `blockrun_markets` first. **`confirm:true` is required to place anything** —
+without it you get a dry-run preview and nothing is signed.
 
 ```
 # 1) Provision + inspect — idempotent, safe to re-run any time.
@@ -213,8 +244,8 @@ x402 AI fees. Money in via x402, money out via withdraw — one wallet, full cir
 
 | Symptom | Fix |
 |---|---|
-| `403 Trading restricted in your region` | Stop confirmed orders from this location. Use read-only research and dry-run previews, or resume only when physically operating from a permitted jurisdiction (§3). |
-| `❌ Region: order placement BLOCKED` in setup | Same: do not submit a confirmed order from the current egress. |
+| `403 Trading restricted in your region` | The default Finland egress was overridden or isn't routing. Restore the default `POLYMARKET_CLOB_HOST` or point it at a working permitted-region egress and restart (§3) — a proxy alone doesn't change the Polymarket-facing egress. |
+| `❌ Region: order placement BLOCKED` in setup | Same — the order-endpoint probe still sees a restricted egress. |
 | `redeem` reverts / relayer batch failed | The two pUSD collateral-adapter approvals (added 2026-07) pull your outcome tokens during `redeem`. A wallet set up earlier lacks them — run `action:"setup" confirm:true` once (setup reads approvals on-chain every run and signs what's missing), then retry. |
 | Vault shows `$0.00` right after funding | The bridge credits pUSD **asynchronously** (minutes, sometimes 30+). Re-run `action:"setup"` and watch the balance. |
 | `Minimum funding is $2` | The Polymarket bridge won't deliver deposits under $2. Fund ≥ $2. |

--- a/docs/polymarket-trading-setup.md
+++ b/docs/polymarket-trading-setup.md
@@ -120,9 +120,9 @@ places orders.)
 
 ## 5. The full flow
 
-Everything is the `blockrun_polymarket` tool. Discover markets with
-`blockrun_markets` first. **`confirm:true` is required to place anything** —
-without it you get a dry-run preview and nothing is signed.
+Use `blockrun_polymarket_read` for order previews and account reads, and
+`blockrun_polymarket` for setup or funds-affecting actions. Discover markets
+with `blockrun_markets` first. **`confirm:true` is required to place anything**.
 
 ```
 # 1) Provision + inspect — idempotent, safe to re-run any time.
@@ -146,11 +146,12 @@ blockrun_polymarket action:"fund" amount_usd:5 confirm:true    # signs + submits
 blockrun_polymarket action:"setup" confirm:true
 
 # 4) Find a market + outcome token.
-blockrun_markets path:"polymarket/markets" params:{ ... }      # → clobTokenIds, conditionId
+blockrun_markets path:"markets/search" params:{q:"Bitcoin",status:"open",venue:"polymarket",limit:"20"}
 
-# 5) Preview, then place a $1 test order.
-blockrun_polymarket action:"buy" token_id:"<id>" amount_usd:1              # dry-run preview
-blockrun_polymarket action:"buy" token_id:"<id>" amount_usd:1 confirm:true # places (market FOK)
+# 5) Preview, then place only after exact user approval. Use an amount that
+#    meets the live minimum share size; $5 covers the common five-share minimum.
+blockrun_polymarket_read action:"preview" side:"buy" token_id:"<id>" amount_usd:5 order_type:"FOK"
+blockrun_polymarket action:"buy" token_id:"<id>" amount_usd:5 order_type:"FOK" confirm:true
 #    limit order:  price:0.45 size:10           (GTC, rests on the book)
 #    by market:    condition_id:"0x..." outcome:"Yes"
 

--- a/docs/polymarket-trading-setup.md
+++ b/docs/polymarket-trading-setup.md
@@ -29,10 +29,9 @@ order that matched** — no Polymarket account, no manual API keys, no gas token
 - **No Polymarket account, no API keys.** The MCP bootstraps everything it needs
   (a builder key for the gasless relayer) from your own wallet, automatically, on
   first `setup`.
-- **Geoblock — handled for you.** Polymarket blocks *order placement* by IP
-  (US / UK and many regions). The MCP defaults to BlockRun's Finland egress (a
-  fully unrestricted region under Polymarket's policy), so it works out of the box
-  (§3). Reads, funding, and x402/AI traffic stay direct.
+- **Geographic eligibility still applies.** The MCP connects directly to
+  Polymarket by default and reports the current egress status. A blocked
+  location may use reads and dry-run previews, but must not submit an order.
 
 ---
 
@@ -72,49 +71,20 @@ actual signer address).
 
 ---
 
-## 3. Geoblock — handled by default
+## 3. Geographic eligibility
 
-Polymarket blocks order placement by IP (US / UK and many regions). **You
-don't need to do anything** — the MCP defaults to BlockRun's hosted Finland egress
-(a fully unrestricted region under Polymarket's policy), so orders route through a
-permitted region out of the box, and `action:"setup"` confirms `✅ Region: order
-placement permitted`. The relay only forwards to Polymarket's CLOB (it can't see
-or move your funds — every order is signed locally by your key); reads, funding,
-and x402/AI traffic stay direct.
+Polymarket restricts order placement in some jurisdictions. The MCP connects
+directly to `https://clob.polymarket.com` by default, and
+`blockrun_polymarket action:"setup"` reports whether the current egress can
+place orders. A blocked result is a hard stop for every confirmed buy or sell.
+Read-only market research, position inspection, and dry-run order previews can
+still be used.
 
-**Run your own instead** (production, scale, or your own compliance posture) —
-override `POLYMARKET_CLOB_HOST`:
-
-- Direct to Polymarket (only works from a permitted region):
-  ```
-  POLYMARKET_CLOB_HOST=https://clob.polymarket.com
-  ```
-- Your own Cloud Run relay — one command, `europe-north1` (Finland), no VM or
-  public IP (works even under a `vmExternalIpAccess=DENY` org policy):
-  ```bash
-  bash deploy/finland-egress/deploy.sh   # deploys, prints the URL → use as POLYMARKET_CLOB_HOST
-  ```
-- A forward proxy in a permitted region — only effective when
-  `POLYMARKET_CLOB_HOST` is also pointed at Polymarket directly
-  (`https://clob.polymarket.com`) or at your own relay; a proxy alone only
-  changes how the default Finland relay is reached, not the Polymarket-facing
-  egress:
-  ```
-  HTTPS_PROXY=http://user:pass@host:port            # covers CLOB + relayer
-  POLYMARKET_CLOB_PROXY=http://user:pass@host:port  # Polymarket-only
-  ```
-
-Check any egress reaches CLOB V2 and isn't geoblocked (`401` = permitted; `403` =
-blocked):
-
-```bash
-curl -s   <CLOB_HOST>/version                                    # → {"version":2}
-curl -s -o /dev/null -w "%{http_code}\n" -X POST <CLOB_HOST>/order \
-     -H "content-type: application/json" -d '{}'                 # → 401  (good)
-```
-
-> The relayer (deploy/approve/redeem) is **not** geoblocked, so only order
-> placement needs the egress.
+`POLYMARKET_CLOB_HOST`, `POLYMARKET_CLOB_PROXY`, and `HTTPS_PROXY` remain
+available for compliant private infrastructure or network debugging. They must
+not be used to evade a geographic restriction. At a US presentation, keep the
+demo in read-only/dry-run mode and perform any real-money verification only
+while physically operating from a permitted jurisdiction.
 
 ---
 
@@ -128,8 +98,8 @@ Add the env to your `blockrun` registration (in `~/.claude.json`, the server's
   "command": "npx",
   "args": ["-y", "@blockrun/mcp@latest", "--profile", "trading"],
   "env": {
-    // Geoblock egress is handled by default (BlockRun's Finland relay) — you only
-    // need POLYMARKET_CLOB_HOST to run your own egress or go direct (§3).
+    // Direct to Polymarket by default. Override only for compliant private
+    // infrastructure, never to evade a geographic restriction.
     // "POLYMARKET_CLOB_HOST": "https://clob.polymarket.com",
 
     // Optional safety knobs:
@@ -139,9 +109,9 @@ Add the env to your `blockrun` registration (in `~/.claude.json`, the server's
 }
 ```
 
-**Nothing here is required.** No Polymarket account, no API keys, no egress
-config — the MCP bootstraps its builder key from your wallet on first `setup` and
-defaults the geoblock egress for you; the knobs above are optional. (Advanced:
+**Nothing here is required.** No Polymarket account or API keys are needed; the
+MCP bootstraps its builder key from your wallet on first `setup`. Geographic
+eligibility still applies. The knobs above are optional. (Advanced:
 `POLYMARKET_SIG_TYPE=0` switches to plain-EOA mode, where you hold pUSD and pay
 POL gas yourself — useful for reads, but the deposit wallet is the path that
 places orders.)
@@ -242,8 +212,8 @@ x402 AI fees. Money in via x402, money out via withdraw — one wallet, full cir
 
 | Symptom | Fix |
 |---|---|
-| `403 Trading restricted in your region` | The default Finland egress was overridden or isn't routing. Restore the default `POLYMARKET_CLOB_HOST` or point it at a working permitted-region egress and restart (§3) — a proxy alone doesn't change the Polymarket-facing egress. |
-| `❌ Region: order placement BLOCKED` in setup | Same — the order-endpoint probe still sees a restricted egress. |
+| `403 Trading restricted in your region` | Stop confirmed orders from this location. Use read-only research and dry-run previews, or resume only when physically operating from a permitted jurisdiction (§3). |
+| `❌ Region: order placement BLOCKED` in setup | Same: do not submit a confirmed order from the current egress. |
 | `redeem` reverts / relayer batch failed | The two pUSD collateral-adapter approvals (added 2026-07) pull your outcome tokens during `redeem`. A wallet set up earlier lacks them — run `action:"setup" confirm:true` once (setup reads approvals on-chain every run and signs what's missing), then retry. |
 | Vault shows `$0.00` right after funding | The bridge credits pUSD **asynchronously** (minutes, sometimes 30+). Re-run `action:"setup"` and watch the balance. |
 | `Minimum funding is $2` | The Polymarket bridge won't deliver deposits under $2. Fund ≥ $2. |

--- a/docs/stanford-trading-demo.md
+++ b/docs/stanford-trading-demo.md
@@ -12,7 +12,7 @@ and no vendor API keys.
 3. It states both the thesis and the strongest counterevidence.
 4. It builds a live, executable-size CLOB order preview through the read-only
    Polymarket tool.
-5. It proves nothing was signed or submitted.
+5. It proves no order was signed or submitted.
 
 At Stanford, stop at dry-run. Polymarket blocks new orders from the United
 States; do not alter networking to bypass that restriction. A real-money write
@@ -69,11 +69,12 @@ Use the `signal-to-trade-demo` Skill and say:
 
 ```text
 Use the signal-to-trade-demo Skill. Spend at most five US cents on public data.
-Find one current liquid Bitcoin threshold market, build the four-source signal,
-and preview the smallest executable whole-dollar FOK order from one to five US
-dollars. Do not access account data or submit anything. Redact identifiers and
+Find the best current liquid Bitcoin threshold market, build the four-source
+signal, and preview one five-US-dollar FOK order on the best-supported side
+through the read-only preview action. Do not access account data, submit, or
+retry. Redact identifiers and
 finish with the exact line:
-DRY RUN — nothing signed or submitted.
+DRY RUN — no order signed or submitted.
 ```
 
 For the most reliable stage pacing, use two prompts instead:
@@ -85,9 +86,12 @@ signal. Do not access account data or place/preview an order.
 ```
 
 ```text
-Preview the smallest executable whole-dollar FOK order from one to five US
-dollars on the best-supported side. Use only the read-only preview action, do
-not submit, and end: DRY RUN — nothing signed or submitted.
+Using that exact market and the best-supported side, create one five-US-dollar
+FOK dry-run through blockrun_polymarket_read action preview. This is an
+execution preview, not permission to trade. Do not access wallet, setup,
+positions, orders, or resources; do not call blockrun_polymarket; do not submit
+or retry. Redact identifiers and end exactly:
+DRY RUN — no order signed or submitted.
 ```
 
 ## Stage flow
@@ -135,10 +139,11 @@ demo less credible.
 
 ### 5:30–7:00 — executable order preview
 
-The agent calls `blockrun_polymarket_read` with `action:"preview"`. It chooses
-the smallest whole-dollar amount from $1–$5 that clears the live minimum share
-size and available book depth. The MCP shows the estimated fill and cannot sign
-or submit anything.
+The agent calls `blockrun_polymarket_read` with `action:"preview"` for a fixed
+$5 FOK dry-run. Five dollars reliably clears the common five-share minimum at
+any valid probability while remaining inside the demo caps; the MCP still
+rejects it if a market has a higher minimum or insufficient depth. It shows the
+estimated fill and cannot sign or submit an order.
 
 ### 7:00–8:00 — close on safety
 

--- a/docs/stanford-trading-demo.md
+++ b/docs/stanford-trading-demo.md
@@ -10,9 +10,9 @@ and no vendor API keys.
 2. It combines live BTC spot, probability history, smart-wallet positioning,
    and liquidity into one evidence table.
 3. It states both the thesis and the strongest counterevidence.
-4. It builds a real $1 CLOB order preview from the live book.
-5. It proves nothing was submitted and verifies positions with a separate
-   read-only MCP tool.
+4. It builds a live, executable-size CLOB order preview through the read-only
+   Polymarket tool.
+5. It proves nothing was signed or submitted.
 
 At Stanford, stop at dry-run. Polymarket blocks new orders from the United
 States; do not alter networking to bypass that restriction. A real-money write
@@ -26,7 +26,7 @@ Claude Code:
 ```bash
 claude mcp add blockrun-trading -s user \
   -e BLOCKRUN_BUDGET_LIMIT=0.15 \
-  -e POLYMARKET_MAX_BET_USD=2 POLYMARKET_MAX_SESSION_USD=5 \
+  -e POLYMARKET_MAX_BET_USD=5 POLYMARKET_MAX_SESSION_USD=5 \
   -- npx -y @blockrun/mcp@latest --profile trading
 claude mcp list
 ```
@@ -43,7 +43,7 @@ Codex CLI:
 ```bash
 codex mcp add blockrun-trading \
   --env BLOCKRUN_BUDGET_LIMIT=0.15 \
-  --env POLYMARKET_MAX_BET_USD=2 \
+  --env POLYMARKET_MAX_BET_USD=5 \
   --env POLYMARKET_MAX_SESSION_USD=5 \
   -- npx -y @blockrun/mcp@latest --profile trading
 codex mcp list
@@ -68,16 +68,26 @@ If image, video, chat, or phone appears, the wrong profile is installed.
 Use the `signal-to-trade-demo` Skill and say:
 
 ```text
-Build a live signal-to-trade demo for one current, liquid Polymarket Bitcoin
-threshold market. Discover it dynamically; do not use a stored condition or
-token ID. Verify the resolution rule and expiry. Then collect BTC spot,
-24-hour Yes-probability candles, 30-day smart-money positioning with at least
-100 trades, and 24-hour historical orderbooks. Make paid calls sequentially.
-
-Show an evidence table, strongest counterevidence, confidence, and a $1 FOK
-buy preview on the justified side. Never pass confirm:true. Redact all wallet,
-order, and transaction identifiers. Finish with the exact line:
+Use the signal-to-trade-demo Skill. Spend at most five US cents on public data.
+Find one current liquid Bitcoin threshold market, build the four-source signal,
+and preview the smallest executable whole-dollar FOK order from one to five US
+dollars. Do not access account data or submit anything. Redact identifiers and
+finish with the exact line:
 DRY RUN — nothing signed or submitted.
+```
+
+For the most reliable stage pacing, use two prompts instead:
+
+```text
+Use the signal-to-trade-demo Skill. Spend at most five US cents on public data.
+Find the best current liquid Bitcoin threshold market and return the four-source
+signal. Do not access account data or place/preview an order.
+```
+
+```text
+Preview the smallest executable whole-dollar FOK order from one to five US
+dollars on the best-supported side. Use only the read-only preview action, do
+not submit, and end: DRY RUN — nothing signed or submitted.
 ```
 
 ## Stage flow
@@ -88,9 +98,9 @@ DRY RUN — nothing signed or submitted.
 wallet, turn those sources into a traceable signal, and act on the same market
 without creating API accounts.”
 
-Show the nine-tool Trading profile. Point out that `polymarket_read` is
-separated from the funds-affecting trading tool, so MCP clients can approve
-reads without approving writes.
+Show the nine-tool Trading profile. Point out that order preview lives inside
+`polymarket_read`, separated from the funds-affecting trading tool, so MCP
+clients do not request write approval for a dry-run.
 
 ### 1:00–3:30 — dynamic market and signal
 
@@ -123,19 +133,17 @@ the remaining price move and negative cohort PnL argue for caution. The agent
 should be allowed to return `NO TRADE`; forcing a bullish answer would make the
 demo less credible.
 
-### 5:30–7:00 — real order preview
+### 5:30–7:00 — executable order preview
 
-The agent calls the trading tool without `confirm`. The tested live preview was
-a $1 market FOK at a best ask near 0.31. The MCP shows the estimated fill and
-does not sign or submit anything.
-
-Then call `blockrun_polymarket_read` for positions and open orders. The tested
-after-state contained zero positions and no submitted order.
+The agent calls `blockrun_polymarket_read` with `action:"preview"`. It chooses
+the smallest whole-dollar amount from $1–$5 that clears the live minimum share
+size and available book depth. The MCP shows the estimated fill and cannot sign
+or submit anything.
 
 ### 7:00–8:00 — close on safety
 
 - local signing and self-custody;
-- $2 per-order and $5 per-session demo caps;
+- $5 per-order and $5 per-session demo caps;
 - $0.15 API budget;
 - pre-payment parameter validation;
 - serialized x402 calls from one wallet;
@@ -153,7 +161,8 @@ after-state contained zero positions and no submitted order.
 
 ## Presenter checklist
 
-- Update to the release containing these fixes; run `claude mcp list`.
+- Update to the release containing these fixes; run `claude mcp list` or
+  `codex mcp list`.
 - Confirm wallet funding privately; never put an address on the projector.
 - Run setup once before screen sharing; verify approvals and blocked-region
   status without showing identifiers.

--- a/docs/stanford-trading-demo.md
+++ b/docs/stanford-trading-demo.md
@@ -1,0 +1,162 @@
+# Stanford demo: live signal → Polymarket order preview
+
+This is an 8-minute, repeatable demo for Claude Code or Codex CLI. It uses the
+BlockRun `trading` profile only: nine tools, no media schemas, one local wallet,
+and no vendor API keys.
+
+## What the audience sees
+
+1. The agent discovers a current, liquid Polymarket question.
+2. It combines live BTC spot, probability history, smart-wallet positioning,
+   and liquidity into one evidence table.
+3. It states both the thesis and the strongest counterevidence.
+4. It builds a real $1 CLOB order preview from the live book.
+5. It proves nothing was submitted and verifies positions with a separate
+   read-only MCP tool.
+
+At Stanford, stop at dry-run. Polymarket blocks new orders from the United
+States; do not alter networking to bypass that restriction. A real-money write
+test must be performed separately while physically operating from an eligible
+jurisdiction and only after explicit approval of the exact trade.
+
+## Install the isolated Trading profile
+
+Claude Code:
+
+```bash
+claude mcp add blockrun-trading -s user \
+  -e BLOCKRUN_BUDGET_LIMIT=0.15 \
+  -e POLYMARKET_MAX_BET_USD=2 POLYMARKET_MAX_SESSION_USD=5 \
+  -- npx -y @blockrun/mcp@latest --profile trading
+claude mcp list
+```
+
+Install the demo Skill from the BlockRun marketplace:
+
+```bash
+claude plugin marketplace add BlockRunAI/blockrun-mcp
+claude plugin install signal-to-trade-demo@blockrun-mcp
+```
+
+Codex CLI:
+
+```bash
+codex mcp add blockrun-trading \
+  --env BLOCKRUN_BUDGET_LIMIT=0.15 \
+  --env POLYMARKET_MAX_BET_USD=2 \
+  --env POLYMARKET_MAX_SESSION_USD=5 \
+  -- npx -y @blockrun/mcp@latest --profile trading
+codex mcp list
+```
+
+Before the fixes are published, replace the `npx` command with:
+
+```bash
+node /ABSOLUTE/PATH/blockrun-mcp/dist/index.js --profile trading
+```
+
+Expected tool surface:
+
+```text
+wallet  price  dex  markets  surf  defi  rpc  polymarket_read  polymarket
+```
+
+If image, video, chat, or phone appears, the wrong profile is installed.
+
+## Main prompt
+
+Use the `signal-to-trade-demo` Skill and say:
+
+```text
+Build a live signal-to-trade demo for one current, liquid Polymarket Bitcoin
+threshold market. Discover it dynamically; do not use a stored condition or
+token ID. Verify the resolution rule and expiry. Then collect BTC spot,
+24-hour Yes-probability candles, 30-day smart-money positioning with at least
+100 trades, and 24-hour historical orderbooks. Make paid calls sequentially.
+
+Show an evidence table, strongest counterevidence, confidence, and a $1 FOK
+buy preview on the justified side. Never pass confirm:true. Redact all wallet,
+order, and transaction identifiers. Finish with the exact line:
+DRY RUN — nothing signed or submitted.
+```
+
+## Stage flow
+
+### 0:00–1:00 — one-line product story
+
+“BlockRun lets an agent pay for several live data sources with one self-custody
+wallet, turn those sources into a traceable signal, and act on the same market
+without creating API accounts.”
+
+Show the nine-tool Trading profile. Point out that `polymarket_read` is
+separated from the funds-affecting trading tool, so MCP clients can approve
+reads without approving writes.
+
+### 1:00–3:30 — dynamic market and signal
+
+Let the agent select a case live. The primary case is a near-dated Bitcoin
+price threshold. On 2026-07-26, the tested candidate was “Will Bitcoin reach
+$67,500 in July?”; reselect on presentation day instead of relying on it.
+
+Require the agent to show:
+
+- market probability and exact resolution source;
+- current BTC price and percentage move required;
+- probability change over a fixed window;
+- smart-money buyer share plus aggregate PnL;
+- recent volume/trades and an executable book.
+
+### 3:30–5:30 — explain the evidence, not a magic score
+
+The tested snapshot on 2026-07-26 showed:
+
+| Evidence | Observation |
+|---|---|
+| Market | Yes about 31%; $2.03M total volume; about $37.4k and 541 trades in 24h |
+| BTC spot | About $64,698; roughly 4.33% below the $67,500 trigger |
+| Probability trend | About 24% → 31% over the tested 24-hour window |
+| Smart-money cohort | 647 wallets; 70.48% net buyers; about $1.77M volume |
+| Counterevidence | Cohort realized PnL about -$28.6k and total PnL about -$48.6k |
+
+This is mixed evidence: positioning and probability momentum lean Yes, while
+the remaining price move and negative cohort PnL argue for caution. The agent
+should be allowed to return `NO TRADE`; forcing a bullish answer would make the
+demo less credible.
+
+### 5:30–7:00 — real order preview
+
+The agent calls the trading tool without `confirm`. The tested live preview was
+a $1 market FOK at a best ask near 0.31. The MCP shows the estimated fill and
+does not sign or submit anything.
+
+Then call `blockrun_polymarket_read` for positions and open orders. The tested
+after-state contained zero positions and no submitted order.
+
+### 7:00–8:00 — close on safety
+
+- local signing and self-custody;
+- $2 per-order and $5 per-session demo caps;
+- $0.15 API budget;
+- pre-payment parameter validation;
+- serialized x402 calls from one wallet;
+- explicit confirmation gate plus regional eligibility enforcement.
+
+## Tested fallbacks
+
+1. A different BTC threshold with clear Binance 1-minute-candle resolution.
+2. A high-volume Fed/rates question, with cited live news kept separate from
+   market-implied probability.
+3. A live crypto up/down window only when activity and the order book are
+   non-zero. Never select the first future placeholder from the raw feed.
+4. If data is stale, liquidity is thin, or the region is blocked, finish with
+   `NO TRADE` or dry-run. Do not hide the failed gate.
+
+## Presenter checklist
+
+- Update to the release containing these fixes; run `claude mcp list`.
+- Confirm wallet funding privately; never put an address on the projector.
+- Run setup once before screen sharing; verify approvals and blocked-region
+  status without showing identifiers.
+- Keep a screenshot of the tested evidence table as a network fallback.
+- Close unrelated terminals and notifications.
+- Never type `confirm:true` during the Stanford session.

--- a/docs/stanford-trading-demo.md
+++ b/docs/stanford-trading-demo.md
@@ -19,6 +19,12 @@ States; do not alter networking to bypass that restriction. A real-money write
 test must be performed separately while physically operating from an eligible
 jurisdiction and only after explicit approval of the exact trade.
 
+The shipped default routes CLOB traffic through BlockRun's Finland egress, so
+`setup` will report a permitted region even from the venue. For the demo to be
+region-honest, set `POLYMARKET_CLOB_HOST=https://clob.polymarket.com`
+explicitly on the presentation machine (the install commands below do this) and
+let `setup` report the real status. Never type `confirm:true` regardless.
+
 ## Install the isolated Trading profile
 
 Claude Code:
@@ -26,7 +32,9 @@ Claude Code:
 ```bash
 claude mcp add blockrun-trading -s user \
   -e BLOCKRUN_BUDGET_LIMIT=0.15 \
-  -e POLYMARKET_MAX_BET_USD=5 POLYMARKET_MAX_SESSION_USD=5 \
+  -e POLYMARKET_MAX_BET_USD=5 \
+  -e POLYMARKET_MAX_SESSION_USD=5 \
+  -e POLYMARKET_CLOB_HOST=https://clob.polymarket.com \
   -- npx -y @blockrun/mcp@latest --profile trading
 claude mcp list
 ```
@@ -45,6 +53,7 @@ codex mcp add blockrun-trading \
   --env BLOCKRUN_BUDGET_LIMIT=0.15 \
   --env POLYMARKET_MAX_BET_USD=5 \
   --env POLYMARKET_MAX_SESSION_USD=5 \
+  --env POLYMARKET_CLOB_HOST=https://clob.polymarket.com \
   -- npx -y @blockrun/mcp@latest --profile trading
 codex mcp list
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "files": [
     "dist",
     "skills",
-    "docs",
     "README.md"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "files": [
     "dist",
     "skills",
+    "docs",
     "README.md"
   ],
   "scripts": {

--- a/skills/polymarket-trading/SKILL.md
+++ b/skills/polymarket-trading/SKILL.md
@@ -21,10 +21,10 @@ this tool only trades.
   signer's EIP-712 signatures. Deploy/approve/redeem are **gasless** (relayer).
 - **Money separation**: bets spend pUSD on Polygon; x402 API fees spend USDC on
   Base. The budget ledger does NOT cover bets — `confirm:true` + caps do.
-- **Zero setup**: no Polymarket account, no API keys, no gas token. On first
-  `setup` the MCP bootstraps a builder key from the user's OWN wallet, then
-  derives + deploys the vault (all gasless). Geoblock is handled by default —
-  CLOB traffic routes through BlockRun's Finland egress out of the box.
+- **Zero account setup**: no Polymarket account, no API keys, no gas token. On
+  first `setup` the MCP bootstraps a builder key from the user's OWN wallet,
+  then derives + deploys the vault (all gasless). The direct CLOB connection
+  still enforces Polymarket's geographic eligibility rules.
 
 ## Golden rules for agents
 
@@ -35,15 +35,15 @@ this tool only trades.
    are enforced server-side; don't try to split orders to sneak past them.
 3. On ANY error, read the message — it says exactly what to do next (fund,
    approve, region, re-run setup). Don't retry blindly.
+4. If `setup` reports a blocked region, stop before every confirmed order.
+   Read-only research and dry-run previews are still suitable for a demo.
 
 ## End-to-end flow
 
 ```
 # 0. No Polymarket account or API keys needed — the MCP bootstraps everything
-#    from the user's own wallet on first setup. (Geoblock is already handled:
-#    CLOB traffic routes through BlockRun's Finland egress by default. Set
-#    POLYMARKET_CLOB_HOST only to use your own egress, or to hit Polymarket
-#    directly from a permitted region.)
+#    from the user's own wallet on first setup. Geographic eligibility still
+#    applies; the default CLOB endpoint is direct to Polymarket.
 
 # 1. Provision + inspect (idempotent, safe to re-run any time)
 blockrun_polymarket action:"setup"
@@ -57,8 +57,9 @@ blockrun_polymarket action:"fund" amount_usd:5 confirm:true
 # 3. Sign the one-time gasless approval batch (after user consent)
 blockrun_polymarket action:"setup" confirm:true
 
-# 4. Find a market + token (data tool, paid data)
-blockrun_markets path:"polymarket/markets" params:{...}   # → clobTokenIds, conditionId
+# 4. Find a market, then resolve the selected condition (paid data)
+blockrun_markets path:"markets/search" params:{q:"Bitcoin",status:"open",venue:"polymarket",limit:"20"}
+blockrun_markets path:"polymarket/markets/keyset" params:{condition_id:"0x...",status:"open",limit:"5"}
 
 # 5. Preview, then place
 blockrun_polymarket action:"buy" token_id:"..." amount_usd:2            # dry-run
@@ -67,9 +68,9 @@ blockrun_polymarket action:"buy" token_id:"..." amount_usd:2 confirm:true  # mar
 #   or via condition: condition_id:"0x..." outcome:"Yes"
 
 # 6. Manage
-blockrun_polymarket action:"orders"                     # open orders
+blockrun_polymarket_read action:"orders"                # open orders
 blockrun_polymarket action:"cancel" order_id:"..."      # or all:true
-blockrun_polymarket action:"positions"                  # holdings + PnL + redeemable
+blockrun_polymarket_read action:"positions"             # holdings + PnL + redeemable
 
 # 7. Claim winnings after resolution (gasless)
 blockrun_polymarket action:"redeem" condition_id:"0x..."             # preview
@@ -90,16 +91,12 @@ blockrun_polymarket action:"withdraw" confirm:true                   # (partial:
 
 ## Regions / geoblock
 
-Order placement is IP-geoblocked (US/UK/EU + many regions). **Handled by
-default** — CLOB traffic routes through BlockRun's Finland egress, so `setup`
-reports `✅ Region: order placement permitted` out of the box; you don't need to
-do anything. A user can override by pointing `POLYMARKET_CLOB_HOST` at their
-own relay (or at Polymarket directly, from a permitted region), optionally
-reached through their own proxy via `POLYMARKET_CLOB_PROXY` / `HTTPS_PROXY`
-(`POLYMARKET_CLOB_PROXY` wins if both are set). A proxy alone does NOT change
-the Polymarket-facing egress — CLOB traffic still exits from BlockRun's Finland
-relay unless `POLYMARKET_CLOB_HOST` is also repointed. Respecting Polymarket's ToS for the
-user's jurisdiction is the user's responsibility — never suggest evading it.
+Order placement is IP-restricted in some jurisdictions. The default connection
+is direct to Polymarket, and `setup` reports whether the current egress is
+eligible. If it is blocked, never submit an order with `confirm:true`; continue
+with read-only data and dry-run previews. `POLYMARKET_CLOB_HOST`,
+`POLYMARKET_CLOB_PROXY`, and `HTTPS_PROXY` are for compliant private
+infrastructure and debugging only, not for bypassing a regional restriction.
 
 ## Troubleshooting
 

--- a/skills/polymarket-trading/SKILL.md
+++ b/skills/polymarket-trading/SKILL.md
@@ -62,8 +62,8 @@ blockrun_markets path:"markets/search" params:{q:"Bitcoin",status:"open",venue:"
 blockrun_markets path:"polymarket/markets/keyset" params:{condition_id:"0x...",status:"open",limit:"5"}
 
 # 5. Preview, then place
-blockrun_polymarket action:"buy" token_id:"..." amount_usd:2            # dry-run
-blockrun_polymarket action:"buy" token_id:"..." amount_usd:2 confirm:true  # market FOK
+blockrun_polymarket_read action:"preview" side:"buy" token_id:"..." amount_usd:5 order_type:"FOK"
+blockrun_polymarket action:"buy" token_id:"..." amount_usd:5 order_type:"FOK" confirm:true
 #   or limit: price:0.45 size:10 (GTC; order_type:"GTD" + expires_at for expiry)
 #   or via condition: condition_id:"0x..." outcome:"Yes"
 

--- a/skills/polymarket-trading/SKILL.md
+++ b/skills/polymarket-trading/SKILL.md
@@ -21,10 +21,10 @@ this tool only trades.
   signer's EIP-712 signatures. Deploy/approve/redeem are **gasless** (relayer).
 - **Money separation**: bets spend pUSD on Polygon; x402 API fees spend USDC on
   Base. The budget ledger does NOT cover bets — `confirm:true` + caps do.
-- **Zero account setup**: no Polymarket account, no API keys, no gas token. On
-  first `setup` the MCP bootstraps a builder key from the user's OWN wallet,
-  then derives + deploys the vault (all gasless). The direct CLOB connection
-  still enforces Polymarket's geographic eligibility rules.
+- **Zero setup**: no Polymarket account, no API keys, no gas token. On first
+  `setup` the MCP bootstraps a builder key from the user's OWN wallet, then
+  derives + deploys the vault (all gasless). Geoblock is handled by default —
+  CLOB traffic routes through BlockRun's Finland egress out of the box.
 
 ## Golden rules for agents
 
@@ -35,15 +35,15 @@ this tool only trades.
    are enforced server-side; don't try to split orders to sneak past them.
 3. On ANY error, read the message — it says exactly what to do next (fund,
    approve, region, re-run setup). Don't retry blindly.
-4. If `setup` reports a blocked region, stop before every confirmed order.
-   Read-only research and dry-run previews are still suitable for a demo.
 
 ## End-to-end flow
 
 ```
 # 0. No Polymarket account or API keys needed — the MCP bootstraps everything
-#    from the user's own wallet on first setup. Geographic eligibility still
-#    applies; the default CLOB endpoint is direct to Polymarket.
+#    from the user's own wallet on first setup. (Geoblock is already handled:
+#    CLOB traffic routes through BlockRun's Finland egress by default. Set
+#    POLYMARKET_CLOB_HOST only to use your own egress, or to hit Polymarket
+#    directly from a permitted region.)
 
 # 1. Provision + inspect (idempotent, safe to re-run any time)
 blockrun_polymarket action:"setup"
@@ -91,12 +91,16 @@ blockrun_polymarket action:"withdraw" confirm:true                   # (partial:
 
 ## Regions / geoblock
 
-Order placement is IP-restricted in some jurisdictions. The default connection
-is direct to Polymarket, and `setup` reports whether the current egress is
-eligible. If it is blocked, never submit an order with `confirm:true`; continue
-with read-only data and dry-run previews. `POLYMARKET_CLOB_HOST`,
-`POLYMARKET_CLOB_PROXY`, and `HTTPS_PROXY` are for compliant private
-infrastructure and debugging only, not for bypassing a regional restriction.
+Order placement is IP-geoblocked (US/UK/EU + many regions). **Handled by
+default** — CLOB traffic routes through BlockRun's Finland egress, so `setup`
+reports `✅ Region: order placement permitted` out of the box; you don't need to
+do anything. A user can override by pointing `POLYMARKET_CLOB_HOST` at their
+own relay (or at Polymarket directly, from a permitted region), optionally
+reached through their own proxy via `POLYMARKET_CLOB_PROXY` / `HTTPS_PROXY`
+(`POLYMARKET_CLOB_PROXY` wins if both are set). A proxy alone does NOT change
+the Polymarket-facing egress — CLOB traffic still exits from BlockRun's Finland
+relay unless `POLYMARKET_CLOB_HOST` is also repointed. Respecting Polymarket's ToS for the
+user's jurisdiction is the user's responsibility — never suggest evading it.
 
 ## Troubleshooting
 

--- a/skills/prediction-markets/SKILL.md
+++ b/skills/prediction-markets/SKILL.md
@@ -88,8 +88,10 @@ Current parameter contracts that prevent paid 4xx responses:
   `1440`. Optional `start_time`/`end_time` are Unix seconds.
 - `polymarket/orderbooks` requires `token_id`, `start_time`, and `end_time`; the
   times are Unix milliseconds.
-- Smart-money calls require a meaningful filter. For general analysis use
-  `{ window: "30d", min_trades: "100" }`.
+- Smart-money calls need at least one cohort filter — `window`, `min_trades`,
+  `min_volume`, `min_roi`, `min_realized_pnl`, `min_total_pnl`, `min_win_rate`,
+  or `min_profit_factor`. For general analysis use
+  `{ window: "30d", min_trades: "100" }`; narrower cohorts are fine too.
 
 ## Two Pricing Tiers
 

--- a/skills/prediction-markets/SKILL.md
+++ b/skills/prediction-markets/SKILL.md
@@ -64,7 +64,7 @@ One tool, three params. Method auto-routes: POST when `body` is set, GET otherwi
 ```ts
 blockrun_markets({ path: "polymarket/events", params: { limit: "10" } })
 
-blockrun_markets({ path: "polymarket/candlesticks/0xCONDITION_ID", params: { interval: "1h" } })
+blockrun_markets({ path: "polymarket/candlesticks/0xCONDITION_ID", params: { interval: "60" } })
 
 blockrun_markets({ path: "polymarket/wallet/identities", body: {
   addresses: ["0xabc...", "0xdef..."]
@@ -72,6 +72,20 @@ blockrun_markets({ path: "polymarket/wallet/identities", body: {
 ```
 
 Paths are relative — no `/api/v1/pm/` prefix. Use `agent_id` to bill a child agent's budget.
+
+Make paid calls sequentially when one wallet is paying. The MCP serializes them
+as a second guard against concurrent x402 payment races.
+
+Current parameter contracts that prevent paid 4xx responses:
+
+- Do not call `markets/listings`; use `markets/search` for discovery, then
+  `polymarket/markets/keyset` with `condition_id` for the selected market.
+- Candlestick `interval` is integer minutes: `0`, `1`, `5`, `15`, `60`, or
+  `1440`. Optional `start_time`/`end_time` are Unix seconds.
+- `polymarket/orderbooks` requires `token_id`, `start_time`, and `end_time`; the
+  times are Unix milliseconds.
+- Smart-money calls require a meaningful filter. For general analysis use
+  `{ window: "30d", min_trades: "100" }`.
 
 ## Two Pricing Tiers
 
@@ -87,7 +101,6 @@ Pass-through pricing, 0% BlockRun margin — settles straight to Predexon's Base
 |---|---|---|
 | **Same question across venues** | `markets` | 1 |
 | **Search every venue at once** | `markets/search` | 2 |
-| Venue-native tradable listings | `markets/listings` | 1 |
 | Resolve a canonical outcome ID | `outcomes/{predexon_id}` | 1 |
 | **Equivalent markets (arbitrage)** | `matching-markets` | 2 |
 | Active matched pairs | `matching-markets/pairs` | 2 |
@@ -156,9 +169,14 @@ blockrun_markets({ path: "outcomes/PXM-12345" })   // → venue listings + price
 ### 3. "Show me this market's price history" (impossible from a free API)
 
 ```ts
-blockrun_markets({ path: "polymarket/candlesticks/0xCONDITION_ID", params: { interval: "1h" } })
+blockrun_markets({ path: "polymarket/candlesticks/0xCONDITION_ID", params: {
+  interval: "60", start_time: "<UNIX_SECONDS>", end_time: "<UNIX_SECONDS>"
+} })
 blockrun_markets({ path: "polymarket/volume-chart/0xCONDITION_ID" })
 blockrun_markets({ path: "polymarket/markets/0xCONDITION_ID/open_interest" })
+blockrun_markets({ path: "polymarket/orderbooks", params: {
+  token_id: "<TOKEN_ID>", start_time: "<UNIX_MILLISECONDS>", end_time: "<UNIX_MILLISECONDS>"
+} })
 ```
 
 ### 4. "Who's smart money betting on in this market?" ← compound
@@ -167,7 +185,9 @@ Positioning → then profile the wallets behind it.
 
 ```ts
 // 1. Which high-performing wallets are in this market, and on which side
-blockrun_markets({ path: "polymarket/market/0xCONDITION_ID/smart-money" })
+blockrun_markets({ path: "polymarket/market/0xCONDITION_ID/smart-money", params: {
+  window: "30d", min_trades: "100"
+} })
 
 // 2. Profile the top wallet it returns — win rate, P&L, style
 blockrun_markets({ path: "polymarket/wallet/0xWHALE" })
@@ -257,7 +277,7 @@ Inside the MCP, use `blockrun_markets` above. For standalone scripts:
 from blockrun_llm import setup_agent_wallet   # setup_agent_solana_wallet() on Solana
 client = setup_agent_wallet()
 
-client.pm("polymarket/candlesticks/0xCONDITION_ID", interval="1h")
+client.pm("polymarket/candlesticks/0xCONDITION_ID", interval="60")
 client.pm_query("polymarket/wallet/identities", {"addresses": ["0xabc"]})
 ```
 

--- a/skills/prediction-markets/SKILL.md
+++ b/skills/prediction-markets/SKILL.md
@@ -78,8 +78,12 @@ as a second guard against concurrent x402 payment races.
 
 Current parameter contracts that prevent paid 4xx responses:
 
-- Do not call `markets/listings`; use `markets/search` for discovery, then
-  `polymarket/markets/keyset` with `condition_id` for the selected market.
+- Discover with `markets/search` (its search term is `q`), then resolve the
+  selected market with `polymarket/markets/keyset` + `condition_id`.
+- On `polymarket/markets{,/keyset}` the free-text filter is `search`, **not**
+  `q`. Use `status:"open"` rather than Gamma's `active`/`closed`, and `sort`
+  rather than `order`/`ascending`. `end_after`/`end_before` are supported
+  (Unix seconds).
 - Candlestick `interval` is integer minutes: `0`, `1`, `5`, `15`, `60`, or
   `1440`. Optional `start_time`/`end_time` are Unix seconds.
 - `polymarket/orderbooks` requires `token_id`, `start_time`, and `end_time`; the
@@ -101,6 +105,7 @@ Pass-through pricing, 0% BlockRun margin — settles straight to Predexon's Base
 |---|---|---|
 | **Same question across venues** | `markets` | 1 |
 | **Search every venue at once** | `markets/search` | 2 |
+| Venue-native tradable listings | `markets/listings` | 1 |
 | Resolve a canonical outcome ID | `outcomes/{predexon_id}` | 1 |
 | **Equivalent markets (arbitrage)** | `matching-markets` | 2 |
 | Active matched pairs | `matching-markets/pairs` | 2 |

--- a/skills/signal-to-trade-demo/SKILL.md
+++ b/skills/signal-to-trade-demo/SKILL.md
@@ -22,7 +22,7 @@ or preparing a fallback.
    `confirm:true`. Continue with live data and a dry-run order preview only.
    A Stanford/US presentation is always dry-run mode.
 3. Always preview through `blockrun_polymarket_read` `action:"preview"`. It has
-   no confirmation input and cannot sign or submit. A real order requires the
+   no confirmation input and cannot sign or submit an order. A real order requires the
    user's explicit approval of the exact market, outcome, amount, price/type,
    and current region eligibility.
 4. Choose the smallest whole-dollar preview from $1–$5 that satisfies the live
@@ -139,7 +139,7 @@ blockrun_polymarket_read {
 ```
 
 Show the outcome, live best ask, estimated shares, max cost, and the explicit
-line `DRY RUN — nothing signed or submitted`.
+line `DRY RUN — no order signed or submitted`.
 
 If the user explicitly approves a real order and the region is permitted,
 repeat the exact economics with `blockrun_polymarket` action `buy`/`sell` and

--- a/skills/signal-to-trade-demo/SKILL.md
+++ b/skills/signal-to-trade-demo/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: signal-to-trade-demo
+description: Prepare or run a polished BlockRun trading demo that discovers a current Polymarket market, combines live price, probability history, smart-money, and liquidity evidence into a balanced signal, produces a real order dry-run, and verifies orders or positions. Use for live demos, signal-to-trade workflows, current crypto prediction markets, or when an agent must decide whether a candidate is safe and presentable before trading.
+---
+
+# Signal-to-Trade Demo
+
+Run one reproducible chain: discover → verify → analyze → preview → inspect.
+Treat signals as evidence, never as a promise of profit. Never expose a wallet,
+credential, order ID, or transaction hash in presentation output.
+
+Read [references/demo-cases.md](references/demo-cases.md) when selecting a case
+or preparing a fallback.
+
+## Hard safety contract
+
+1. Start with `blockrun_polymarket` `action:"setup"` without `confirm` to check
+   readiness and geographic eligibility. Use `blockrun_polymarket_read` for
+   positions and orders.
+2. If the current egress is blocked, never call a funds-affecting action with
+   `confirm:true`. Continue with live data and a dry-run order preview only.
+   A Stanford/US presentation is always dry-run mode.
+3. Always preview an order without `confirm` first. A real order requires the
+   user's explicit approval of the exact market, outcome, amount, price/type,
+   and current region eligibility.
+4. Default demo notional is $1, hard cap $2. Do not split orders to bypass caps.
+5. Make paid market-data calls sequentially. Do not launch them in parallel
+   against one payment wallet.
+
+## 1. Preflight
+
+- Confirm the Trading profile exposes nine tools and no image/video/media tool:
+  wallet, price, dex, markets, surf, defi, rpc, polymarket_read, polymarket.
+- Check `blockrun_wallet` status and set a small API budget if needed. Report
+  only chain and rounded balance; redact addresses.
+- Call `blockrun_polymarket` setup without confirmation. Record only readiness,
+  pUSD balance, approvals, and region result.
+- Call `blockrun_polymarket_read` positions and orders to establish the before
+  state.
+
+## 2. Discover a current market
+
+Use a dynamic search rather than a hard-coded condition or token ID:
+
+```text
+blockrun_markets {
+  path: "markets/search",
+  params: { q: "Bitcoin", status: "open", venue: "polymarket", limit: "20" }
+}
+```
+
+Do not use `markets/listings`; the current Predexon API no longer exposes it.
+Do not automatically select the first `polymarket/crypto-updown` result because
+that feed can contain future placeholders with no liquidity. Rank candidates by:
+
+- open status and a future close time;
+- an unambiguous resolution source and threshold;
+- non-zero 24-hour volume and trade count;
+- a valid condition ID plus outcome token IDs;
+- an outcome price away from 0 and 1;
+- a live order preview that finds a usable book.
+
+Resolve the selected market using `polymarket/markets/keyset` with
+`condition_id`, `status:"open"`, and a small `limit`. Do not invent Gamma API
+parameters such as `active`, `closed`, `order`, or `ascending`; unknown values
+may be ignored silently.
+
+## 3. Collect evidence sequentially
+
+Use four independent lenses where the market supports them:
+
+1. **Underlying:** get current BTC/USD with `blockrun_price`, then compute the
+   exact percentage move required to reach the market threshold before expiry.
+2. **Probability trend:** query the selected Yes token:
+
+   ```text
+   blockrun_markets {
+     path: "polymarket/candlesticks/token/<TOKEN_ID>",
+     params: { interval: "60", start_time: "<UNIX_SECONDS>", end_time: "<UNIX_SECONDS>" }
+   }
+   ```
+
+   `interval` is integer minutes (`60`, not `1h`); `start_time` and `end_time`
+   are Unix seconds.
+3. **Smart money:** use a meaningful cohort:
+
+   ```text
+   blockrun_markets {
+     path: "polymarket/market/<CONDITION_ID>/smart-money",
+     params: { window: "30d", min_trades: "100" }
+   }
+   ```
+
+   Report wallet count, net-buyer share, volume, and aggregate PnL. A high buyer
+   share with negative PnL is mixed evidence, not automatically bullish.
+4. **Liquidity/history:** query historical orderbooks with `token_id`,
+   `start_time`, and `end_time` in Unix milliseconds. The order dry-run is the
+   authoritative live fillability check.
+
+Record the timestamp and data source for every observation. If a source fails,
+label it unavailable and continue; never manufacture a value.
+
+## 4. Build the signal
+
+Present an evidence table with these columns:
+
+| Source | Observation | Supports | Reliability |
+|---|---|---|---|
+| Spot vs threshold | Exact distance and time remaining | Yes/No/Mixed | High |
+| Market trend | Probability change over a fixed window | Yes/No/Mixed | Medium |
+| Smart-money cohort | Buyer share, volume, PnL | Yes/No/Mixed | Medium |
+| Book/liquidity | Spread, available size, 24h activity | Executable/Thin | High |
+
+Then state:
+
+- one-sentence thesis;
+- strongest counterevidence;
+- confidence (`low`, `medium`, or `high`) with a reason;
+- proposed side and maximum $1 preview, or `NO TRADE` when gates fail.
+
+Do not describe the result as financial advice or a guaranteed “good signal.”
+
+## 5. Preview and verify
+
+Preview without confirmation:
+
+```text
+blockrun_polymarket {
+  action: "buy",
+  token_id: "<TOKEN_ID>",
+  amount_usd: 1,
+  order_type: "FOK"
+}
+```
+
+Show the outcome, live best ask, estimated shares, max cost, and the explicit
+line `DRY RUN — nothing signed or submitted`. If blocked, stop here.
+
+If the user explicitly approves a real order and the region is permitted,
+repeat the exact call with `confirm:true`, then use
+`blockrun_polymarket_read` to inspect positions and open orders. Redact all
+identifiers. If a FOK does not fill, report it honestly; do not silently switch
+to FAK or raise the price.
+
+## Presentation output
+
+End with a compact slide-ready block:
+
+```text
+LIVE SIGNAL SNAPSHOT — <UTC timestamp>
+Market: <question> | Implied probability: <p>
+Underlying: <spot> | Required move: <x%> | Time left: <duration>
+Trend: <change> | Smart money: <buyer share + PnL caveat>
+Liquidity: <spread/activity>
+Verdict: <side or NO TRADE> | Confidence: <level>
+Order: $1 <side> preview | DRY RUN / SUBMITTED
+Safety: local signing, capped notional, IDs redacted
+```

--- a/skills/signal-to-trade-demo/SKILL.md
+++ b/skills/signal-to-trade-demo/SKILL.md
@@ -52,8 +52,8 @@ blockrun_markets {
 }
 ```
 
-Do not use `markets/listings`; the current Predexon API no longer exposes it.
-Do not automatically select the first `polymarket/crypto-updown` result because
+`markets/search` is the discovery path for a demo — it ranks across venues in
+one call. Do not automatically select the first `polymarket/crypto-updown` result because
 that feed can contain future placeholders with no liquidity. Rank candidates by:
 
 - open status and a future close time;
@@ -64,9 +64,10 @@ that feed can contain future placeholders with no liquidity. Rank candidates by:
 - a live order preview that finds a usable book.
 
 Resolve the selected market using `polymarket/markets/keyset` with
-`condition_id`, `status:"open"`, and a small `limit`. Do not invent Gamma API
-parameters such as `active`, `closed`, `order`, `ascending`, `search`, or
-`sort`; the MCP rejects these before payment.
+`condition_id`, `status:"open"`, and a small `limit`. Do not invent Gamma-only
+parameters such as `active`, `closed`, `order`, or `ascending`; the MCP rejects
+those before payment. Predexon's own `search`, `sort`, `end_after`, and
+`end_before` filters are supported on that endpoint.
 
 ## 3. Collect evidence sequentially
 

--- a/skills/signal-to-trade-demo/SKILL.md
+++ b/skills/signal-to-trade-demo/SKILL.md
@@ -14,29 +14,32 @@ or preparing a fallback.
 
 ## Hard safety contract
 
-1. Start with `blockrun_polymarket` `action:"setup"` without `confirm` to check
-   readiness and geographic eligibility. Use `blockrun_polymarket_read` for
-   positions and orders.
+1. In a presentation dry-run, do not call wallet, setup, positions, orders, or
+   resources. Those responses can contain wallet-derived identifiers before the
+   final answer is redacted. The presenter performs account readiness privately
+   before screen sharing.
 2. If the current egress is blocked, never call a funds-affecting action with
    `confirm:true`. Continue with live data and a dry-run order preview only.
    A Stanford/US presentation is always dry-run mode.
-3. Always preview an order without `confirm` first. A real order requires the
+3. Always preview through `blockrun_polymarket_read` `action:"preview"`. It has
+   no confirmation input and cannot sign or submit. A real order requires the
    user's explicit approval of the exact market, outcome, amount, price/type,
    and current region eligibility.
-4. Default demo notional is $1, hard cap $2. Do not split orders to bypass caps.
+4. Choose the smallest whole-dollar preview from $1–$5 that satisfies the live
+   `min_order_size` and book depth. Never present a smaller, non-executable
+   preview as valid. Do not split orders to bypass caps.
 5. Make paid market-data calls sequentially. Do not launch them in parallel
    against one payment wallet.
 
-## 1. Preflight
+## 1. Private operator preflight
 
 - Confirm the Trading profile exposes nine tools and no image/video/media tool:
   wallet, price, dex, markets, surf, defi, rpc, polymarket_read, polymarket.
-- Check `blockrun_wallet` status and set a small API budget if needed. Report
-  only chain and rounded balance; redact addresses.
-- Call `blockrun_polymarket` setup without confirmation. Record only readiness,
-  pUSD balance, approvals, and region result.
-- Call `blockrun_polymarket_read` positions and orders to establish the before
-  state.
+- Before screen sharing, the human operator may check `blockrun_wallet`, run
+  setup, and inspect positions/orders. Never include those raw calls in the
+  presentation conversation.
+- For the live dry-run conversation, begin directly with public market
+  discovery. No account state is required to preview a CLOB order.
 
 ## 2. Discover a current market
 
@@ -62,8 +65,8 @@ that feed can contain future placeholders with no liquidity. Rank candidates by:
 
 Resolve the selected market using `polymarket/markets/keyset` with
 `condition_id`, `status:"open"`, and a small `limit`. Do not invent Gamma API
-parameters such as `active`, `closed`, `order`, or `ascending`; unknown values
-may be ignored silently.
+parameters such as `active`, `closed`, `order`, `ascending`, `search`, or
+`sort`; the MCP rejects these before payment.
 
 ## 3. Collect evidence sequentially
 
@@ -116,28 +119,31 @@ Then state:
 - one-sentence thesis;
 - strongest counterevidence;
 - confidence (`low`, `medium`, or `high`) with a reason;
-- proposed side and maximum $1 preview, or `NO TRADE` when gates fail.
+- proposed side and the smallest executable whole-dollar preview from $1–$5,
+  or `NO TRADE` when gates fail.
 
 Do not describe the result as financial advice or a guaranteed “good signal.”
 
 ## 5. Preview and verify
 
-Preview without confirmation:
+Preview through the dedicated non-destructive action:
 
 ```text
-blockrun_polymarket {
-  action: "buy",
+blockrun_polymarket_read {
+  action: "preview",
+  side: "buy",
   token_id: "<TOKEN_ID>",
-  amount_usd: 1,
+  amount_usd: <SMALLEST_WHOLE_DOLLAR_FROM_1_TO_5_THAT_MEETS_MIN_SIZE>,
   order_type: "FOK"
 }
 ```
 
 Show the outcome, live best ask, estimated shares, max cost, and the explicit
-line `DRY RUN — nothing signed or submitted`. If blocked, stop here.
+line `DRY RUN — nothing signed or submitted`.
 
 If the user explicitly approves a real order and the region is permitted,
-repeat the exact call with `confirm:true`, then use
+repeat the exact economics with `blockrun_polymarket` action `buy`/`sell` and
+`confirm:true`, then use
 `blockrun_polymarket_read` to inspect positions and open orders. Redact all
 identifiers. If a FOK does not fill, report it honestly; do not silently switch
 to FAK or raise the price.
@@ -153,6 +159,6 @@ Underlying: <spot> | Required move: <x%> | Time left: <duration>
 Trend: <change> | Smart money: <buyer share + PnL caveat>
 Liquidity: <spread/activity>
 Verdict: <side or NO TRADE> | Confidence: <level>
-Order: $1 <side> preview | DRY RUN / SUBMITTED
+Order: $<amount> <side> preview | DRY RUN / SUBMITTED
 Safety: local signing, capped notional, IDs redacted
 ```

--- a/skills/signal-to-trade-demo/agents/openai.yaml
+++ b/skills/signal-to-trade-demo/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Signal to Trade Demo"
+  short_description: "Build a verified Polymarket signal-to-order demo"
+  default_prompt: "Use $signal-to-trade-demo to analyze a live Polymarket market and prepare a safe order preview."

--- a/skills/signal-to-trade-demo/references/demo-cases.md
+++ b/skills/signal-to-trade-demo/references/demo-cases.md
@@ -1,0 +1,37 @@
+# Demo case selection
+
+All cases are selected live. Never hard-code a condition ID, token ID, price,
+or outcome in a presentation script.
+
+## Case A — BTC reaches a threshold (primary)
+
+Search open Polymarket Bitcoin markets and choose a near-dated threshold with
+material 24-hour activity. It gives a clear story: current BTC spot, percentage
+move required, probability trend, smart-money positioning, and live fillability.
+Prefer this case for the main Stanford demo.
+
+Reject it when the resolution source is unclear, expiry has passed, 24-hour
+volume is zero, no Yes/No token is present, or the dry-run finds no book.
+
+## Case B — macro event (fallback)
+
+Search an open Fed/rates or inflation question with a precise resolution rule.
+Use the same market-history, smart-money, and book lenses. Add live news only
+when the Trading profile's `blockrun_surf` can cite a current source. Keep news
+and market-implied probability separate.
+
+## Case C — crypto up/down (short-form fallback)
+
+Use only a window that is already live, has non-zero recent volume/trades, and
+has an executable order book. Raw `polymarket/crypto-updown` results may include
+pre-created future windows with zero liquidity, so never pick the first item.
+
+## Fallback ladder
+
+1. If the candidate is stale or thin, return to `markets/search` and rank again.
+2. If a paid history source is unavailable, show the remaining evidence and
+   reduce confidence; do not retry-loop.
+3. If no candidate passes the gates, demonstrate a truthful `NO TRADE` decision.
+   This is a stronger safety demo than forcing a weak trade.
+4. If geographic eligibility is blocked, finish with the real CLOB dry-run and
+   the read-only before/after state. Never alter networking to evade the block.

--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -23,7 +23,7 @@ import { registerPhoneTool } from "./tools/phone.js";
 import { registerSurfTool } from "./tools/surf.js";
 import { registerRpcTool } from "./tools/rpc.js";
 import { registerDefiTool } from "./tools/defi.js";
-import { registerPolymarketTool } from "./tools/polymarket.js";
+import { registerPolymarketReadTool, registerPolymarketTool } from "./tools/polymarket.js";
 import { resolveTools, type ToolName } from "./profiles.js";
 
 /**
@@ -73,6 +73,7 @@ export function initializeMcpServer(
     surf: () => registerSurfTool(server, budget),
     rpc: () => registerRpcTool(server, budget),
     defi: () => registerDefiTool(server, budget),
+    polymarket_read: () => registerPolymarketReadTool(server),
     polymarket: () => registerPolymarketTool(server),
   };
 

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -27,6 +27,7 @@ export type ToolName =
   | "surf"
   | "rpc"
   | "defi"
+  | "polymarket_read"
   | "polymarket";
 
 // `as const satisfies` keeps the literal tuple type (so the exhaustiveness
@@ -35,7 +36,7 @@ export type ToolName =
 export const ALL_TOOLS = [
   "wallet", "chat", "models", "image", "music", "speech", "video", "realface",
   "search", "exa", "markets", "price", "dex", "modal", "phone", "surf", "rpc", "defi",
-  "polymarket",
+  "polymarket_read", "polymarket",
 ] as const satisfies readonly ToolName[];
 
 // Compile-time guard: if a new ToolName is added to the union but not to
@@ -56,7 +57,7 @@ export const PROFILES: Record<string, ToolName[] | "all"> = {
   // Markets & on-chain data: prediction markets (data + Polymarket trading),
   // realtime prices, DEX/CEX data, DeFi metrics, and raw RPC, plus the wallet
   // for balance/funding.
-  trading: ["wallet", "price", "dex", "markets", "surf", "defi", "rpc", "polymarket"],
+  trading: ["wallet", "price", "dex", "markets", "surf", "defi", "rpc", "polymarket_read", "polymarket"],
   // Web research & analysis: live search, neural search, Surf's news/SQL,
   // and chat for synthesis, plus wallet and the model catalogue.
   research: ["wallet", "models", "chat", "search", "exa", "surf"],

--- a/src/tool-annotations.ts
+++ b/src/tool-annotations.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared MCP safety metadata. Keep these conservative: a tool that can spend
+ * USDC or mutate external state is not read-only even when some actions are.
+ */
+export const TOOL_ANNOTATIONS = {
+  readOnly: {
+    readOnlyHint: true,
+    openWorldHint: false,
+    destructiveHint: false,
+  },
+  readOnlyOpenWorld: {
+    readOnlyHint: true,
+    openWorldHint: true,
+    destructiveHint: false,
+  },
+  walletManagement: {
+    readOnlyHint: false,
+    openWorldHint: false,
+    destructiveHint: false,
+  },
+  paidPrivate: {
+    readOnlyHint: false,
+    openWorldHint: false,
+    destructiveHint: true,
+  },
+  paidOpenWorld: {
+    readOnlyHint: false,
+    openWorldHint: true,
+    destructiveHint: true,
+  },
+  publicOrExternalWrite: {
+    readOnlyHint: false,
+    openWorldHint: true,
+    destructiveHint: true,
+  },
+} as const;

--- a/src/tool-annotations.ts
+++ b/src/tool-annotations.ts
@@ -1,33 +1,55 @@
 /**
- * Shared MCP safety metadata. Keep these conservative: a tool that can spend
- * USDC or mutate external state is not read-only even when some actions are.
+ * Shared MCP safety metadata.
+ *
+ * The axis these hints describe is EFFECT, not cost. `readOnlyHint` means the
+ * tool does not modify its environment; `destructiveHint` (only meaningful when
+ * `readOnlyHint` is false) means an update is irreversible. Neither says
+ * anything about money, and MCP has no "this costs USDC" hint.
+ *
+ * So a paid data query is still read-only. Marking `blockrun_markets` or
+ * `blockrun_exa` destructive because it settles $0.0095 makes every client that
+ * honors annotations demand approval for a plain lookup — wrong on the spec,
+ * and hostile to any agent doing real research. Spend control is the budget
+ * ledger's job (`BLOCKRUN_BUDGET_LIMIT`, `reserveBudget`, per-agent delegation),
+ * not the safety hints'.
+ *
+ * What genuinely earns `destructiveHint: true` here: moving funds
+ * (`polymarket`), placing real calls (`phone`), executing arbitrary code
+ * (`modal`), or broadcasting a signed transaction (`rpc`).
  */
 export const TOOL_ANNOTATIONS = {
+  /** Local/cached reads that never leave the process boundary. */
   readOnly: {
     readOnlyHint: true,
     openWorldHint: false,
     destructiveHint: false,
   },
+  /** Queries against an external API. Paid or free — reading is reading. */
   readOnlyOpenWorld: {
     readOnlyHint: true,
     openWorldHint: true,
     destructiveHint: false,
   },
+  /**
+   * Creates something — an image, a clip, a completion, an enrolled face asset —
+   * without destroying anything. Not read-only, not destructive: the shape MCP
+   * defines for a benign write.
+   */
+  generative: {
+    readOnlyHint: false,
+    openWorldHint: false,
+    destructiveHint: false,
+  },
+  /** Local wallet/budget state changes: reversible, no external side effects. */
   walletManagement: {
     readOnlyHint: false,
     openWorldHint: false,
     destructiveHint: false,
   },
-  paidPrivate: {
-    readOnlyHint: false,
-    openWorldHint: false,
-    destructiveHint: true,
-  },
-  paidOpenWorld: {
-    readOnlyHint: false,
-    openWorldHint: true,
-    destructiveHint: true,
-  },
+  /**
+   * Moves real funds, calls real phone numbers, runs arbitrary code, or can
+   * broadcast a signed transaction. Approve-before-run is correct here.
+   */
   publicOrExternalWrite: {
     readOnlyHint: false,
     openWorldHint: true,

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -1,5 +1,6 @@
 // src/tools/chat.ts
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
 import { buildClient, buildClientWithTimeout, getAnthropicClient, baseOnlyMessage } from "../utils/wallet.js";
 import { streamChatText, supportsStreaming, type StreamChatMessage } from "../utils/chat-stream.js";
@@ -172,6 +173,7 @@ Notable modes:
 Pick directly: model:"moonshot/kimi-k3", model:"openai/gpt-5.6-sol", model:"anthropic/claude-opus-4.8", model:"xai/grok-4.5", model:"nvidia/deepseek-v4-flash" (free).
 
 Run blockrun_models to see all available models with pricing.`,
+      annotations: TOOL_ANNOTATIONS.paidPrivate,
       inputSchema: {
         message: z.string().describe("Your message to the AI"),
         model: z.string().optional().describe("Specific model ID (e.g., 'moonshot/kimi-k3', 'openai/gpt-5.6-sol', 'zai/glm-5')"),

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -173,7 +173,7 @@ Notable modes:
 Pick directly: model:"moonshot/kimi-k3", model:"openai/gpt-5.6-sol", model:"anthropic/claude-opus-4.8", model:"xai/grok-4.5", model:"nvidia/deepseek-v4-flash" (free).
 
 Run blockrun_models to see all available models with pricing.`,
-      annotations: TOOL_ANNOTATIONS.paidPrivate,
+      annotations: TOOL_ANNOTATIONS.generative,
       inputSchema: {
         message: z.string().describe("Your message to the AI"),
         model: z.string().optional().describe("Specific model ID (e.g., 'moonshot/kimi-k3', 'openai/gpt-5.6-sol', 'zai/glm-5')"),

--- a/src/tools/defi.ts
+++ b/src/tools/defi.ts
@@ -6,6 +6,8 @@
 // in USDC via x402. Endpoint catalog mirrors blockrun/src/lib/defillama.ts.
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
+import { serializePaidRequest } from "../utils/payment-serialization.js";
 import { z } from "zod";
 import { reserveBudget, recordSpending } from "../utils/budget.js";
 import { withTxFee } from "../utils/tx-fee.js";
@@ -45,6 +47,7 @@ Examples:
   blockrun_defi({ path: "chains" })
 
 Use blockrun_price (free) for plain spot quotes, blockrun_dex (free) for DEX pairs, blockrun_surf for labeled on-chain data — this tool is for protocol/TVL/yield fundamentals.`,
+      annotations: TOOL_ANNOTATIONS.paidPrivate,
       inputSchema: {
         path: z.string().describe("Endpoint under /v1/defillama/, e.g. 'protocols', 'protocol/aave-v3', 'chains', 'yields', 'prices/coingecko:ethereum'"),
         agent_id: z.string().optional().describe("Agent identifier for budget tracking and enforcement."),
@@ -66,7 +69,7 @@ Use blockrun_price (free) for plain spot quotes, blockrun_dex (free) for DEX pai
         }
         try {
           const client = getClient() as unknown as RawClient;
-          const result = await client.getWithPaymentRaw(`/v1/defillama/${cleanPath}`);
+          const result = await serializePaidRequest(() => client.getWithPaymentRaw(`/v1/defillama/${cleanPath}`));
           recordSpending(budget, estimatedCost, agent_id);
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],

--- a/src/tools/defi.ts
+++ b/src/tools/defi.ts
@@ -47,7 +47,7 @@ Examples:
   blockrun_defi({ path: "chains" })
 
 Use blockrun_price (free) for plain spot quotes, blockrun_dex (free) for DEX pairs, blockrun_surf for labeled on-chain data — this tool is for protocol/TVL/yield fundamentals.`,
-      annotations: TOOL_ANNOTATIONS.paidPrivate,
+      annotations: TOOL_ANNOTATIONS.readOnlyOpenWorld,
       inputSchema: {
         path: z.string().describe("Endpoint under /v1/defillama/, e.g. 'protocols', 'protocol/aave-v3', 'chains', 'yields', 'prices/coingecko:ethereum'"),
         agent_id: z.string().optional().describe("Agent identifier for budget tracking and enforcement."),

--- a/src/tools/dex.ts
+++ b/src/tools/dex.ts
@@ -1,5 +1,6 @@
 // src/tools/dex.ts
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
 import { fetchWithTimeout } from "../utils/http.js";
 
@@ -18,6 +19,7 @@ Examples:
   blockrun_dex({ query: "SOL" })           -> Search for SOL pairs
   blockrun_dex({ token: "So11...xxx" })    -> Get specific token data
   blockrun_dex({ symbol: "PEPE" })         -> Search by symbol`,
+      annotations: TOOL_ANNOTATIONS.readOnlyOpenWorld,
       inputSchema: {
         query: z.string().optional().describe("Search query (token name, symbol, or address)"),
         token: z.string().optional().describe("Token address for direct lookup"),

--- a/src/tools/exa.ts
+++ b/src/tools/exa.ts
@@ -5,6 +5,7 @@
 // not the tool description.
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
 import { reserveBudget, recordSpending } from "../utils/budget.js";
 import { withTxFee } from "../utils/tx-fee.js";
@@ -53,6 +54,7 @@ Common paths (all POST, body shapes documented in the exa-research skill):
 Categories for search: "news", "research paper", "company", "tweet", "github", "pdf".
 
 Full request/response shapes + worked research workflows in the \`exa-research\` skill.`,
+      annotations: TOOL_ANNOTATIONS.paidOpenWorld,
       inputSchema: {
         path: z.string().describe("Endpoint name under /v1/exa/, e.g. 'search', 'answer', 'contents', 'find-similar'"),
         body: z.any().optional().describe("JSON body for the call. Sent as POST. Required for all four endpoints."),

--- a/src/tools/exa.ts
+++ b/src/tools/exa.ts
@@ -6,6 +6,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
+import { serializePaidRequest } from "../utils/payment-serialization.js";
 import { z } from "zod";
 import { reserveBudget, recordSpending } from "../utils/budget.js";
 import { withTxFee } from "../utils/tx-fee.js";
@@ -54,7 +55,7 @@ Common paths (all POST, body shapes documented in the exa-research skill):
 Categories for search: "news", "research paper", "company", "tweet", "github", "pdf".
 
 Full request/response shapes + worked research workflows in the \`exa-research\` skill.`,
-      annotations: TOOL_ANNOTATIONS.paidOpenWorld,
+      annotations: TOOL_ANNOTATIONS.readOnlyOpenWorld,
       inputSchema: {
         path: z.string().describe("Endpoint name under /v1/exa/, e.g. 'search', 'answer', 'contents', 'find-similar'"),
         body: z.any().optional().describe("JSON body for the call. Sent as POST. Required for all four endpoints."),
@@ -79,7 +80,7 @@ Full request/response shapes + worked research workflows in the \`exa-research\`
         try {
           const client = getClient() as unknown as RawClient;
           const endpoint = `/v1/exa/${cleanPath}`;
-          const result = await client.requestWithPaymentRaw(endpoint, body ?? {});
+          const result = await serializePaidRequest(() => client.requestWithPaymentRaw(endpoint, body ?? {}));
           recordSpending(budget, estimatedCost, agent_id);
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],

--- a/src/tools/image.ts
+++ b/src/tools/image.ts
@@ -277,7 +277,7 @@ Generation models (1024x1024 base price; larger sizes cost more on gpt-image-*):
 Edit (img2img) models: openai/gpt-image-2 (default), openai/gpt-image-1, google/nano-banana, google/nano-banana-pro
 Multi-image edit: pass an array of 2–4 source images to "image" to fuse them in one render (openai/* up to 4, google/* up to 3) — e.g. a subject plus a sprite layout guide, or a reference plus a brand logo.
 Source images and masks accept a base64 data URI, an http(s) URL, or a local file path (auto-encoded). Inpaint mask (openai/gpt-image-* only) via "mask"; not combinable with multiple source images.`,
-      annotations: TOOL_ANNOTATIONS.paidPrivate,
+      annotations: TOOL_ANNOTATIONS.generative,
       inputSchema: {
         prompt: z.string().describe("Image description or edit instructions"),
         action: z.enum(["generate", "edit"]).optional().default("generate").describe("generate: create from text; edit: transform existing image"),

--- a/src/tools/image.ts
+++ b/src/tools/image.ts
@@ -1,5 +1,6 @@
 // src/tools/image.ts
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
 import { PaymentError } from "@blockrun/llm";
 import { reserveBudget, recordSpending, recordActualSpend, reReserveIfHigher, BudgetExceededError } from "../utils/budget.js";
@@ -276,6 +277,7 @@ Generation models (1024x1024 base price; larger sizes cost more on gpt-image-*):
 Edit (img2img) models: openai/gpt-image-2 (default), openai/gpt-image-1, google/nano-banana, google/nano-banana-pro
 Multi-image edit: pass an array of 2–4 source images to "image" to fuse them in one render (openai/* up to 4, google/* up to 3) — e.g. a subject plus a sprite layout guide, or a reference plus a brand logo.
 Source images and masks accept a base64 data URI, an http(s) URL, or a local file path (auto-encoded). Inpaint mask (openai/gpt-image-* only) via "mask"; not combinable with multiple source images.`,
+      annotations: TOOL_ANNOTATIONS.paidPrivate,
       inputSchema: {
         prompt: z.string().describe("Image description or edit instructions"),
         action: z.enum(["generate", "edit"]).optional().default("generate").describe("generate: create from text; edit: transform existing image"),

--- a/src/tools/markets.ts
+++ b/src/tools/markets.ts
@@ -36,6 +36,7 @@ export function registerMarketsTool(server: McpServer, budget: BudgetState): voi
 
 CANONICAL CROSS-VENUE (Tier 1) — Predexon v2 unified data layer:
 - markets — list canonical market/question containers with cross-venue Predexon IDs
+- markets/listings — venue-native executable listings flattened across canonical markets
 - outcomes/:predexon_id — resolve a canonical outcome ID to its market context + venue listings
   Filter with ?venue=polymarket|kalshi|limitless|opinion|predictfun, ?status=, ?category=, ?league=, ?event_id=, ?pagination_key=
 
@@ -82,7 +83,8 @@ CROSS-PLATFORM:
 - markets/search — search across all platforms in one call
 
 REQUEST CONTRACTS:
-- Discover current markets with markets/search, then resolve the chosen Polymarket market with polymarket/markets/keyset and condition_id. markets/listings is no longer available.
+- Discover current markets with markets/search (its search term is "q"), then resolve the chosen Polymarket market with polymarket/markets/keyset and condition_id.
+- On polymarket/markets{,/keyset} the free-text filter is "search" (NOT "q"), and status:"open"/"closed" replaces Gamma's active/closed. "sort", "end_after", and "end_before" are supported; "order"/"ascending" are not.
 - Candlesticks interval is integer minutes: 0|1|5|15|60|1440 (use "60", not "1h"); start_time/end_time are Unix seconds.
 - polymarket/orderbooks requires token_id plus start_time/end_time in Unix milliseconds.
 - Smart-money calls require a meaningful cohort filter; a safe default is { window: "30d", min_trades: "100" }.

--- a/src/tools/markets.ts
+++ b/src/tools/markets.ts
@@ -92,7 +92,7 @@ Pass query params via 'params' (GET). Use 'body' only for POST endpoints (e.g. p
       annotations: TOOL_ANNOTATIONS.paidOpenWorld,
       inputSchema: {
         path: z.string().describe("Endpoint path, e.g. 'polymarket/events', 'kalshi/markets/KXBTC-25MAR14', 'polymarket/wallet/0xabc...', 'markets/search'"),
-        params: z.record(z.string(), z.string()).optional().describe("Query parameters for GET requests (e.g. { limit: '20', active: 'true' })"),
+        params: z.record(z.string(), z.string()).optional().describe("Query parameters for GET requests (e.g. markets/search uses { q: 'Bitcoin', status: 'open', venue: 'polymarket', limit: '20' })"),
         body: z.any().optional().describe("JSON body for POST queries (triggers pmQuery — most endpoints are GET)"),
         agent_id: z.string().optional().describe("Agent identifier for budget tracking and enforcement."),
       },

--- a/src/tools/markets.ts
+++ b/src/tools/markets.ts
@@ -7,6 +7,9 @@ import { getClient } from "../utils/wallet.js";
 import { extractErrorMessage, formatError } from "../utils/errors.js";
 import { hasPathTraversal } from "../utils/path-safety.js";
 import type { BudgetState } from "../types.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
+import { serializePaidRequest } from "../utils/payment-serialization.js";
+import { validateMarketRequest } from "../utils/markets-validation.js";
 
 // What x402 CHARGES, which is not the 402's JSON `price` field. That field is the
 // BASE ($0.0075); the charge is base + a $0.002 flat transaction fee, and it lives
@@ -33,7 +36,6 @@ export function registerMarketsTool(server: McpServer, budget: BudgetState): voi
 
 CANONICAL CROSS-VENUE (Tier 1) — Predexon v2 unified data layer:
 - markets — list canonical market/question containers with cross-venue Predexon IDs
-- markets/listings — venue-native executable listings flattened across canonical markets
 - outcomes/:predexon_id — resolve a canonical outcome ID to its market context + venue listings
   Filter with ?venue=polymarket|kalshi|limitless|opinion|predictfun, ?status=, ?category=, ?league=, ?event_id=, ?pagination_key=
 
@@ -79,7 +81,15 @@ CROSS-PLATFORM:
 - matching-markets, matching-markets/pairs — equivalent markets across Polymarket+Kalshi
 - markets/search — search across all platforms in one call
 
+REQUEST CONTRACTS:
+- Discover current markets with markets/search, then resolve the chosen Polymarket market with polymarket/markets/keyset and condition_id. markets/listings is no longer available.
+- Candlesticks interval is integer minutes: 0|1|5|15|60|1440 (use "60", not "1h"); start_time/end_time are Unix seconds.
+- polymarket/orderbooks requires token_id plus start_time/end_time in Unix milliseconds.
+- Smart-money calls require a meaningful cohort filter; a safe default is { window: "30d", min_trades: "100" }.
+- Issue paid calls sequentially. The MCP also serializes them to protect one wallet from concurrent x402 payment races.
+
 Pass query params via 'params' (GET). Use 'body' only for POST endpoints (e.g. polymarket/wallet/identities).`,
+      annotations: TOOL_ANNOTATIONS.paidOpenWorld,
       inputSchema: {
         path: z.string().describe("Endpoint path, e.g. 'polymarket/events', 'kalshi/markets/KXBTC-25MAR14', 'polymarket/wallet/0xabc...', 'markets/search'"),
         params: z.record(z.string(), z.string()).optional().describe("Query parameters for GET requests (e.g. { limit: '20', active: 'true' })"),
@@ -95,6 +105,10 @@ Pass query params via 'params' (GET). Use 'body' only for POST endpoints (e.g. p
         if (hasPathTraversal(path)) {
           return { content: [{ type: "text", text: formatError(`Invalid path '${path}'.`) }], isError: true };
         }
+        const validationError = validateMarketRequest(path, params, body);
+        if (validationError) {
+          return { content: [{ type: "text", text: formatError(validationError) }], isError: true };
+        }
         const estimatedCost = estimateMarketCost(path, body);
         const gate = reserveBudget(budget, agent_id, estimatedCost);
         if (!gate.allowed) {
@@ -105,9 +119,9 @@ Pass query params via 'params' (GET). Use 'body' only for POST endpoints (e.g. p
         }
         try {
           const llm = getClient();
-          const result = body !== undefined
-            ? await llm.pmQuery(path, body)
-            : await llm.pm(path, params);
+          const result = await serializePaidRequest(() => body !== undefined
+            ? llm.pmQuery(path, body)
+            : llm.pm(path, params));
           recordSpending(budget, estimatedCost, agent_id);
 
           return {

--- a/src/tools/markets.ts
+++ b/src/tools/markets.ts
@@ -87,11 +87,11 @@ REQUEST CONTRACTS:
 - On polymarket/markets{,/keyset} the free-text filter is "search" (NOT "q"), and status:"open"/"closed" replaces Gamma's active/closed. "sort", "end_after", and "end_before" are supported; "order"/"ascending" are not.
 - Candlesticks interval is integer minutes: 0|1|5|15|60|1440 (use "60", not "1h"); start_time/end_time are Unix seconds.
 - polymarket/orderbooks requires token_id plus start_time/end_time in Unix milliseconds.
-- Smart-money calls require a meaningful cohort filter; a safe default is { window: "30d", min_trades: "100" }.
+- Smart-money calls need at least one cohort filter (window, min_trades, min_volume, min_roi, min_*_pnl, min_win_rate, min_profit_factor); a good default is { window: "30d", min_trades: "100" }.
 - Issue paid calls sequentially. The MCP also serializes them to protect one wallet from concurrent x402 payment races.
 
 Pass query params via 'params' (GET). Use 'body' only for POST endpoints (e.g. polymarket/wallet/identities).`,
-      annotations: TOOL_ANNOTATIONS.paidOpenWorld,
+      annotations: TOOL_ANNOTATIONS.readOnlyOpenWorld,
       inputSchema: {
         path: z.string().describe("Endpoint path, e.g. 'polymarket/events', 'kalshi/markets/KXBTC-25MAR14', 'polymarket/wallet/0xabc...', 'markets/search'"),
         params: z.record(z.string(), z.string()).optional().describe("Query parameters for GET requests (e.g. markets/search uses { q: 'Bitcoin', status: 'open', venue: 'polymarket', limit: '20' })"),

--- a/src/tools/modal.ts
+++ b/src/tools/modal.ts
@@ -5,6 +5,7 @@
 // GPU type / image / timeout details live in the modal skill.
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
 import { reserveBudget, recordSpending } from "../utils/budget.js";
 import { withTxFee } from "../utils/tx-fee.js";
@@ -115,6 +116,7 @@ Common paths (all POST):
 - sandbox/terminate  — body: { sandbox_id }                                                ($0.0030)
 
 Full pricing tables + GPU details in the \`modal\` skill.`,
+      annotations: TOOL_ANNOTATIONS.paidPrivate,
       inputSchema: {
         path: z.string().describe("Endpoint under /v1/modal/, e.g. 'sandbox/create', 'sandbox/exec'"),
         body: z.any().optional().describe("JSON body. Sent as POST."),

--- a/src/tools/modal.ts
+++ b/src/tools/modal.ts
@@ -116,7 +116,7 @@ Common paths (all POST):
 - sandbox/terminate  — body: { sandbox_id }                                                ($0.0030)
 
 Full pricing tables + GPU details in the \`modal\` skill.`,
-      annotations: TOOL_ANNOTATIONS.paidPrivate,
+      annotations: TOOL_ANNOTATIONS.publicOrExternalWrite,
       inputSchema: {
         path: z.string().describe("Endpoint under /v1/modal/, e.g. 'sandbox/create', 'sandbox/exec'"),
         body: z.any().optional().describe("JSON body. Sent as POST."),

--- a/src/tools/models.ts
+++ b/src/tools/models.ts
@@ -1,5 +1,6 @@
 // src/tools/models.ts
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
 import type { ImageModel, Model } from "@blockrun/llm";
 import { getClient } from "../utils/wallet.js";
@@ -15,6 +16,7 @@ export function registerModelsTool(server: McpServer, modelCache: ModelCache): v
     "blockrun_models",
     {
       description: "List available AI models with pricing. Use to discover models and compare costs.",
+      annotations: TOOL_ANNOTATIONS.readOnly,
       inputSchema: {
         category: z.enum(["all", "chat", "reasoning", "image", "embedding"]).optional().default("all").describe("Filter by category"),
         provider: z.string().optional().describe("Filter by provider (e.g., 'openai', 'anthropic')"),

--- a/src/tools/music.ts
+++ b/src/tools/music.ts
@@ -40,7 +40,7 @@ are not charged.
 Models: minimax/music-2.5+ ($0.1575), minimax/music-2.5 ($0.1575)
 
 Returns a permanent BlockRun-hosted URL.`,
-      annotations: TOOL_ANNOTATIONS.paidPrivate,
+      annotations: TOOL_ANNOTATIONS.generative,
       inputSchema: {
         prompt: z.string().describe("Music style, mood, or description. E.g. 'upbeat synthwave with neon pads', 'chill lo-fi beats', 'epic orchestral film score'"),
         instrumental: z.boolean().optional().default(true).describe("Generate without vocals (default: true)"),

--- a/src/tools/music.ts
+++ b/src/tools/music.ts
@@ -1,5 +1,6 @@
 // src/tools/music.ts
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
 import { amountToUsd, reserveBudget, recordActualSpend } from "../utils/budget.js";
 import { withTxFee } from "../utils/tx-fee.js";
@@ -39,6 +40,7 @@ are not charged.
 Models: minimax/music-2.5+ ($0.1575), minimax/music-2.5 ($0.1575)
 
 Returns a permanent BlockRun-hosted URL.`,
+      annotations: TOOL_ANNOTATIONS.paidPrivate,
       inputSchema: {
         prompt: z.string().describe("Music style, mood, or description. E.g. 'upbeat synthwave with neon pads', 'chill lo-fi beats', 'epic orchestral film score'"),
         instrumental: z.boolean().optional().default(true).describe("Generate without vocals (default: true)"),

--- a/src/tools/phone.ts
+++ b/src/tools/phone.ts
@@ -6,6 +6,7 @@
 // Full catalog lives in the phone skill.
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
 import { reserveBudget, recordSpending } from "../utils/budget.js";
 import { withTxFee } from "../utils/tx-fee.js";
@@ -75,6 +76,7 @@ REQUIRED for voice/call: \`from\` must be a number your wallet owns. Provision o
 Voice presets: nat, josh, maya, june, paige, derek, florian. Phone numbers use E.164 format (e.g. +1 followed by 10 US digits, or +<country-code><number>).
 
 Voice call flow + voice preset details + full body shapes in the \`phone\` skill.`,
+      annotations: TOOL_ANNOTATIONS.publicOrExternalWrite,
       inputSchema: {
         path: z.string().describe("Endpoint after /v1/. Use 'phone/...' for lookup + number ops, 'voice/call' for outbound AI calls, 'voice/call/{id}' (no body) to poll status."),
         body: z.any().optional().describe("JSON body. Sent as POST. Omit for the free GET poll (voice/call/{call_id})."),

--- a/src/tools/polymarket.ts
+++ b/src/tools/polymarket.ts
@@ -36,7 +36,7 @@ Actions:
 - redeem — claim resolved winnings for condition_id (confirm:true; gasless)
 - withdraw — cash out pUSD → native USDC on Base to your agent wallet (confirm:true). amount_usd optional (default: full balance); to_address optional (default: your wallet).
 
-Prices are probabilities 0–1 on the market's tick grid. token_id comes from blockrun_markets Polymarket data. The default CLOB connection is direct so Polymarket can enforce geographic eligibility; setup reports status. Never route around a blocked jurisdiction.`,
+Prices are probabilities 0–1 on the market's tick grid. token_id comes from blockrun_markets Polymarket data. Geoblock is handled by default (CLOB traffic routes through BlockRun's Finland egress) — setup reports your region status. Complying with Polymarket's terms for the user's jurisdiction is the user's responsibility.`,
       annotations: TOOL_ANNOTATIONS.publicOrExternalWrite,
       inputSchema: {
         action: z.enum(["setup", "fund", "buy", "sell", "cancel", "orders", "positions", "redeem", "withdraw"])

--- a/src/tools/polymarket.ts
+++ b/src/tools/polymarket.ts
@@ -135,7 +135,7 @@ export function registerPolymarketReadTool(server: McpServer): void {
 Actions:
 - positions — holdings, current value, PnL, and redeemable status (free Data API)
 - orders — open CLOB orders, optionally filtered by condition_id
-- preview — build a live buy/sell order preview from the CLOB book. side plus token_id (or condition_id+outcome) are required. Market buys use amount_usd; limit orders use price+size. This action never accepts confirm and never signs or submits.
+- preview — build a live buy/sell order preview from the CLOB book. side plus token_id (or condition_id+outcome) are required. Market buys use amount_usd; limit orders use price+size. This action never accepts confirm and never signs or submits an order.
 
 Use blockrun_polymarket only for setup and funds-affecting operations: confirmed buy/sell, cancel, redeem, fund, or withdraw.`,
       annotations: TOOL_ANNOTATIONS.readOnlyOpenWorld,
@@ -180,8 +180,11 @@ Use blockrun_polymarket only for setup and funds-affecting operations: confirmed
         if (result.isError) {
           return { content: [{ type: "text" as const, text: `Error: ${result.text}` }], isError: true };
         }
+        const text = args.action === "preview"
+          ? formatReadOnlyPreviewText(result.text)
+          : result.text;
         return {
-          content: [{ type: "text" as const, text: result.text }],
+          content: [{ type: "text" as const, text }],
           structuredContent: asStructuredContent(result.structured ?? {}),
         };
       } catch (err) {
@@ -191,5 +194,18 @@ Use blockrun_polymarket only for setup and funds-affecting operations: confirmed
         };
       }
     },
+  );
+}
+
+/**
+ * executeTrade's generic dry-run response tells callers how to repeat a trade
+ * with confirm:true. That is useful on the funds-affecting tool, but misleading
+ * on blockrun_polymarket_read because the read tool deliberately has no confirm
+ * input. Keep the execution economics while making that boundary explicit.
+ */
+export function formatReadOnlyPreviewText(text: string): string {
+  return text.replace(
+    /\n\nRe-call with confirm:true to sign and submit\.$/,
+    "\n\nREAD-ONLY PREVIEW — this tool cannot sign or submit an order.",
   );
 }

--- a/src/tools/polymarket.ts
+++ b/src/tools/polymarket.ts
@@ -130,24 +130,53 @@ export function registerPolymarketReadTool(server: McpServer): void {
   server.registerTool(
     "blockrun_polymarket_read",
     {
-      description: `Read the local wallet's Polymarket state without signing or changing anything.
+      description: `Read or preview Polymarket state without signing or changing anything.
 
 Actions:
 - positions — holdings, current value, PnL, and redeemable status (free Data API)
 - orders — open CLOB orders, optionally filtered by condition_id
+- preview — build a live buy/sell order preview from the CLOB book. side plus token_id (or condition_id+outcome) are required. Market buys use amount_usd; limit orders use price+size. This action never accepts confirm and never signs or submits.
 
-Use blockrun_polymarket for setup, dry-run previews, buy/sell, cancel, redeem, fund, or withdraw.`,
-      annotations: TOOL_ANNOTATIONS.readOnly,
+Use blockrun_polymarket only for setup and funds-affecting operations: confirmed buy/sell, cancel, redeem, fund, or withdraw.`,
+      annotations: TOOL_ANNOTATIONS.readOnlyOpenWorld,
       inputSchema: {
-        action: z.enum(["positions", "orders"]).describe("Read-only operation"),
+        action: z.enum(["positions", "orders", "preview"]).describe("Read-only operation"),
         condition_id: z.string().optional().describe("orders: optional market condition ID filter"),
+        side: z.enum(["buy", "sell"]).optional().describe("preview: order side"),
+        token_id: z.string().optional().describe("preview: outcome token ID"),
+        outcome: z.string().optional().describe("preview: outcome label used with condition_id"),
+        price: z.number().gt(0).lt(1).optional().describe("preview: limit probability; omit for market order"),
+        size: z.number().positive().optional().describe("preview: shares for limits and market sells"),
+        amount_usd: z.number().positive().optional().describe("preview: pUSD to spend on a market buy"),
+        order_type: z.enum(["GTC", "GTD", "FOK", "FAK"]).optional().describe("preview: order type"),
+        expires_at: z.number().int().positive().optional().describe("preview: GTD expiry in Unix seconds"),
+        post_only: z.boolean().optional().describe("preview: maker-only limit order"),
       },
     },
-    async ({ action, condition_id }) => {
+    async (args) => {
       try {
-        const result = action === "positions"
-          ? await listPositions()
-          : await listOpenOrders({ condition_id });
+        let result: ToolResult;
+        if (args.action === "positions") {
+          result = await listPositions();
+        } else if (args.action === "orders") {
+          result = await listOpenOrders({ condition_id: args.condition_id });
+        } else if (!args.side) {
+          result = { text: "preview requires side:'buy' or side:'sell'.", isError: true };
+        } else {
+          result = await executeTrade({
+            action: args.side,
+            token_id: args.token_id,
+            condition_id: args.condition_id,
+            outcome: args.outcome,
+            price: args.price,
+            size: args.size,
+            amount_usd: args.amount_usd,
+            order_type: args.order_type,
+            expires_at: args.expires_at,
+            post_only: args.post_only,
+            confirm: false,
+          });
+        }
         if (result.isError) {
           return { content: [{ type: "text" as const, text: `Error: ${result.text}` }], isError: true };
         }

--- a/src/tools/polymarket.ts
+++ b/src/tools/polymarket.ts
@@ -9,6 +9,7 @@ import { redeemPosition } from "../utils/polymarket/redeem.js";
 import { runSetup } from "../utils/polymarket/setup.js";
 import { withdrawFunds } from "../utils/polymarket/withdraw.js";
 import { fundVault } from "../utils/polymarket/fund.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 
 /**
  * Trading is intentionally NOT gated on the x402 budget ledger: that ledger
@@ -35,7 +36,8 @@ Actions:
 - redeem — claim resolved winnings for condition_id (confirm:true; gasless)
 - withdraw — cash out pUSD → native USDC on Base to your agent wallet (confirm:true). amount_usd optional (default: full balance); to_address optional (default: your wallet).
 
-Prices are probabilities 0–1 on the market's tick grid. token_id = clobTokenIds from blockrun_markets Polymarket data. Geoblock is handled by default (CLOB traffic routes through BlockRun's Finland egress) — setup reports your region status.`,
+Prices are probabilities 0–1 on the market's tick grid. token_id comes from blockrun_markets Polymarket data. The default CLOB connection is direct so Polymarket can enforce geographic eligibility; setup reports status. Never route around a blocked jurisdiction.`,
+      annotations: TOOL_ANNOTATIONS.publicOrExternalWrite,
       inputSchema: {
         action: z.enum(["setup", "fund", "buy", "sell", "cancel", "orders", "positions", "redeem", "withdraw"])
           .describe("Operation to perform"),
@@ -106,6 +108,52 @@ Prices are probabilities 0–1 on the market's tick grid. token_id = clobTokenId
         return {
           content: [{ type: "text" as const, text: result.text }],
           structuredContent: asStructuredContent(result.structured ?? { session: getSessionLedger() }),
+        };
+      } catch (err) {
+        return {
+          content: [{ type: "text" as const, text: `Error: ${extractErrorMessage(err)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+/**
+ * Narrow read surface for clients that enforce MCP annotations at tool level.
+ * The legacy blockrun_polymarket tool keeps these actions for compatibility,
+ * but mixing reads and real-money writes forces that whole tool to be marked
+ * destructive. This companion lets Codex and other clients safely inspect
+ * positions/orders without approving a funds-affecting tool call.
+ */
+export function registerPolymarketReadTool(server: McpServer): void {
+  server.registerTool(
+    "blockrun_polymarket_read",
+    {
+      description: `Read the local wallet's Polymarket state without signing or changing anything.
+
+Actions:
+- positions — holdings, current value, PnL, and redeemable status (free Data API)
+- orders — open CLOB orders, optionally filtered by condition_id
+
+Use blockrun_polymarket for setup, dry-run previews, buy/sell, cancel, redeem, fund, or withdraw.`,
+      annotations: TOOL_ANNOTATIONS.readOnly,
+      inputSchema: {
+        action: z.enum(["positions", "orders"]).describe("Read-only operation"),
+        condition_id: z.string().optional().describe("orders: optional market condition ID filter"),
+      },
+    },
+    async ({ action, condition_id }) => {
+      try {
+        const result = action === "positions"
+          ? await listPositions()
+          : await listOpenOrders({ condition_id });
+        if (result.isError) {
+          return { content: [{ type: "text" as const, text: `Error: ${result.text}` }], isError: true };
+        }
+        return {
+          content: [{ type: "text" as const, text: result.text }],
+          structuredContent: asStructuredContent(result.structured ?? {}),
         };
       } catch (err) {
         return {

--- a/src/tools/price.ts
+++ b/src/tools/price.ts
@@ -56,7 +56,7 @@ Examples:
 - { action: "price", category: "stocks", symbol: "AAPL", market: "us" }
 - { action: "history", category: "crypto", symbol: "ETH-USD", resolution: "D", from: 1700000000, to: 1710000000 }
 - { action: "list", category: "crypto", query: "sol" }`,
-      annotations: TOOL_ANNOTATIONS.paidPrivate,
+      annotations: TOOL_ANNOTATIONS.readOnlyOpenWorld,
       inputSchema: {
         action: ACTION.describe("Which endpoint to hit: price, history, or list."),
         category: CATEGORY.describe("Market category."),

--- a/src/tools/price.ts
+++ b/src/tools/price.ts
@@ -19,6 +19,8 @@ import { withTxFee } from "../utils/tx-fee.js";
 import type { BudgetState } from "../types.js";
 import { getChain, getPriceClient } from "../utils/wallet.js";
 import { extractErrorMessage, formatError } from "../utils/errors.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
+import { serializePaidRequest } from "../utils/payment-serialization.js";
 
 const CATEGORY = z.enum(["crypto", "fx", "commodity", "usstock", "stocks"]);
 const MARKET = z.enum([
@@ -54,6 +56,7 @@ Examples:
 - { action: "price", category: "stocks", symbol: "AAPL", market: "us" }
 - { action: "history", category: "crypto", symbol: "ETH-USD", resolution: "D", from: 1700000000, to: 1710000000 }
 - { action: "list", category: "crypto", query: "sol" }`,
+      annotations: TOOL_ANNOTATIONS.paidPrivate,
       inputSchema: {
         action: ACTION.describe("Which endpoint to hit: price, history, or list."),
         category: CATEGORY.describe("Market category."),
@@ -98,10 +101,11 @@ Examples:
 
           if (action === "price") {
             if (!symbol) throw new Error("symbol is required for action='price'");
-            const result = await priceClient.price(category as PriceCategory, symbol, {
+            const task = () => priceClient.price(category as PriceCategory, symbol, {
               market: market as StockMarket | undefined,
               session: session as MarketSession | undefined,
             });
+            const result = paid ? await serializePaidRequest(task) : await task();
             if (estimatedCost > 0) recordSpending(budget, estimatedCost, agent_id);
             return {
               content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -112,13 +116,14 @@ Examples:
           if (action === "history") {
             if (!symbol) throw new Error("symbol is required for action='history'");
             if (from === undefined) throw new Error("from (unix seconds) is required for action='history'");
-            const result = await priceClient.history(category as PriceCategory, symbol, {
+            const task = () => priceClient.history(category as PriceCategory, symbol, {
               market: market as StockMarket | undefined,
               session: session as MarketSession | undefined,
               resolution: (resolution ?? "D") as BarResolution,
               from,
               to,
             });
+            const result = paid ? await serializePaidRequest(task) : await task();
             if (estimatedCost > 0) recordSpending(budget, estimatedCost, agent_id);
             return {
               content: [{ type: "text", text: JSON.stringify(result, null, 2) }],

--- a/src/tools/realface.ts
+++ b/src/tools/realface.ts
@@ -1,5 +1,6 @@
 // src/tools/realface.ts
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
 import { amountToUsd, reserveBudget, recordActualSpend } from "../utils/budget.js";
 import { withTxFee } from "../utils/tx-fee.js";
@@ -99,6 +100,7 @@ Typical flow:
   4. blockrun_video model:"bytedance/seedance-2.0" real_face_asset_id:"ta_xxxx" prompt:"…"
 
 Privacy: BlockRun does not store face/liveness data — only the asset id, name, and the photo URL you supply.`,
+      annotations: TOOL_ANNOTATIONS.paidPrivate,
       inputSchema: {
         action: z.enum(["init", "status", "enroll", "portrait", "list"]).describe("What to do"),
         name: z.string().min(1).max(64).optional().describe("Display name for the person/character (required for init, enroll, and portrait)."),

--- a/src/tools/realface.ts
+++ b/src/tools/realface.ts
@@ -100,7 +100,7 @@ Typical flow:
   4. blockrun_video model:"bytedance/seedance-2.0" real_face_asset_id:"ta_xxxx" prompt:"…"
 
 Privacy: BlockRun does not store face/liveness data — only the asset id, name, and the photo URL you supply.`,
-      annotations: TOOL_ANNOTATIONS.paidPrivate,
+      annotations: TOOL_ANNOTATIONS.generative,
       inputSchema: {
         action: z.enum(["init", "status", "enroll", "portrait", "list"]).describe("What to do"),
         name: z.string().min(1).max(64).optional().describe("Display name for the person/character (required for init, enroll, and portrait)."),

--- a/src/tools/rpc.ts
+++ b/src/tools/rpc.ts
@@ -43,7 +43,7 @@ Examples:
   blockrun_rpc({ network: "ethereum", body: [{jsonrpc:"2.0",id:1,method:"eth_blockNumber"},{...}] })  // batch
 
 Prefer blockrun_price (free quotes), blockrun_dex (free DEX data), or blockrun_surf (labeled/aggregated data) when they cover the question — this tool is for raw chain access.`,
-      annotations: TOOL_ANNOTATIONS.paidPrivate,
+      annotations: TOOL_ANNOTATIONS.publicOrExternalWrite,
       inputSchema: {
         network: z.string().describe("Chain key, e.g. 'ethereum', 'base', 'solana', 'bitcoin', 'arbitrum', 'polygon'. Unknown slugs pass through to the Tatum gateway."),
         method: z.string().optional().describe("JSON-RPC method, e.g. 'eth_blockNumber', 'eth_call', 'getSlot' (Solana), 'getblockchaininfo' (Bitcoin). Required unless 'body' is set."),

--- a/src/tools/rpc.ts
+++ b/src/tools/rpc.ts
@@ -8,6 +8,8 @@
 // and per-chain method examples live in the `rpc` skill.
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
+import { serializePaidRequest } from "../utils/payment-serialization.js";
 import { z } from "zod";
 import { reserveBudget, recordSpending } from "../utils/budget.js";
 import { withTxFee } from "../utils/tx-fee.js";
@@ -41,6 +43,7 @@ Examples:
   blockrun_rpc({ network: "ethereum", body: [{jsonrpc:"2.0",id:1,method:"eth_blockNumber"},{...}] })  // batch
 
 Prefer blockrun_price (free quotes), blockrun_dex (free DEX data), or blockrun_surf (labeled/aggregated data) when they cover the question — this tool is for raw chain access.`,
+      annotations: TOOL_ANNOTATIONS.paidPrivate,
       inputSchema: {
         network: z.string().describe("Chain key, e.g. 'ethereum', 'base', 'solana', 'bitcoin', 'arbitrum', 'polygon'. Unknown slugs pass through to the Tatum gateway."),
         method: z.string().optional().describe("JSON-RPC method, e.g. 'eth_blockNumber', 'eth_call', 'getSlot' (Solana), 'getblockchaininfo' (Bitcoin). Required unless 'body' is set."),
@@ -89,7 +92,7 @@ Prefer blockrun_price (free quotes), blockrun_dex (free DEX data), or blockrun_s
         }
         try {
           const client = getClient() as unknown as RawClient;
-          const result = await client.requestWithPaymentRaw(`/v1/rpc/${cleanNetwork}`, body);
+          const result = await serializePaidRequest(() => client.requestWithPaymentRaw(`/v1/rpc/${cleanNetwork}`, body));
           recordSpending(budget, estimatedCost, agent_id);
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -6,6 +6,7 @@
 // skill, not the tool description.
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
 import { reserveBudget, recordSpending } from "../utils/budget.js";
 import { asStructuredContent, coerceBody } from "../utils/body.js";
@@ -75,6 +76,7 @@ Common shape:
 \`sources\` accepts any subset of ["web","x","news"] (defaults to all three). For tweet-only searches, use ["x"]. \`max_results\` is 1–50 (default 10) and drives the price — pass a smaller value if you want to cap spend.
 
 Full request shape + worked examples in the \`search\` skill (\`skills/search/SKILL.md\`).`,
+      annotations: TOOL_ANNOTATIONS.paidOpenWorld,
       inputSchema: {
         path: z.string().optional().default("").describe("Endpoint sub-path under /v1/search/ (default empty = root /v1/search). Reserved for future surfaces."),
         body: z.any().optional().describe("Request body. At minimum { query: '...' }. Sent as POST."),

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -7,6 +7,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
+import { serializePaidRequest } from "../utils/payment-serialization.js";
 import { z } from "zod";
 import { reserveBudget, recordSpending } from "../utils/budget.js";
 import { asStructuredContent, coerceBody } from "../utils/body.js";
@@ -76,7 +77,7 @@ Common shape:
 \`sources\` accepts any subset of ["web","x","news"] (defaults to all three). For tweet-only searches, use ["x"]. \`max_results\` is 1–50 (default 10) and drives the price — pass a smaller value if you want to cap spend.
 
 Full request shape + worked examples in the \`search\` skill (\`skills/search/SKILL.md\`).`,
-      annotations: TOOL_ANNOTATIONS.paidOpenWorld,
+      annotations: TOOL_ANNOTATIONS.readOnlyOpenWorld,
       inputSchema: {
         path: z.string().optional().default("").describe("Endpoint sub-path under /v1/search/ (default empty = root /v1/search). Reserved for future surfaces."),
         body: z.any().optional().describe("Request body. At minimum { query: '...' }. Sent as POST."),
@@ -101,7 +102,7 @@ Full request shape + worked examples in the \`search\` skill (\`skills/search/SK
         try {
           const client = getClient() as unknown as RawClient;
           const endpoint = cleanPath ? `/v1/search/${cleanPath}` : "/v1/search";
-          const result = await client.requestWithPaymentRaw(endpoint, body ?? {});
+          const result = await serializePaidRequest(() => client.requestWithPaymentRaw(endpoint, body ?? {}));
           recordSpending(budget, estimatedCost, agent_id);
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],

--- a/src/tools/speech.ts
+++ b/src/tools/speech.ts
@@ -9,6 +9,7 @@
 // the same amount the server settles.
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
 import { amountToUsd, reserveBudget, recordActualSpend } from "../utils/budget.js";
 import { withTxFee } from "../utils/tx-fee.js";
@@ -83,6 +84,7 @@ Models (speak): elevenlabs/flash-v2.5 ($0.05/1k chars, ~75ms, default), elevenla
 Voice aliases: sarah (default), george, laura, charlie, river, roger, callum, harry — or any raw ElevenLabs voice_id.
 
 Returns a hosted audio URL — download immediately if you need to keep the file.`,
+      annotations: TOOL_ANNOTATIONS.paidPrivate,
       inputSchema: {
         action: z.enum(["speak", "sound_effect", "voices"]).optional().default("speak").describe("speak: text-to-speech (default). sound_effect: generate a sound effect. voices: list voices (free)."),
         input: z.string().optional().describe("speak: text to synthesize. sound_effect: description of the sound, e.g. 'rain on a tin roof, distant thunder' (max 1000 chars)."),

--- a/src/tools/speech.ts
+++ b/src/tools/speech.ts
@@ -84,7 +84,7 @@ Models (speak): elevenlabs/flash-v2.5 ($0.05/1k chars, ~75ms, default), elevenla
 Voice aliases: sarah (default), george, laura, charlie, river, roger, callum, harry — or any raw ElevenLabs voice_id.
 
 Returns a hosted audio URL — download immediately if you need to keep the file.`,
-      annotations: TOOL_ANNOTATIONS.paidPrivate,
+      annotations: TOOL_ANNOTATIONS.generative,
       inputSchema: {
         action: z.enum(["speak", "sound_effect", "voices"]).optional().default("speak").describe("speak: text-to-speech (default). sound_effect: generate a sound effect. voices: list voices (free)."),
         input: z.string().optional().describe("speak: text to synthesize. sound_effect: description of the sound, e.g. 'rain on a tin roof, distant thunder' (max 1000 chars)."),

--- a/src/tools/surf.ts
+++ b/src/tools/surf.ts
@@ -11,6 +11,8 @@
 // forwards the request server-side using the BlockRun-held SURF_API_KEY.
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
+import { serializePaidRequest } from "../utils/payment-serialization.js";
 import { z } from "zod";
 import { reserveBudget, recordSpending } from "../utils/budget.js";
 import { asStructuredContent, coerceBody } from "../utils/body.js";
@@ -73,6 +75,7 @@ Common paths (full 83-endpoint catalog in the surf skill):
 
 Method is auto-routed: pass 'body' for POST endpoints; otherwise GET with 'params'.
 Each Surf endpoint pre-validates required params before settling — you get a 400 (not a charge) if a required field is missing. Browse the full catalog: https://blockrun.ai/marketplace/surf`,
+      annotations: TOOL_ANNOTATIONS.paidOpenWorld,
       inputSchema: {
         path: z.string().describe("Endpoint path under /v1/surf/, e.g. 'market/price', 'prediction-market/polymarket/ranking', 'wallet/detail', 'onchain/sql'"),
         params: z.record(z.string(), z.string()).optional().describe("Query parameters for GET endpoints, e.g. { symbol: 'BTC' } or { address: '0x...', chain: 'ethereum' }"),
@@ -98,9 +101,9 @@ Each Surf endpoint pre-validates required params before settling — you get a 4
         try {
           const client = getClient() as unknown as SurfClient;
           const endpoint = `/v1/surf/${cleanPath}`;
-          const result = body !== undefined
-            ? await client.requestWithPaymentRaw(endpoint, body)
-            : await client.getWithPaymentRaw(endpoint, params);
+          const result = await serializePaidRequest(() => body !== undefined
+            ? client.requestWithPaymentRaw(endpoint, body)
+            : client.getWithPaymentRaw(endpoint, params));
           recordSpending(budget, estimatedCost, agent_id);
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],

--- a/src/tools/surf.ts
+++ b/src/tools/surf.ts
@@ -75,7 +75,7 @@ Common paths (full 83-endpoint catalog in the surf skill):
 
 Method is auto-routed: pass 'body' for POST endpoints; otherwise GET with 'params'.
 Each Surf endpoint pre-validates required params before settling — you get a 400 (not a charge) if a required field is missing. Browse the full catalog: https://blockrun.ai/marketplace/surf`,
-      annotations: TOOL_ANNOTATIONS.paidOpenWorld,
+      annotations: TOOL_ANNOTATIONS.readOnlyOpenWorld,
       inputSchema: {
         path: z.string().describe("Endpoint path under /v1/surf/, e.g. 'market/price', 'prediction-market/polymarket/ranking', 'wallet/detail', 'onchain/sql'"),
         params: z.record(z.string(), z.string()).optional().describe("Query parameters for GET endpoints, e.g. { symbol: 'BTC' } or { address: '0x...', chain: 'ethereum' }"),

--- a/src/tools/video.ts
+++ b/src/tools/video.ts
@@ -1,5 +1,6 @@
 // src/tools/video.ts
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
 import { amountToUsd, reserveBudget, recordActualSpend } from "../utils/budget.js";
 import { formatError, isPaymentRejectionError } from "../utils/errors.js";
@@ -72,6 +73,7 @@ Models (Seedance defaults bumped to 720p + synced audio on the gateway):
 RealFace: to generate video of a SPECIFIC real person, first enroll them with blockrun_realface (returns a ta_xxxx asset id), then pass real_face_asset_id here with a Seedance 2.0 model. Mutually exclusive with image_url.
 
 Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GCS so URLs don't expire).`,
+      annotations: TOOL_ANNOTATIONS.paidPrivate,
       inputSchema: {
         prompt: z.string().describe("Text description of the video to generate. E.g. 'a red apple slowly spinning on a wooden table', 'a hummingbird hovering near a red flower, ultra slow motion'"),
         image_url: z.string().url().optional().describe("Optional seed image URL for image-to-video generation"),

--- a/src/tools/video.ts
+++ b/src/tools/video.ts
@@ -73,7 +73,7 @@ Models (Seedance defaults bumped to 720p + synced audio on the gateway):
 RealFace: to generate video of a SPECIFIC real person, first enroll them with blockrun_realface (returns a ta_xxxx asset id), then pass real_face_asset_id here with a Seedance 2.0 model. Mutually exclusive with image_url.
 
 Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GCS so URLs don't expire).`,
-      annotations: TOOL_ANNOTATIONS.paidPrivate,
+      annotations: TOOL_ANNOTATIONS.generative,
       inputSchema: {
         prompt: z.string().describe("Text description of the video to generate. E.g. 'a red apple slowly spinning on a wooden table', 'a hummingbird hovering near a red flower, ultra slow motion'"),
         image_url: z.string().url().optional().describe("Optional seed image URL for image-to-video generation"),

--- a/src/tools/wallet.ts
+++ b/src/tools/wallet.ts
@@ -6,6 +6,7 @@ import { getWalletInfo, getUsdcBalance, getChain, setChain, ensureBothWallets, g
 import { generateQrPng, openQrInViewer } from "../utils/qr.js";
 import { launchTopUp } from "../utils/onramp.js";
 import { formatError } from "../utils/errors.js";
+import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 
 export function registerWalletTool(server: McpServer, budget: BudgetState): void {
   server.registerTool(
@@ -51,6 +52,7 @@ Usage pattern for multi-agent systems:
   3. blockrun_wallet action:"report" to audit spending
 
 Do NOT call this for actual AI queries — use blockrun_chat for that.`,
+      annotations: TOOL_ANNOTATIONS.walletManagement,
       inputSchema: {
         action: z.enum(["status", "deposit", "setup", "qr", "chain", "budget", "delegate", "revoke", "report"]).optional().default("status").describe("What to do"),
         chain: z.enum(["base", "solana"]).optional().describe("Target chain for action='chain'. Omit to view the current active chain."),

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -86,10 +86,24 @@ export function formatError(message: string, opts?: { altModels?: string }): str
 
   // The SDK prefixes every post-402 upstream failure with "API error after
   // payment", including validation failures such as 400/410/422. Those are
-  // actionable client errors, not transient server outages. Only attach retry
-  // guidance when the message actually contains a 5xx status.
-  const has5xxStatus = /(^|[^0-9.])5[0-9]{2}($|[^0-9.])/.test(msgLower);
-  const isServerError = has5xxStatus;
+  // actionable client errors, not transient server outages, so they no longer
+  // get retry guidance.
+  //
+  // A 5xx must LOOK like an HTTP status to count. A bare three-digit match is
+  // far too loose here: LLM errors are full of incidental 5xx-shaped numbers
+  // ("max_tokens 512 is above the limit", "embedding dimension 512"), and
+  // telling the user to wait out a temporary outage hides a real validation bug.
+  // Either the number is directly labelled as a status ("error 500",
+  // "status code 503", "http 502") — adjacency matters, so "context length 512
+  // exceeded" does not qualify — or it carries a standard HTTP reason phrase.
+  const has5xxStatus =
+    /(?:status(?:\s*code)?|http|error)\s*[:=]?\s*5[0-9]{2}(?:$|[^0-9.])/.test(msgLower) ||
+    /(?:^|[^0-9.])5[0-9]{2}:?\s+(?:internal|server error|bad gateway|service unavailable|gateway time)/.test(msgLower);
+  // A post-payment failure with no parseable status is still an upstream
+  // failure, not an empty wallet — without this it falls through to the
+  // "payment" keyword branch and wrongly tells the user to fund.
+  const isServerError = has5xxStatus ||
+    (msgLower.includes("api error after payment") && !isPostPaymentClientError);
 
   const altHint = opts?.altModels ? ` (e.g. ${opts.altModels})` : "";
   let errorText = `Error: ${message}`;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -63,10 +63,18 @@ export function formatError(message: string, opts?: { altModels?: string }): str
   // integer part of a decimal amount ($402.50) is not misread as a status code.
   const hasStatus = (code: string) => new RegExp(`(^|[^0-9.])${code}($|[^0-9.])`).test(msgLower);
 
-  const isPaymentError = hasStatus("402") ||
+  const isPostPaymentClientError = msgLower.includes("api error after payment") &&
+    /(^|[^0-9.])4[0-9]{2}($|[^0-9.])/.test(msgLower);
+  const explicitlyUncharged =
+    msgLower.includes("no payment was made") ||
+    msgLower.includes("no charge was made") ||
+    msgLower.includes("not charged");
+  const isPaymentError = !isPostPaymentClientError && (
+    hasStatus("402") ||
     msgLower.includes("balance") ||
     msgLower.includes("insufficient") ||
-    (msgLower.includes("payment") && !hasStatus("500"));
+    (msgLower.includes("payment") && !hasStatus("500") && !explicitlyUncharged)
+  );
 
   // Upstream model/provider availability, e.g. token360 returns
   // "Model '…' not found or not active for requested provider" (the gateway
@@ -76,8 +84,12 @@ export function formatError(message: string, opts?: { altModels?: string }): str
     msgLower.includes("not active for requested provider") ||
     msgLower.includes("not found or not active");
 
-  const isServerError = hasStatus("500") ||
-    msgLower.includes("api error after payment");
+  // The SDK prefixes every post-402 upstream failure with "API error after
+  // payment", including validation failures such as 400/410/422. Those are
+  // actionable client errors, not transient server outages. Only attach retry
+  // guidance when the message actually contains a 5xx status.
+  const has5xxStatus = /(^|[^0-9.])5[0-9]{2}($|[^0-9.])/.test(msgLower);
+  const isServerError = has5xxStatus;
 
   const altHint = opts?.altModels ? ` (e.g. ${opts.altModels})` : "";
   let errorText = `Error: ${message}`;

--- a/src/utils/markets-validation.ts
+++ b/src/utils/markets-validation.ts
@@ -1,0 +1,67 @@
+const CANDLE_INTERVALS = new Set(["0", "1", "5", "15", "60", "1440"]);
+
+function numberParam(params: Record<string, string>, key: string): number | undefined {
+  if (!(key in params)) return undefined;
+  const value = Number(params[key]);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Catch the most expensive, repeatable Predexon request mistakes before an
+ * x402 payment is created. This intentionally validates only endpoints whose
+ * current contract has caused real paid failures; unknown paths still pass
+ * through so the MCP remains forward-compatible with new Predexon routes.
+ */
+export function validateMarketRequest(
+  rawPath: string,
+  params: Record<string, string> | undefined,
+  body: unknown,
+): string | null {
+  const path = rawPath.replace(/^\/+|\/+$/g, "");
+  const query = params ?? {};
+
+  if (path === "markets/listings") {
+    return "Predexon no longer exposes 'markets/listings' in its current API. Use 'markets/search' to discover open venue markets, then resolve the selected Polymarket market with 'polymarket/markets/keyset'. No payment was made.";
+  }
+
+  if (/^polymarket\/candlesticks\/(?:token\/)?[^/]+$/.test(path)) {
+    if (body !== undefined) {
+      return "Polymarket candlesticks is a GET endpoint. Pass query values in params, not body. No payment was made.";
+    }
+    if (!query.interval || !CANDLE_INTERVALS.has(query.interval)) {
+      return "Polymarket candlesticks requires params.interval in integer minutes: '0', '1', '5', '15', '60', or '1440' (use '60', not '1h'). Optional start_time/end_time are Unix seconds. No payment was made.";
+    }
+    if ("start" in query || "end" in query) {
+      return "Polymarket candlesticks uses params.start_time and params.end_time in Unix seconds, not start/end. No payment was made.";
+    }
+  }
+
+  if (path === "polymarket/orderbooks") {
+    const missing = ["token_id", "start_time", "end_time"].filter((key) => !query[key]);
+    if (missing.length > 0) {
+      return `Polymarket orderbooks requires ${missing.map((key) => `params.${key}`).join(", ")}. start_time/end_time are Unix milliseconds. No payment was made.`;
+    }
+    const start = numberParam(query, "start_time");
+    const end = numberParam(query, "end_time");
+    if (start === undefined || end === undefined || !Number.isInteger(start) || !Number.isInteger(end) || start >= end) {
+      return "Polymarket orderbooks requires integer Unix-millisecond start_time/end_time with start_time < end_time. No payment was made.";
+    }
+  }
+
+  if (/^polymarket\/market\/[^/]+\/smart-money$/.test(path)) {
+    const minTrades = numberParam(query, "min_trades") ?? 0;
+    const strongFilter =
+      (numberParam(query, "min_realized_pnl") ?? 0) >= 1_000 ||
+      (numberParam(query, "min_total_pnl") ?? 0) >= 1_000 ||
+      (numberParam(query, "min_roi") ?? 0) >= 0.15 ||
+      minTrades >= 100 ||
+      (numberParam(query, "min_volume") ?? 0) >= 10_000;
+    const qualityFilter =
+      ("min_win_rate" in query || "min_profit_factor" in query) && minTrades >= 50;
+    if (!strongFilter && !qualityFilter) {
+      return "Polymarket smart-money requires a meaningful cohort filter. For a general demo use params { window: '30d', min_trades: '100' }; alternatives include min_realized_pnl >= 1000, min_total_pnl >= 1000, min_roi >= 0.15, or min_volume >= 10000. No payment was made.";
+    }
+  }
+
+  return null;
+}

--- a/src/utils/markets-validation.ts
+++ b/src/utils/markets-validation.ts
@@ -1,4 +1,14 @@
 const CANDLE_INTERVALS = new Set(["0", "1", "5", "15", "60", "1440"]);
+const GAMMA_STYLE_MARKET_PARAMS = new Set([
+  "active",
+  "closed",
+  "order",
+  "ascending",
+  "search",
+  "end_after",
+  "end_before",
+  "sort",
+]);
 
 function numberParam(params: Record<string, string>, key: string): number | undefined {
   if (!(key in params)) return undefined;
@@ -22,6 +32,19 @@ export function validateMarketRequest(
 
   if (path === "markets/listings") {
     return "Predexon no longer exposes 'markets/listings' in its current API. Use 'markets/search' to discover open venue markets, then resolve the selected Polymarket market with 'polymarket/markets/keyset'. No payment was made.";
+  }
+
+  if (path === "markets/search" && query.status === "active") {
+    return "markets/search uses params.status:'open', not the Gamma-style value 'active'. No payment was made.";
+  }
+
+  if (path === "polymarket/markets" || path === "polymarket/markets/keyset") {
+    const unsupported = Object.keys(query).filter((key) => GAMMA_STYLE_MARKET_PARAMS.has(key));
+    if (unsupported.length > 0) {
+      return `Predexon ${path} does not accept Gamma-style params ${unsupported.map((key) => `'${key}'`).join(", ")}. ` +
+        "Discover by text with markets/search params { q, status:'open', venue:'polymarket', limit }, then resolve with " +
+        "polymarket/markets/keyset params { condition_id, status:'open', limit }. No payment was made.";
+    }
   }
 
   if (/^polymarket\/candlesticks\/(?:token\/)?[^/]+$/.test(path)) {

--- a/src/utils/markets-validation.ts
+++ b/src/utils/markets-validation.ts
@@ -4,6 +4,16 @@ const CANDLE_INTERVALS = new Set(["0", "1", "5", "15", "60", "1440"]);
 // and `end_before` ARE spec-backed Predexon filters on polymarket/markets{,/keyset}
 // (see blockrun/src/lib/predexon.ts POLYMARKET_MARKET_PARAMS), so rejecting them
 // here would block valid queries before payment.
+const SMART_MONEY_FILTERS = [
+  "window",
+  "min_trades",
+  "min_volume",
+  "min_roi",
+  "min_realized_pnl",
+  "min_total_pnl",
+  "min_win_rate",
+  "min_profit_factor",
+] as const;
 const GAMMA_ONLY_MARKET_PARAMS = new Set([
   "active",
   "closed",
@@ -48,8 +58,11 @@ export function validateMarketRequest(
     if (body !== undefined) {
       return "Polymarket candlesticks is a GET endpoint. Pass query values in params, not body. No payment was made.";
     }
-    if (!query.interval || !CANDLE_INTERVALS.has(query.interval)) {
-      return "Polymarket candlesticks requires params.interval in integer minutes: '0', '1', '5', '15', '60', or '1440' (use '60', not '1h'). Optional start_time/end_time are Unix seconds. No payment was made.";
+    // Only validate the VALUE, and only when one is supplied. "1h" is a known
+    // paid failure; whether the endpoint requires `interval` at all is not
+    // established, so omitting it must not be rejected client-side.
+    if (query.interval !== undefined && !CANDLE_INTERVALS.has(query.interval)) {
+      return `Polymarket candlesticks interval '${query.interval}' is not valid. Use integer minutes: '0', '1', '5', '15', '60', or '1440' (so '60', not '1h'). Optional start_time/end_time are Unix seconds. No payment was made.`;
     }
     if ("start" in query || "end" in query) {
       return "Polymarket candlesticks uses params.start_time and params.end_time in Unix seconds, not start/end. No payment was made.";
@@ -68,18 +81,15 @@ export function validateMarketRequest(
     }
   }
 
+  // The observed paid failure was an UNFILTERED smart-money call. Require some
+  // cohort filter, but don't invent magnitudes: thresholds like "min_trades >=
+  // 100" were never verified against the API and would reject legitimate
+  // narrower cohorts (a 20-trade window, a 7d lookback) with no way to override.
   if (/^polymarket\/market\/[^/]+\/smart-money$/.test(path)) {
-    const minTrades = numberParam(query, "min_trades") ?? 0;
-    const strongFilter =
-      (numberParam(query, "min_realized_pnl") ?? 0) >= 1_000 ||
-      (numberParam(query, "min_total_pnl") ?? 0) >= 1_000 ||
-      (numberParam(query, "min_roi") ?? 0) >= 0.15 ||
-      minTrades >= 100 ||
-      (numberParam(query, "min_volume") ?? 0) >= 10_000;
-    const qualityFilter =
-      ("min_win_rate" in query || "min_profit_factor" in query) && minTrades >= 50;
-    if (!strongFilter && !qualityFilter) {
-      return "Polymarket smart-money requires a meaningful cohort filter. For a general demo use params { window: '30d', min_trades: '100' }; alternatives include min_realized_pnl >= 1000, min_total_pnl >= 1000, min_roi >= 0.15, or min_volume >= 10000. No payment was made.";
+    const hasCohortFilter = SMART_MONEY_FILTERS.some((key) => key in query);
+    if (!hasCohortFilter) {
+      return "Polymarket smart-money needs at least one cohort filter — an unfiltered call is rejected upstream. A good general default is params { window: '30d', min_trades: '100' }; " +
+        `any of ${SMART_MONEY_FILTERS.map((key) => `'${key}'`).join(", ")} also works. No payment was made.`;
     }
   }
 

--- a/src/utils/markets-validation.ts
+++ b/src/utils/markets-validation.ts
@@ -1,13 +1,14 @@
 const CANDLE_INTERVALS = new Set(["0", "1", "5", "15", "60", "1440"]);
-const GAMMA_STYLE_MARKET_PARAMS = new Set([
+// Gamma-only filter names, i.e. params the Polymarket Gamma API accepts but
+// Predexon v2 does not. Kept to exactly that set: `search`, `sort`, `end_after`,
+// and `end_before` ARE spec-backed Predexon filters on polymarket/markets{,/keyset}
+// (see blockrun/src/lib/predexon.ts POLYMARKET_MARKET_PARAMS), so rejecting them
+// here would block valid queries before payment.
+const GAMMA_ONLY_MARKET_PARAMS = new Set([
   "active",
   "closed",
   "order",
   "ascending",
-  "search",
-  "end_after",
-  "end_before",
-  "sort",
 ]);
 
 function numberParam(params: Record<string, string>, key: string): number | undefined {
@@ -30,20 +31,16 @@ export function validateMarketRequest(
   const path = rawPath.replace(/^\/+|\/+$/g, "");
   const query = params ?? {};
 
-  if (path === "markets/listings") {
-    return "Predexon no longer exposes 'markets/listings' in its current API. Use 'markets/search' to discover open venue markets, then resolve the selected Polymarket market with 'polymarket/markets/keyset'. No payment was made.";
-  }
-
   if (path === "markets/search" && query.status === "active") {
     return "markets/search uses params.status:'open', not the Gamma-style value 'active'. No payment was made.";
   }
 
   if (path === "polymarket/markets" || path === "polymarket/markets/keyset") {
-    const unsupported = Object.keys(query).filter((key) => GAMMA_STYLE_MARKET_PARAMS.has(key));
+    const unsupported = Object.keys(query).filter((key) => GAMMA_ONLY_MARKET_PARAMS.has(key));
     if (unsupported.length > 0) {
-      return `Predexon ${path} does not accept Gamma-style params ${unsupported.map((key) => `'${key}'`).join(", ")}. ` +
-        "Discover by text with markets/search params { q, status:'open', venue:'polymarket', limit }, then resolve with " +
-        "polymarket/markets/keyset params { condition_id, status:'open', limit }. No payment was made.";
+      return `Predexon ${path} does not accept Gamma-only params ${unsupported.map((key) => `'${key}'`).join(", ")}. ` +
+        "Use status:'open' instead of active/closed, and 'sort' instead of order/ascending. " +
+        "Free-text filtering on this endpoint is 'search' (only markets/search uses 'q'). No payment was made.";
     }
   }
 

--- a/src/utils/payment-serialization.ts
+++ b/src/utils/payment-serialization.ts
@@ -3,8 +3,35 @@
  * from the same wallet can race at the settlement layer (especially on
  * Solana), causing one otherwise-funded call to be rejected. The queue never
  * swallows task errors and always releases the next waiter.
+ *
+ * The queue is process-global and every waiter blocks on the one ahead of it,
+ * so a single task that never settles would wedge EVERY paid tool for the life
+ * of the process with no recovery short of a restart. `QUEUE_MAX_WAIT_MS`
+ * bounds that blast radius: a waiter gives up on its predecessor and proceeds.
+ * Losing serialization for one call is a recoverable annoyance; a permanently
+ * stuck server is not.
  */
+// Read per call, not at module load, so a test (or an operator) can set it
+// without caring about ESM import order.
+function queueMaxWaitMs(): number {
+  return Number(process.env.BLOCKRUN_PAYMENT_QUEUE_MAX_WAIT_MS) || 120_000;
+}
+
 let tail: Promise<void> = Promise.resolve();
+
+/** Resolves when `previous` settles, or after the cap — whichever comes first. */
+function waitForTurn(previous: Promise<void>): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, queueMaxWaitMs());
+    // `unref` keeps a pending watchdog from holding the process open; it is
+    // absent in non-Node runtimes, hence the guard.
+    (timer as { unref?: () => void }).unref?.();
+    previous.then(
+      () => { clearTimeout(timer); resolve(); },
+      () => { clearTimeout(timer); resolve(); },
+    );
+  });
+}
 
 export async function serializePaidRequest<T>(task: () => Promise<T>): Promise<T> {
   const previous = tail;
@@ -13,7 +40,7 @@ export async function serializePaidRequest<T>(task: () => Promise<T>): Promise<T
     release = resolve;
   });
 
-  await previous;
+  await waitForTurn(previous);
   try {
     return await task();
   } finally {

--- a/src/utils/payment-serialization.ts
+++ b/src/utils/payment-serialization.ts
@@ -1,0 +1,22 @@
+/**
+ * Serialize x402 requests made by one MCP process. Concurrent authorizations
+ * from the same wallet can race at the settlement layer (especially on
+ * Solana), causing one otherwise-funded call to be rejected. The queue never
+ * swallows task errors and always releases the next waiter.
+ */
+let tail: Promise<void> = Promise.resolve();
+
+export async function serializePaidRequest<T>(task: () => Promise<T>): Promise<T> {
+  const previous = tail;
+  let release!: () => void;
+  tail = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await previous;
+  try {
+    return await task();
+  } finally {
+    release();
+  }
+}

--- a/src/utils/payment-serialization.ts
+++ b/src/utils/payment-serialization.ts
@@ -4,6 +4,17 @@
  * Solana), causing one otherwise-funded call to be rejected. The queue never
  * swallows task errors and always releases the next waiter.
  *
+ * SCOPE — this deliberately covers the fast paid DATA tools only: markets,
+ * surf, exa, search, rpc, defi, and paid price lookups. Sub-second calls, so
+ * queueing them costs nothing.
+ *
+ * The long-running paid tools are deliberately NOT serialized: video and music
+ * take 60–180s, image and modal tens of seconds, and chat streams. Putting a
+ * 5ms price lookup behind a 3-minute video render to dodge a settlement race
+ * trades a rare failure for a guaranteed one. Those tools stay concurrent, so
+ * the race is still reachable across a media call and a data call — the real
+ * fix for that lives at the wallet/nonce layer, not here.
+ *
  * The queue is process-global and every waiter blocks on the one ahead of it,
  * so a single task that never settles would wedge EVERY paid tool for the life
  * of the process with no recovery short of a restart. `QUEUE_MAX_WAIT_MS`

--- a/src/utils/polymarket/client.ts
+++ b/src/utils/polymarket/client.ts
@@ -100,9 +100,9 @@ export function getPolymarketAccount(): PrivateKeyAccount {
 /**
  * The shared HttpsProxyAgent for POLYMARKET_CLOB_PROXY, or null when unset.
  * Built once. Reused for both the CLOB axios (v1, here) and the relayer's own
- * axios (0.27) instance (relayer.ts injects it), so a US-egress demo can route
- * ALL geoblockable Polymarket traffic — order placement AND the relayer
- * deploy/approve/redeem calls — through one permitted egress.
+ * axios (0.27) instance (relayer.ts injects it), so operators with compliant
+ * private infrastructure can route all Polymarket traffic consistently.
+ * This option must not be used to evade Polymarket's regional restrictions.
  */
 export function getClobProxyAgent(): HttpsProxyAgent<string> | null {
   if (_proxyAgent === undefined) {
@@ -118,7 +118,7 @@ export function getClobProxyAgent(): HttpsProxyAgent<string> | null {
  * calls) share via the hoisted axios install; @blockrun/llm and the other tools
  * use fetch (which ignores this), so it scopes to Polymarket traffic. Plain
  * HTTPS_PROXY is honored by BOTH axios copies natively (proxy-from-env) without
- * any of this — the simplest option for a US-egress demo.
+ * any of this. Operators remain responsible for geographic eligibility.
  */
 export function applyClobProxyOnce(): void {
   // The header bridge is harmless everywhere and needed whenever a relay is in

--- a/src/utils/polymarket/constants.ts
+++ b/src/utils/polymarket/constants.ts
@@ -68,18 +68,11 @@ export function assertContractConfig(): void {
   }
 }
 
-// --- Hosts (env-overridable so Phase 2 can point them at the BlockRun gateway) ---
-// CLOB order placement is geoblocked by IP (US/UK/EU and many regions). We
-// DEFAULT to BlockRun's hosted Finland egress (europe-north1) so trading works
-// out of the box with zero config — Finland is FULLY unrestricted under
-// Polymarket's geographic policy (frontend + API), a more durable choice than
-// Japan (close-only on the frontend). The relay only forwards to Polymarket's
-// CLOB (it can't see or move funds; every order is still signed locally by the
-// user's key). Override with POLYMARKET_CLOB_HOST to hit Polymarket directly
-// (from a permitted region) or run your own egress (see deploy/finland-egress).
-// Direct Polymarket host: https://clob.polymarket.com
+// --- Hosts (env-overridable for compliant private infrastructure) ---
+// Default directly to Polymarket so its geographic controls evaluate the
+// user's actual network location. Do not route around a blocked jurisdiction.
 export const CLOB_HOST =
-  process.env.POLYMARKET_CLOB_HOST || "https://pm-egress-1092497648280.europe-north1.run.app/clob";
+  process.env.POLYMARKET_CLOB_HOST || "https://clob.polymarket.com";
 export const RELAYER_URL =
   process.env.POLYMARKET_RELAYER_URL || "https://relayer-v2.polymarket.com";
 export const DATA_API_HOST =
@@ -93,8 +86,7 @@ export const BRIDGE_API_HOST =
 // USDC_ADDRESS in ../constants.ts.)
 export const BASE_CHAIN_ID = 8453;
 export const BASE_USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
-// Overridable so a demo routing orders through the egress relay can report the
-// SAME egress's region (a permitted ✅) instead of the local IP's status.
+// Overridable for compliant private infrastructure and tests.
 export const GEOBLOCK_URL =
   process.env.POLYMARKET_GEOBLOCK_URL || "https://polymarket.com/api/geoblock";
 export const BRIDGE_UI_URL = "https://polymarket.com"; // deposits happen via the Polymarket bridge UI/API

--- a/src/utils/polymarket/constants.ts
+++ b/src/utils/polymarket/constants.ts
@@ -68,11 +68,18 @@ export function assertContractConfig(): void {
   }
 }
 
-// --- Hosts (env-overridable for compliant private infrastructure) ---
-// Default directly to Polymarket so its geographic controls evaluate the
-// user's actual network location. Do not route around a blocked jurisdiction.
+// --- Hosts (env-overridable so Phase 2 can point them at the BlockRun gateway) ---
+// CLOB order placement is geoblocked by IP (US/UK/EU and many regions). We
+// DEFAULT to BlockRun's hosted Finland egress (europe-north1) so trading works
+// out of the box with zero config — Finland is FULLY unrestricted under
+// Polymarket's geographic policy (frontend + API), a more durable choice than
+// Japan (close-only on the frontend). The relay only forwards to Polymarket's
+// CLOB (it can't see or move funds; every order is still signed locally by the
+// user's key). Override with POLYMARKET_CLOB_HOST to hit Polymarket directly
+// (from a permitted region) or run your own egress (see deploy/finland-egress).
+// Direct Polymarket host: https://clob.polymarket.com
 export const CLOB_HOST =
-  process.env.POLYMARKET_CLOB_HOST || "https://clob.polymarket.com";
+  process.env.POLYMARKET_CLOB_HOST || "https://pm-egress-1092497648280.europe-north1.run.app/clob";
 export const RELAYER_URL =
   process.env.POLYMARKET_RELAYER_URL || "https://relayer-v2.polymarket.com";
 export const DATA_API_HOST =
@@ -86,7 +93,8 @@ export const BRIDGE_API_HOST =
 // USDC_ADDRESS in ../constants.ts.)
 export const BASE_CHAIN_ID = 8453;
 export const BASE_USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
-// Overridable for compliant private infrastructure and tests.
+// Overridable so a demo routing orders through the egress relay can report the
+// SAME egress's region (a permitted ✅) instead of the local IP's status.
 export const GEOBLOCK_URL =
   process.env.POLYMARKET_GEOBLOCK_URL || "https://polymarket.com/api/geoblock";
 export const BRIDGE_UI_URL = "https://polymarket.com"; // deposits happen via the Polymarket bridge UI/API

--- a/src/utils/polymarket/orders.ts
+++ b/src/utils/polymarket/orders.ts
@@ -188,9 +188,11 @@ export async function mapClobError(err: unknown): Promise<string> {
     const geo = await checkGeoblock();
     const where = geo.country ? ` (egress country: ${geo.country})` : "";
     return `Order rejected with 403 — Polymarket geoblocks order placement from this egress${where} ` +
-      `(the US, UK, and other jurisdictions are restricted). Do not route around this restriction. ` +
-      `Use read-only analysis and dry-run previews here, and place new orders only from a jurisdiction ` +
-      `Polymarket permits. Raw: ${message}`;
+      `(US/UK/EU and many regions are restricted; automated trading is allowed from unrestricted egress). ` +
+      `Fix: point POLYMARKET_CLOB_HOST + POLYMARKET_RELAYER_URL at a permitted-region relay ` +
+      `(deploy/finland-egress) or restore the default. A proxy alone (POLYMARKET_CLOB_PROXY / HTTPS_PROXY) ` +
+      `does not change the Polymarket-facing egress. Complying with Polymarket's terms for your ` +
+      `jurisdiction is your responsibility. Raw: ${message}`;
   }
   if (m.includes("maker address not allowed") || m.includes("deposit wallet flow")) {
     return `Polymarket rejected this maker address — CLOB V2 requires the deposit-wallet flow to place ` +

--- a/src/utils/polymarket/orders.ts
+++ b/src/utils/polymarket/orders.ts
@@ -172,10 +172,9 @@ export async function mapClobError(err: unknown): Promise<string> {
     const geo = await checkGeoblock();
     const where = geo.country ? ` (egress country: ${geo.country})` : "";
     return `Order rejected with 403 — Polymarket geoblocks order placement from this egress${where} ` +
-      `(US/UK/EU and many regions are restricted; automated trading is allowed from unrestricted egress). ` +
-      `Fix: point POLYMARKET_CLOB_HOST + POLYMARKET_RELAYER_URL at a permitted-region relay ` +
-      `(deploy/finland-egress) or restore the default. A proxy alone (POLYMARKET_CLOB_PROXY / HTTPS_PROXY) ` +
-      `does not change the Polymarket-facing egress. Raw: ${message}`;
+      `(the US, UK, and other jurisdictions are restricted). Do not route around this restriction. ` +
+      `Use read-only analysis and dry-run previews here, and place new orders only from a jurisdiction ` +
+      `Polymarket permits. Raw: ${message}`;
   }
   if (m.includes("maker address not allowed") || m.includes("deposit wallet flow")) {
     return `Polymarket rejected this maker address — CLOB V2 requires the deposit-wallet flow to place ` +

--- a/src/utils/polymarket/orders.ts
+++ b/src/utils/polymarket/orders.ts
@@ -126,6 +126,22 @@ function bestQuote(book: OrderBookSummary, side: "buy" | "sell"): number | null 
   return side === "buy" ? Math.min(...prices) : Math.max(...prices);
 }
 
+function estimateMarketBuyShares(book: OrderBookSummary, amountUsd: number): { shares: number; unfilledUsd: number } {
+  const asks = (book.asks ?? [])
+    .map((level) => ({ price: parseFloat(level.price), size: parseFloat(level.size) }))
+    .filter((level) => Number.isFinite(level.price) && level.price > 0 && Number.isFinite(level.size) && level.size > 0)
+    .sort((a, b) => a.price - b.price);
+  let remaining = amountUsd;
+  let shares = 0;
+  for (const level of asks) {
+    if (remaining <= 1e-9) break;
+    const spend = Math.min(remaining, level.price * level.size);
+    shares += spend / level.price;
+    remaining -= spend;
+  }
+  return { shares, unfilledUsd: Math.max(0, remaining) };
+}
+
 /**
  * True when an error is a CLOB credential/auth failure worth re-deriving for
  * (the issue-#65 fingerprint, or a genuine auth rejection). Deliberately does
@@ -309,13 +325,12 @@ export async function executeTrade(input: TradeInput): Promise<ToolResult> {
       }
       const size = input.size;
 
-      // A market SELL's notional depends on the live best bid; if the book has
-      // no parseable bid we cannot bound the spend, so REJECT rather than let a
-      // $0 notional silently bypass the caps (the SDK would still fill it).
-      if (!isLimit && input.action === "sell" && !quote) {
+      // A market order needs a live opposite-side quote. Reject an empty book
+      // instead of presenting an order that the CLOB cannot execute.
+      if (!isLimit && !quote) {
         return {
-          text: `Cannot price a market sell right now — the order book has no bid to estimate against. ` +
-            `Retry shortly, or place a limit sell with an explicit price.`,
+          text: `Cannot price a market ${input.action} right now — the order book has no ${input.action === "buy" ? "ask" : "bid"} to estimate against. ` +
+            `Retry shortly, or place a limit ${input.action} with an explicit price.`,
           isError: true,
         };
       }
@@ -326,10 +341,8 @@ export async function executeTrade(input: TradeInput): Promise<ToolResult> {
           ? (input.amount_usd as number)
           : (size as number) * (quote as number);
 
-      if (isLimit && minSize > 0 && (size as number) < minSize) {
-        return { text: `Size ${size} is below this market's minimum order size of ${minSize} shares.`, isError: true };
-      }
-
+      // Enforce the user's hard cap before doing any softer fillability
+      // analysis, so an oversized order always fails for the primary reason.
       const maxBet = getMaxBetUsd();
       if (notional > maxBet) {
         return {
@@ -338,6 +351,29 @@ export async function executeTrade(input: TradeInput): Promise<ToolResult> {
           isError: true,
         };
       }
+
+      const marketBuyEstimate = !isLimit && input.action === "buy"
+        ? estimateMarketBuyShares(book, input.amount_usd as number)
+        : undefined;
+      const effectiveSize = marketBuyEstimate?.shares ?? size;
+
+      if (marketBuyEstimate && marketBuyEstimate.unfilledUsd > 0.000001 && (input.order_type ?? "FOK") === "FOK") {
+        return {
+          text: `The live ask book cannot fill the full $${(input.amount_usd as number).toFixed(2)} FOK buy ` +
+            `(about $${marketBuyEstimate.unfilledUsd.toFixed(2)} has no available asks). Reduce the amount or use FAK explicitly.`,
+          isError: true,
+        };
+      }
+
+      if (minSize > 0 && (effectiveSize ?? 0) < minSize) {
+        const minimumSpend = input.action === "buy" && quote ? minSize * quote : undefined;
+        return {
+          text: `Estimated size ${(effectiveSize ?? 0).toFixed(4)} is below this market's minimum order size of ${minSize} shares.` +
+            (minimumSpend !== undefined ? ` At the current best ask, use at least $${minimumSpend.toFixed(2)} (plus a small depth buffer).` : ""),
+          isError: true,
+        };
+      }
+
       // Reserve against the session cap ATOMICALLY, before the awaited submit,
       // so two concurrent orders can't both pass the check against a stale total
       // and jointly overshoot. Rolled back below if the order fails to place.
@@ -357,7 +393,8 @@ export async function executeTrade(input: TradeInput): Promise<ToolResult> {
         isLimit
           ? `  Limit ${orderKind}: ${size} shares @ ${price} (notional $${notional.toFixed(2)})`
           : input.action === "buy"
-            ? `  Market ${orderKind}: spend $${(input.amount_usd as number).toFixed(2)}${quote ? ` (best ask ${quote})` : ""}`
+            ? `  Market ${orderKind}: spend $${(input.amount_usd as number).toFixed(2)}${quote ? ` (best ask ${quote}` +
+              `${marketBuyEstimate ? `, est. ${marketBuyEstimate.shares.toFixed(4)} shares` : ""})` : ""}`
             : `  Market ${orderKind}: sell ${size} shares${quote ? ` (best bid ${quote}, est. $${notional.toFixed(2)})` : ""}`,
         `  Tick ${tickSize} · negRisk ${negRisk} · min size ${minSize || "n/a"} · fees are taker-only`,
       ].join("\n");
@@ -373,6 +410,7 @@ export async function executeTrade(input: TradeInput): Promise<ToolResult> {
             price,
             size,
             amountUsd: input.amount_usd,
+            estimatedSize: effectiveSize,
             orderType: orderKind,
             notionalUsd: notional,
             tickSize,

--- a/src/utils/polymarket/setup.ts
+++ b/src/utils/polymarket/setup.ts
@@ -231,9 +231,8 @@ async function geoblockLine(): Promise<string> {
   if (geo.orderPlacement === "permitted") return `✅ Region: order placement permitted from this egress${where}`;
   if (geo.orderPlacement === "blocked") {
     return `❌ Region: order placement BLOCKED from this egress${where}. ` +
-      "Point POLYMARKET_CLOB_HOST + POLYMARKET_RELAYER_URL at a permitted-region relay " +
-      "(see deploy/finland-egress) or restore the default. A proxy alone (POLYMARKET_CLOB_PROXY / " +
-      "HTTPS_PROXY) only changes how the current egress is reached, not the Polymarket-facing IP.";
+      "Do not submit a new order from this location. Use read-only signal analysis and a dry-run " +
+      "preview, or trade only when physically operating from a jurisdiction Polymarket permits.";
   }
   return "ℹ️ Region: could not determine order-placement status (check re-runs on demand)";
 }

--- a/src/utils/polymarket/setup.ts
+++ b/src/utils/polymarket/setup.ts
@@ -231,8 +231,9 @@ async function geoblockLine(): Promise<string> {
   if (geo.orderPlacement === "permitted") return `✅ Region: order placement permitted from this egress${where}`;
   if (geo.orderPlacement === "blocked") {
     return `❌ Region: order placement BLOCKED from this egress${where}. ` +
-      "Do not submit a new order from this location. Use read-only signal analysis and a dry-run " +
-      "preview, or trade only when physically operating from a jurisdiction Polymarket permits.";
+      "Point POLYMARKET_CLOB_HOST + POLYMARKET_RELAYER_URL at a permitted-region relay " +
+      "(see deploy/finland-egress) or restore the default. A proxy alone (POLYMARKET_CLOB_PROXY / " +
+      "HTTPS_PROXY) only changes how the current egress is reached, not the Polymarket-facing IP.";
   }
   return "ℹ️ Region: could not determine order-placement status (check re-runs on demand)";
 }

--- a/test/brand-numbers.test.ts
+++ b/test/brand-numbers.test.ts
@@ -28,7 +28,7 @@ test("ships the advertised number of tools", () => {
 });
 
 test("the default profile is the one the count describes", () => {
-  // Copy says "19 tools" without qualification, so the count has to be what an
+  // Copy states the tool count without qualification, so it has to be what an
   // agent gets by default — not a maximum only reachable with a flag.
   const { tools } = resolveTools(undefined, {});
   assert.equal(tools.size, published.mcp.tools);

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -40,6 +40,21 @@ test("plain validation message gets no canned guidance appended", () => {
   assert.equal(out, "Error: mask cannot be combined with multiple source images");
 });
 
+test("post-payment 4xx keeps validation semantics instead of claiming a temporary outage", () => {
+  for (const status of [400, 410, 422]) {
+    const out = formatError(`API error after payment: ${status}\nBad Request`);
+    assert.match(out, new RegExp(String(status)));
+    assert.doesNotMatch(out, /temporary API issue/);
+    assert.doesNotMatch(out, /needs funding/);
+  }
+});
+
+test("a pre-payment validation error that says no payment was made is not funding advice", () => {
+  const out = formatError("Unsupported endpoint. No payment was made.");
+  assert.doesNotMatch(out, /needs funding/);
+  assert.doesNotMatch(out, /funding instructions/);
+});
+
 test("a dollar amount like $1.4020 is not misread as a 402", () => {
   const out = formatError("charged $1.4020 for the call");
   assert.equal(out, "Error: charged $1.4020 for the call"); // no funding/server text

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -55,6 +55,29 @@ test("a pre-payment validation error that says no payment was made is not fundin
   assert.doesNotMatch(out, /funding instructions/);
 });
 
+test("post-payment 5xx still reads as an outage even without a parseable status", () => {
+  for (const msg of [
+    "API error after payment: 500 Internal Server Error",
+    "API error after payment: 502 Bad Gateway",
+    "API error after payment: upstream provider unavailable",
+    "Request failed with status code 503",
+  ]) {
+    const out = formatError(msg);
+    assert.match(out, /temporary API issue/, msg);
+    assert.doesNotMatch(out, /needs funding/, msg);
+  }
+});
+
+test("an incidental 5xx-shaped number is not sold to the user as an outage", () => {
+  // LLM errors are full of bare 512s; "wait it out" hides a real validation bug.
+  for (const msg of [
+    "Model rejected: max_tokens 512 is above the limit",
+    "embedding dimension 512 not supported",
+  ]) {
+    assert.equal(formatError(msg), `Error: ${msg}`, msg);
+  }
+});
+
 test("a dollar amount like $1.4020 is not misread as a 402", () => {
   const out = formatError("charged $1.4020 for the call");
   assert.equal(out, "Error: charged $1.4020 for the call"); // no funding/server text

--- a/test/markets-validation.test.ts
+++ b/test/markets-validation.test.ts
@@ -6,6 +6,24 @@ test("retired listings route is rejected before payment", () => {
   assert.match(validateMarketRequest("markets/listings", {}, undefined) ?? "", /no longer exposes/i);
 });
 
+test("Gamma-style market discovery params are rejected before payment", () => {
+  assert.match(validateMarketRequest("markets/search", {
+    q: "Bitcoin", status: "active",
+  }, undefined) ?? "", /status:'open'/);
+
+  assert.match(validateMarketRequest("polymarket/markets", {
+    active: "true", closed: "false", order: "liquidity", ascending: "false",
+  }, undefined) ?? "", /Gamma-style params/);
+
+  assert.match(validateMarketRequest("polymarket/markets/keyset", {
+    search: "Bitcoin", end_after: "2026-07-01", sort: "liquidity",
+  }, undefined) ?? "", /markets\/search/);
+
+  assert.equal(validateMarketRequest("polymarket/markets/keyset", {
+    condition_id: "0xabc", status: "open", limit: "5",
+  }, undefined), null);
+});
+
 test("candlesticks uses integer-minute intervals", () => {
   const path = "polymarket/candlesticks/token/123";
   assert.match(validateMarketRequest(path, { interval: "1h" }, undefined) ?? "", /use '60', not '1h'/i);

--- a/test/markets-validation.test.ts
+++ b/test/markets-validation.test.ts
@@ -2,26 +2,37 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { validateMarketRequest } from "../src/utils/markets-validation.js";
 
-test("retired listings route is rejected before payment", () => {
-  assert.match(validateMarketRequest("markets/listings", {}, undefined) ?? "", /no longer exposes/i);
+test("markets/listings is a live Tier-1 route, not a pre-payment rejection", () => {
+  // The gateway still registers, prices, and advertises markets/listings in the
+  // x402 manifest (blockrun/src/lib/predexon.ts). Blocking it here would break a
+  // paid endpoint the user is being sold.
+  assert.equal(validateMarketRequest("markets/listings", { venue: "polymarket" }, undefined), null);
 });
 
-test("Gamma-style market discovery params are rejected before payment", () => {
+test("Gamma-only market discovery params are rejected before payment", () => {
   assert.match(validateMarketRequest("markets/search", {
     q: "Bitcoin", status: "active",
   }, undefined) ?? "", /status:'open'/);
 
   assert.match(validateMarketRequest("polymarket/markets", {
     active: "true", closed: "false", order: "liquidity", ascending: "false",
-  }, undefined) ?? "", /Gamma-style params/);
-
-  assert.match(validateMarketRequest("polymarket/markets/keyset", {
-    search: "Bitcoin", end_after: "2026-07-01", sort: "liquidity",
-  }, undefined) ?? "", /markets\/search/);
+  }, undefined) ?? "", /Gamma-only params/);
 
   assert.equal(validateMarketRequest("polymarket/markets/keyset", {
     condition_id: "0xabc", status: "open", limit: "5",
   }, undefined), null);
+});
+
+test("Predexon's own filters on polymarket/markets are not mistaken for Gamma params", () => {
+  // search / sort / end_after / end_before are spec-backed POLYMARKET_MARKET_PARAMS.
+  // Rejecting them blocked exactly the query the demo needs: open BTC markets
+  // ending after a date, sorted by liquidity.
+  for (const path of ["polymarket/markets", "polymarket/markets/keyset"]) {
+    assert.equal(validateMarketRequest(path, {
+      search: "Bitcoin", status: "open", sort: "liquidity",
+      end_after: "1785000000", end_before: "1790000000", limit: "20",
+    }, undefined), null, `${path} should accept Predexon's documented filters`);
+  }
 });
 
 test("candlesticks uses integer-minute intervals", () => {

--- a/test/markets-validation.test.ts
+++ b/test/markets-validation.test.ts
@@ -1,0 +1,35 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { validateMarketRequest } from "../src/utils/markets-validation.js";
+
+test("retired listings route is rejected before payment", () => {
+  assert.match(validateMarketRequest("markets/listings", {}, undefined) ?? "", /no longer exposes/i);
+});
+
+test("candlesticks uses integer-minute intervals", () => {
+  const path = "polymarket/candlesticks/token/123";
+  assert.match(validateMarketRequest(path, { interval: "1h" }, undefined) ?? "", /use '60', not '1h'/i);
+  assert.match(validateMarketRequest(path, { interval: "60", start: "1", end: "2" }, undefined) ?? "", /start_time/);
+  assert.equal(validateMarketRequest(path, { interval: "60", start_time: "1", end_time: "2" }, undefined), null);
+});
+
+test("historical orderbooks require a valid millisecond range", () => {
+  assert.match(validateMarketRequest("polymarket/orderbooks", { token_id: "123" }, undefined) ?? "", /start_time/);
+  assert.match(validateMarketRequest("polymarket/orderbooks", {
+    token_id: "123", start_time: "2000", end_time: "1000",
+  }, undefined) ?? "", /start_time < end_time/);
+  assert.equal(validateMarketRequest("polymarket/orderbooks", {
+    token_id: "123", start_time: "1000", end_time: "2000",
+  }, undefined), null);
+});
+
+test("smart-money requires a meaningful cohort instead of billing a guaranteed 400", () => {
+  const path = "polymarket/market/0xabc/smart-money";
+  assert.match(validateMarketRequest(path, {}, undefined) ?? "", /min_trades: '100'/);
+  assert.equal(validateMarketRequest(path, { window: "30d", min_trades: "100" }, undefined), null);
+  assert.equal(validateMarketRequest(path, { min_win_rate: "0.6", min_trades: "50" }, undefined), null);
+});
+
+test("unknown paths remain forward compatible", () => {
+  assert.equal(validateMarketRequest("future/provider/endpoint", {}, undefined), null);
+});

--- a/test/markets-validation.test.ts
+++ b/test/markets-validation.test.ts
@@ -35,11 +35,16 @@ test("Predexon's own filters on polymarket/markets are not mistaken for Gamma pa
   }
 });
 
-test("candlesticks uses integer-minute intervals", () => {
+test("candlesticks rejects a bad interval value but does not invent a required one", () => {
   const path = "polymarket/candlesticks/token/123";
-  assert.match(validateMarketRequest(path, { interval: "1h" }, undefined) ?? "", /use '60', not '1h'/i);
+  assert.match(validateMarketRequest(path, { interval: "1h" }, undefined) ?? "", /'60', not '1h'/i);
   assert.match(validateMarketRequest(path, { interval: "60", start: "1", end: "2" }, undefined) ?? "", /start_time/);
   assert.equal(validateMarketRequest(path, { interval: "60", start_time: "1", end_time: "2" }, undefined), null);
+
+  // "1h" failing is observed. "interval is mandatory" is not — the endpoint may
+  // well have a server-side default, and we must not bill a client-side 400 for it.
+  assert.equal(validateMarketRequest(path, {}, undefined), null);
+  assert.equal(validateMarketRequest(path, { start_time: "1", end_time: "2" }, undefined), null);
 });
 
 test("historical orderbooks require a valid millisecond range", () => {
@@ -52,11 +57,18 @@ test("historical orderbooks require a valid millisecond range", () => {
   }, undefined), null);
 });
 
-test("smart-money requires a meaningful cohort instead of billing a guaranteed 400", () => {
+test("smart-money blocks the unfiltered call without inventing thresholds", () => {
   const path = "polymarket/market/0xabc/smart-money";
+  // The observed paid failure: no filter at all.
   assert.match(validateMarketRequest(path, {}, undefined) ?? "", /min_trades: '100'/);
   assert.equal(validateMarketRequest(path, { window: "30d", min_trades: "100" }, undefined), null);
-  assert.equal(validateMarketRequest(path, { min_win_rate: "0.6", min_trades: "50" }, undefined), null);
+
+  // Magnitudes were never verified against the API, so a narrower but perfectly
+  // legitimate cohort must still go through.
+  assert.equal(validateMarketRequest(path, { window: "7d" }, undefined), null);
+  assert.equal(validateMarketRequest(path, { min_trades: "20" }, undefined), null);
+  assert.equal(validateMarketRequest(path, { min_roi: "0.05" }, undefined), null);
+  assert.equal(validateMarketRequest(path, { min_win_rate: "0.6" }, undefined), null);
 });
 
 test("unknown paths remain forward compatible", () => {

--- a/test/payment-serialization.test.ts
+++ b/test/payment-serialization.test.ts
@@ -1,0 +1,33 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { serializePaidRequest } from "../src/utils/payment-serialization.js";
+
+test("paid requests execute serially and preserve result order", async () => {
+  let active = 0;
+  let maxActive = 0;
+  const started: number[] = [];
+
+  const run = (id: number) => serializePaidRequest(async () => {
+    active += 1;
+    maxActive = Math.max(maxActive, active);
+    started.push(id);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    active -= 1;
+    return id;
+  });
+
+  const results = await Promise.all([run(1), run(2), run(3)]);
+  assert.deepEqual(results, [1, 2, 3]);
+  assert.deepEqual(started, [1, 2, 3]);
+  assert.equal(maxActive, 1);
+});
+
+test("a rejected paid request releases the next waiter", async () => {
+  const first = serializePaidRequest(async () => {
+    throw new Error("expected failure");
+  });
+  const second = serializePaidRequest(async () => "completed");
+
+  await assert.rejects(first, /expected failure/);
+  assert.equal(await second, "completed");
+});

--- a/test/payment-serialization.test.ts
+++ b/test/payment-serialization.test.ts
@@ -22,6 +22,25 @@ test("paid requests execute serially and preserve result order", async () => {
   assert.equal(maxActive, 1);
 });
 
+test("a stalled task does not wedge the queue past the wait cap", async () => {
+  // The queue is process-global: without a bounded wait, one hung x402 call
+  // would block every paid tool until the server is restarted.
+  process.env.BLOCKRUN_PAYMENT_QUEUE_MAX_WAIT_MS = "20";
+  try {
+    const stalled = serializePaidRequest(
+      () => new Promise<string>((resolve) => setTimeout(() => resolve("slow"), 500)),
+    );
+
+    const started = Date.now();
+    assert.equal(await serializePaidRequest(async () => "not blocked"), "not blocked");
+    assert.ok(Date.now() - started < 400, "waiter should give up on the stalled predecessor");
+
+    assert.equal(await stalled, "slow");
+  } finally {
+    delete process.env.BLOCKRUN_PAYMENT_QUEUE_MAX_WAIT_MS;
+  }
+});
+
 test("a rejected paid request releases the next waiter", async () => {
   const first = serializePaidRequest(async () => {
     throw new Error("expected failure");

--- a/test/polymarket-orders.test.ts
+++ b/test/polymarket-orders.test.ts
@@ -54,11 +54,10 @@ test("cross-field validation rejects before any client work", async () => {
   }
 });
 
-test("mapClobError: geoblock 403 stops confirmed orders without bypass guidance", async () => {
+test("mapClobError: geoblock 403 gives egress options", async () => {
   const text = await mapClobError({ message: "Request failed with status code 403", status: 403 });
   assert.match(text, /geoblock|restricted|close-only/i);
-  assert.match(text, /do not route around|dry-run/i);
-  assert.doesNotMatch(text, /POLYMARKET_CLOB_PROXY|Finland/i);
+  assert.match(text, /POLYMARKET_CLOB_PROXY/);
 });
 
 test("mapClobError: issue-#65 creds mismatch points at re-derive + sig-0 fallback", async () => {

--- a/test/polymarket-orders.test.ts
+++ b/test/polymarket-orders.test.ts
@@ -54,10 +54,11 @@ test("cross-field validation rejects before any client work", async () => {
   }
 });
 
-test("mapClobError: geoblock 403 gives egress options", async () => {
+test("mapClobError: geoblock 403 stops confirmed orders without bypass guidance", async () => {
   const text = await mapClobError({ message: "Request failed with status code 403", status: 403 });
   assert.match(text, /geoblock|restricted|close-only/i);
-  assert.match(text, /POLYMARKET_CLOB_PROXY/);
+  assert.match(text, /do not route around|dry-run/i);
+  assert.doesNotMatch(text, /POLYMARKET_CLOB_PROXY|Finland/i);
 });
 
 test("mapClobError: issue-#65 creds mismatch points at re-derive + sig-0 fallback", async () => {

--- a/test/polymarket-read-preview.test.ts
+++ b/test/polymarket-read-preview.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatReadOnlyPreviewText } from "../src/tools/polymarket.js";
+
+test("read-only preview removes confirm:true trading guidance", () => {
+  const generic = [
+    "DRY RUN — no order placed.",
+    "BUY token 123…",
+    "",
+    "Re-call with confirm:true to sign and submit.",
+  ].join("\n");
+
+  const actual = formatReadOnlyPreviewText(generic);
+
+  assert.equal(actual.includes("confirm:true"), false);
+  assert.match(actual, /READ-ONLY PREVIEW — this tool cannot sign or submit an order\.$/);
+  assert.match(actual, /^DRY RUN — no order placed\./);
+});
+
+test("read-only preview formatter leaves unexpected messages unchanged", () => {
+  const error = "Market is closed.";
+  assert.equal(formatReadOnlyPreviewText(error), error);
+});

--- a/test/polymarket-trade-gating.test.ts
+++ b/test/polymarket-trade-gating.test.ts
@@ -78,6 +78,14 @@ test("minimum order size enforced from the live book", async () => {
   assert.equal(calls.length, 0);
 });
 
+test("market-buy preview enforces the live minimum share size", async () => {
+  const res = await executeTrade({ action: "buy", token_id: "111", amount_usd: 1 });
+  assert.equal(res.isError, true);
+  assert.match(res.text, /minimum order size of 5 shares/);
+  assert.match(res.text, /use at least \$2\.25/i);
+  assert.equal(calls.length, 0);
+});
+
 test("confirm:true submits a limit BUY with the price floored onto the tick grid", async () => {
   const res = await executeTrade({ action: "buy", token_id: "111", price: 0.456, size: 10, confirm: true });
   assert.equal(res.isError, undefined, res.text);
@@ -174,6 +182,33 @@ test("market sell with no bid in the book is rejected, not silently $0-notional"
     const res = await executeTrade({ action: "sell", token_id: "111", size: 100000, confirm: true });
     assert.equal(res.isError, true);
     assert.match(res.text, /no bid|price a market sell/i);
+  } finally {
+    mock.restoreAll();
+  }
+});
+
+test("market buy with no ask is rejected instead of producing a fake preview", async () => {
+  mock.method(fakeClob, "getOrderBook", async () => ({
+    tick_size: "0.01", neg_risk: false, min_order_size: "5", asks: [], bids: [],
+  }));
+  try {
+    const res = await executeTrade({ action: "buy", token_id: "111", amount_usd: 5 });
+    assert.equal(res.isError, true);
+    assert.match(res.text, /no ask|price a market buy/i);
+  } finally {
+    mock.restoreAll();
+  }
+});
+
+test("FOK market-buy preview rejects insufficient ask depth", async () => {
+  mock.method(fakeClob, "getOrderBook", async () => ({
+    tick_size: "0.01", neg_risk: false, min_order_size: "5",
+    asks: [{ price: "0.45", size: "5" }], bids: [{ price: "0.44", size: "100" }],
+  }));
+  try {
+    const res = await executeTrade({ action: "buy", token_id: "111", amount_usd: 5, order_type: "FOK" });
+    assert.equal(res.isError, true);
+    assert.match(res.text, /cannot fill the full \$5\.00 FOK buy/i);
   } finally {
     mock.restoreAll();
   }

--- a/test/profiles.test.ts
+++ b/test/profiles.test.ts
@@ -4,16 +4,16 @@ import assert from "node:assert/strict";
 import { ALL_TOOLS, PROFILES, resolveProfileName, resolveTools } from "../src/profiles.js";
 
 const EXPECTED_COUNTS: Record<string, number> = {
-  full: 19,
+  full: 20,
   media: 7,
-  trading: 8,
+  trading: 9,
   research: 6,
   chat: 3,
 };
 
-test("ALL_TOOLS has the full 19-tool set", () => {
-  assert.equal(ALL_TOOLS.length, 19);
-  assert.equal(new Set(ALL_TOOLS).size, 19, "no duplicates");
+test("ALL_TOOLS has the full 20-tool set", () => {
+  assert.equal(ALL_TOOLS.length, 20);
+  assert.equal(new Set(ALL_TOOLS).size, 20, "no duplicates");
 });
 
 test("resolveProfileName precedence: --profile flag > env > default", () => {
@@ -46,16 +46,16 @@ test("every profile includes wallet (needed to pay)", () => {
   }
 });
 
-test("unknown profile name falls back to full (19 tools)", () => {
+test("unknown profile name falls back to full (20 tools)", () => {
   const { profile, tools } = resolveTools(["--profile", "nonsense"], {});
   assert.equal(profile, "full");
-  assert.equal(tools.size, 19);
+  assert.equal(tools.size, 20);
 });
 
 test("no args → full", () => {
   const { profile, tools } = resolveTools([], {});
   assert.equal(profile, "full");
-  assert.equal(tools.size, 19);
+  assert.equal(tools.size, 20);
 });
 
 test("Object.prototype key names fall back to full instead of crashing", () => {
@@ -64,7 +64,7 @@ test("Object.prototype key names fall back to full instead of crashing", () => {
   for (const name of ["constructor", "__proto__", "toString", "hasOwnProperty"]) {
     const { profile, tools } = resolveTools(["--profile", name], {});
     assert.equal(profile, "full", `${name} should fall back to full`);
-    assert.equal(tools.size, 19, `${name} should expose all 19 tools`);
+    assert.equal(tools.size, 20, `${name} should expose all 20 tools`);
   }
 });
 

--- a/test/tool-annotations.test.ts
+++ b/test/tool-annotations.test.ts
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { initializeMcpServer } from "../src/mcp-handler.js";
+import { ALL_TOOLS } from "../src/profiles.js";
 
 type Annotation = {
   readOnlyHint?: boolean;
@@ -9,7 +10,7 @@ type Annotation = {
   openWorldHint?: boolean;
 };
 
-test("trading profile exposes nine annotated tools and no media surface", () => {
+function collect(argv: string[]): { annotations: Map<string, Annotation>; profile: string } {
   const annotations = new Map<string, Annotation>();
   const fakeServer = {
     registerTool(name: string, options: { annotations?: Annotation }) {
@@ -17,9 +18,13 @@ test("trading profile exposes nine annotated tools and no media surface", () => 
     },
     registerResource() {},
   } as unknown as McpServer;
+  const result = initializeMcpServer(fakeServer, { argv, env: {} });
+  return { annotations, profile: result.profile };
+}
 
-  const result = initializeMcpServer(fakeServer, { argv: ["--profile", "trading"], env: {} });
-  assert.equal(result.profile, "trading");
+test("trading profile exposes nine annotated tools and no media surface", () => {
+  const { annotations, profile } = collect(["--profile", "trading"]);
+  assert.equal(profile, "trading");
   assert.equal(annotations.size, 9);
   assert.equal(annotations.has("blockrun_image"), false);
   assert.equal(annotations.has("blockrun_video"), false);
@@ -34,11 +39,59 @@ test("trading profile exposes nine annotated tools and no media surface", () => 
     openWorldHint: true,
     destructiveHint: true,
   });
-  assert.deepEqual(annotations.get("blockrun_markets"), {
-    readOnlyHint: false,
-    openWorldHint: true,
-    destructiveHint: true,
-  });
-  assert.equal(annotations.get("blockrun_dex")?.readOnlyHint, true);
-  assert.equal(annotations.get("blockrun_dex")?.openWorldHint, true);
+});
+
+test("every shipped tool carries an annotation", () => {
+  // Without this, a new tool silently defaults to destructiveHint:true under
+  // the MCP spec and clients start prompting for it.
+  const { annotations } = collect([]);
+  assert.equal(annotations.size, ALL_TOOLS.length);
+  for (const [name, a] of annotations) {
+    assert.equal(typeof a.readOnlyHint, "boolean", `${name} missing readOnlyHint`);
+    assert.equal(typeof a.openWorldHint, "boolean", `${name} missing openWorldHint`);
+    assert.equal(typeof a.destructiveHint, "boolean", `${name} missing destructiveHint`);
+  }
+});
+
+test("costing USDC does not make a data query destructive", () => {
+  // These all settle real USDC per call and all only READ. The hints describe
+  // effect, not price — spend control is the budget ledger's job. Marking them
+  // destructive makes annotation-honoring clients prompt on every lookup.
+  const { annotations } = collect([]);
+  for (const name of [
+    "blockrun_markets", "blockrun_search", "blockrun_exa",
+    "blockrun_surf", "blockrun_defi", "blockrun_price",
+  ]) {
+    assert.deepEqual(annotations.get(name), {
+      readOnlyHint: true,
+      openWorldHint: true,
+      destructiveHint: false,
+    }, `${name} is a paid read, not a destructive write`);
+  }
+});
+
+test("only tools with real external side effects are destructive", () => {
+  const { annotations } = collect([]);
+  const destructive = [...annotations]
+    .filter(([, a]) => a.destructiveHint)
+    .map(([name]) => name)
+    .sort();
+
+  // polymarket moves funds; phone places real calls; modal executes arbitrary
+  // code; rpc can broadcast a signed transaction.
+  assert.deepEqual(destructive, [
+    "blockrun_modal", "blockrun_phone", "blockrun_polymarket", "blockrun_rpc",
+  ]);
+});
+
+test("generative tools are writes but not destructive", () => {
+  const { annotations } = collect([]);
+  for (const name of [
+    "blockrun_image", "blockrun_video", "blockrun_music",
+    "blockrun_speech", "blockrun_realface", "blockrun_chat",
+  ]) {
+    const a = annotations.get(name);
+    assert.equal(a?.readOnlyHint, false, `${name} creates something`);
+    assert.equal(a?.destructiveHint, false, `${name} destroys nothing`);
+  }
 });

--- a/test/tool-annotations.test.ts
+++ b/test/tool-annotations.test.ts
@@ -26,7 +26,7 @@ test("trading profile exposes nine annotated tools and no media surface", () => 
 
   assert.deepEqual(annotations.get("blockrun_polymarket_read"), {
     readOnlyHint: true,
-    openWorldHint: false,
+    openWorldHint: true,
     destructiveHint: false,
   });
   assert.deepEqual(annotations.get("blockrun_polymarket"), {

--- a/test/tool-annotations.test.ts
+++ b/test/tool-annotations.test.ts
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { initializeMcpServer } from "../src/mcp-handler.js";
+
+type Annotation = {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  openWorldHint?: boolean;
+};
+
+test("trading profile exposes nine annotated tools and no media surface", () => {
+  const annotations = new Map<string, Annotation>();
+  const fakeServer = {
+    registerTool(name: string, options: { annotations?: Annotation }) {
+      annotations.set(name, options.annotations ?? {});
+    },
+    registerResource() {},
+  } as unknown as McpServer;
+
+  const result = initializeMcpServer(fakeServer, { argv: ["--profile", "trading"], env: {} });
+  assert.equal(result.profile, "trading");
+  assert.equal(annotations.size, 9);
+  assert.equal(annotations.has("blockrun_image"), false);
+  assert.equal(annotations.has("blockrun_video"), false);
+
+  assert.deepEqual(annotations.get("blockrun_polymarket_read"), {
+    readOnlyHint: true,
+    openWorldHint: false,
+    destructiveHint: false,
+  });
+  assert.deepEqual(annotations.get("blockrun_polymarket"), {
+    readOnlyHint: false,
+    openWorldHint: true,
+    destructiveHint: true,
+  });
+  assert.deepEqual(annotations.get("blockrun_markets"), {
+    readOnlyHint: false,
+    openWorldHint: true,
+    destructiveHint: true,
+  });
+  assert.equal(annotations.get("blockrun_dex")?.readOnlyHint, true);
+  assert.equal(annotations.get("blockrun_dex")?.openWorldHint, true);
+});


### PR DESCRIPTION
## Summary

- add MCP safety annotations for all tools and a read-only Polymarket positions/orders surface
- serialize paid Trading requests and validate Predexon request contracts before payment
- use Polymarket's direct CLOB endpoint, remove geoblock-bypass guidance, and add a packaged signal-to-trade Skill plus Stanford runbook
- expand the Trading profile to the nine tools needed for discovery, evidence, portfolio checks, and dry-run order construction

## Validation

- 264 tests passing
- TypeScript typecheck and production build passing
- Skill validation and npm package dry-run passing
- clean Claude Code and Codex CLI MCP installation verified
- live concurrent price/candlestick/order-book/smart-money flow completed without same-wallet x402 conflicts
- live $1 FOK Polymarket order dry-run completed without signing or submission
- retired market-data route rejected before payment with a zero-spend session ledger

## Safety / demo scope

No new live order was submitted. Polymarket's official US geoblock prevents a confirmed trade from the Stanford venue, so the live presentation is designed to show current signals and an executable order dry-run, with explicit confirmation still required for any future write.

Draft for review.