### PR TITLE
feat(skills): register every skill in the marketplace, and add a core skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,9 +6,34 @@
   },
   "plugins": [
     {
+      "name": "blockrun",
+      "source": "./skills/blockrun",
+      "description": "Start here. Pay-per-call access to AI models, real-time data, media generation and multi-chain RPC over x402 — which tool to reach for, how the wallet works, and how to get a first call working without spending anything."
+    },
+    {
       "name": "exa-research",
       "source": "./skills/exa-research",
       "description": "Use when researching products, finding academic papers, discovering competitors, reading webpage content, or getting cited answers grounded in real web sources."
+    },
+    {
+      "name": "search",
+      "source": "./skills/search",
+      "description": "Use when the user wants real-time web or news results with AI-summarized answers and citations — the cheapest path for \"what just happened\" questions where freshness beats semantic ranking."
+    },
+    {
+      "name": "crypto-data",
+      "source": "./skills/crypto-data",
+      "description": "Use for any crypto data question — token prices, FX, commodities, stocks, OHLC history, DEX pairs, DeFi TVL and yields, on-chain SQL, wallet labels and net worth, social mindshare. Routes across five overlapping tools and says which one to use and which are free."
+    },
+    {
+      "name": "surf",
+      "source": "./skills/surf",
+      "description": "Use when the user wants deep crypto data — on-chain SQL, CEX order books, wallet labels and net worth, social mindshare, news and unified search across exchange, on-chain, wallet, social and prediction endpoints."
+    },
+    {
+      "name": "rpc",
+      "source": "./skills/rpc",
+      "description": "Use when the user needs raw blockchain JSON-RPC — contract reads, native balances, blocks, transactions, logs, gas estimates — across 40 chains through one gateway, with no node and no API key."
     },
     {
       "name": "prediction-markets",
@@ -24,6 +49,26 @@
       "name": "signal-to-trade-demo",
       "source": "./skills/signal-to-trade-demo",
       "description": "Build a presentation-ready live Polymarket signal from price, probability history, smart-money, and liquidity evidence, then produce a safe order preview and verify state."
+    },
+    {
+      "name": "image-prompting",
+      "source": "./skills/image-prompting",
+      "description": "Use when generating or editing images — turns a vague request (\"make me a cool poster\") into a structured, text-accurate prompt that renders what was actually asked for."
+    },
+    {
+      "name": "phone",
+      "source": "./skills/phone",
+      "description": "Use when the user wants phone-number intelligence (carrier, line type, SIM-swap and call-forwarding fraud signals), US/CA number provisioning, or outbound AI voice calls."
+    },
+    {
+      "name": "modal",
+      "source": "./skills/modal",
+      "description": "Use when the user needs to run code remotely in a disposable container, wants optional GPU access, or needs a safer place for untrusted or heavy compute."
+    },
+    {
+      "name": "gentech-blockrun",
+      "source": "./skills/gentech-blockrun",
+      "description": "GenTech Labs' integration patterns for BlockRun from Hermes Agent — daily usage patterns, cost-optimized workflows, multi-tool pipelines and error handling across the full toolset."
     }
   ]
 }

--- a/skills/blockrun/SKILL.md
+++ b/skills/blockrun/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: blockrun
+description: |
+  Pay-per-call access to AI models, real-time data, media generation and multi-chain RPC over
+  x402 micropayments (USDC on Base or Solana). No API keys, no accounts, no subscriptions.
+  Start here when you have the BlockRun MCP installed and need to know WHICH tool answers a
+  question, how the wallet works, or how to make a first call for free.
+  TOOLS: blockrun_chat, blockrun_image, blockrun_video, blockrun_music, blockrun_speech,
+  blockrun_search, blockrun_exa, blockrun_markets, blockrun_polymarket, blockrun_surf,
+  blockrun_price, blockrun_dex, blockrun_defi, blockrun_rpc, blockrun_phone, blockrun_realface,
+  blockrun_modal, blockrun_models, blockrun_wallet.
+  TRIGGERS: blockrun, x402, use grok, use gpt, use deepseek, compare models, generate image,
+  generate video, generate music, text to speech, web search, news search, prediction market,
+  crypto price, on-chain data, blockchain rpc, phone call, run code remotely, pay per call
+homepage: https://blockrun.ai
+metadata:
+  version: 1
+---
+
+# BlockRun
+
+One wallet, pay-per-call, no API keys. Every paid tool below settles in USDC over x402 at the
+moment of the call.
+
+## Never quote a price from memory
+
+There is no price table in this skill, and that is deliberate. Every flat per-call price
+published in this repo drifted by exactly the per-transaction fee the last time that fee
+changed, because each one was a typed copy. Read prices from a live source instead:
+
+| Need | Where |
+|------|-------|
+| Per-token model pricing | `blockrun_models` |
+| What a call will actually cost | the `402` response — it carries the real amount |
+| Full endpoint catalog with prices | <https://blockrun.ai/llms.txt> |
+
+The tool descriptions in the MCP server carry current prices too; they are generated, not typed.
+
+## Getting a first call working
+
+**Free, no wallet, no key.** Six open-weight chat models cost nothing. Use `blockrun_chat` with
+`routing: "free"`, or call the API directly with `api_key="not-needed-for-free-models"`. Do this
+first whenever a language model is all the task needs — it is the shortest path to something
+working, and it costs nothing if it turns out to be the wrong approach.
+
+**When you need the paid catalog**, check the balance with `blockrun_wallet`
+(`action: "status"`). If it is zero:
+
+1. `blockrun_wallet action: "setup"` prints the address and a funding QR.
+2. To fund with a card, `POST https://blockrun.ai/api/v1/onramp/token` with
+   `{"address": "0x..."}`. Free, settles nothing — the x402 signature only proves you control
+   the wallet, so the address must match the signer — and it returns a one-time Coinbase link.
+3. Or send USDC to the address on Base or Solana.
+
+Do not fund a wallet inside an ephemeral sandbox (Claude Cowork / Desktop / Web). The key lives
+in `~/.blockrun/` on whatever filesystem you are on, and if that is a throwaway VM the USDC goes
+with it. In a sandbox, use the free models or hand the user the command to run locally.
+
+Deeper wallet, budget and x402 mechanics — including calling the HTTP API directly — are in
+[rules/wallet-and-payment.md](rules/wallet-and-payment.md).
+
+## Which tool
+
+| The question | Tool | Notes |
+|---|---|---|
+| Anything a language model can answer | `blockrun_chat` | See routing modes below |
+| Make an image | `blockrun_image` | Also `/edit` for changes to an existing image |
+| Make a video | `blockrun_video` | Async — submit, then poll |
+| Make music | `blockrun_music` | Full-length tracks |
+| Speak text aloud | `blockrun_speech` | Also sound effects |
+| "What just happened" — news, live web | `blockrun_search` | Freshest; priced per source |
+| Research, papers, competitors, page contents | `blockrun_exa` | Semantic, not keyword |
+| Event odds, betting markets | `blockrun_markets` | Reading only |
+| Actually place a Polymarket bet | `blockrun_polymarket` | Real money — confirm-gated |
+| Token / FX / commodity price | `blockrun_price` | Crypto, FX and commodities are free |
+| DEX pairs and liquidity | `blockrun_dex` | Free |
+| DeFi TVL, yields | `blockrun_defi` | |
+| On-chain SQL, wallet labels, social mindshare | `blockrun_surf` | The deep crypto tool |
+| Raw JSON-RPC against a chain | `blockrun_rpc` | 40 chains, one gateway |
+| Phone lookup, buy a number, make an AI call | `blockrun_phone` | Buy the number first |
+| Run code in a remote container / on a GPU | `blockrun_modal` | Prefer local for normal repo work |
+| Which models exist, and what they cost | `blockrun_models` | |
+| Balance, funding, spend caps | `blockrun_wallet` | |
+
+The crypto tools overlap heavily. Prefer the free ones (`blockrun_price`, `blockrun_dex`) when
+they already answer the question, and reach for `blockrun_surf` only when they do not.
+
+## Picking a chat model
+
+`blockrun_chat` takes a `mode` instead of a model id. **Default to `balanced`** — it is what an
+omitted `mode` resolves to anyway, and it is the right answer for most requests.
+
+| `mode` | Reach for it when | Speed |
+|--------|-------------------|-------|
+| `balanced` | **The default.** General work, code, analysis | Medium |
+| `fast` | Latency matters more than depth — classification, extraction, short replies | Fastest |
+| `powerful` | Frontier models. Hard reasoning, work you would not want to redo | Slowest |
+| `reasoning` | Multi-step logic, maths, proofs | Slow |
+| `coding` | Code generation and refactors specifically | Medium |
+| `glm` | Cheap and strong at code | Fast |
+| `cheap` | High volume, low stakes | Fast |
+| `free` | Anything where "good enough and free" wins | Fast |
+
+Two things to know about `free`: it routes to the open-weight tier only, and that path silently
+caps very long inputs — do not send a large document to it and trust the answer covered all of
+it. `mode` is ignored entirely when you pass an explicit `model`.
+
+Name a specific model only when the user names one, or when a task genuinely needs that model's
+quirk. Otherwise a mode is both cheaper and more robust to the catalog moving.
+
+For media, the picking advice lives with the generation tools, and **`blockrun_models` is
+authoritative** — this list would go stale within a release.
+
+## Cost discipline
+
+- **Failed requests are not charged.** Settlement happens on success only, so a non-2xx costs
+  nothing and retrying after an upstream error is free. Do not let a failure stop you retrying.
+- **Check the balance before an expensive call.** Video generation is the priciest category by
+  a wide margin — a single call can cost more than a thousand chat calls.
+- **Free before paid.** `blockrun_price` (crypto/FX/commodities), `blockrun_dex`, and the free
+  chat tier cost nothing. Reach for them before their paid equivalents.
+- **Set a cap for unattended work.** `blockrun_wallet action: "budget"` sets a session spend
+  ceiling; `action: "delegate"` gives a sub-agent its own allowance.
+
+## Troubleshooting
+
+| Symptom | What it means |
+|---|---|
+| `402 Payment Required` came back twice | The signature did not verify. Check the wallet has a key and the chain matches the requirements. |
+| "Insufficient balance" | `blockrun_wallet action: "status"`, then fund — or switch to a free model. |
+| Balance funded but still zero | Wait for network confirmation and re-check; Base finality is seconds, not instant. |
+| A model id 404s | It was delisted. `blockrun_models` for the live list; some ids redirect, some are gone. |
+| Video job never finishes | Video is async by design. Poll the job id; minutes, not seconds. |
+| Price does not match what you expected | Read the 402, not a remembered figure. Prices move. |
+| Per-call cap refused to sign | That is a client-side spending hook, not BlockRun rejecting the call. |
+
+## Related skills
+
+Install from the same marketplace for depth on one area: `search`, `exa-research`,
+`crypto-data`, `surf`, `rpc`, `prediction-markets`, `polymarket-trading`, `image-prompting`,
+`phone`, `modal`.
+
+```bash
+/plugin marketplace add BlockRunAI/blockrun-mcp
+```

--- a/skills/blockrun/SKILL.md
+++ b/skills/blockrun/SKILL.md
@@ -6,9 +6,9 @@ description: |
   Start here when you have the BlockRun MCP installed and need to know WHICH tool answers a
   question, how the wallet works, or how to make a first call for free.
   TOOLS: blockrun_chat, blockrun_image, blockrun_video, blockrun_music, blockrun_speech,
-  blockrun_search, blockrun_exa, blockrun_markets, blockrun_polymarket, blockrun_surf,
-  blockrun_price, blockrun_dex, blockrun_defi, blockrun_rpc, blockrun_phone, blockrun_realface,
-  blockrun_modal, blockrun_models, blockrun_wallet.
+  blockrun_search, blockrun_exa, blockrun_markets, blockrun_polymarket_read, blockrun_polymarket,
+  blockrun_surf, blockrun_price, blockrun_dex, blockrun_defi, blockrun_rpc, blockrun_phone,
+  blockrun_realface, blockrun_modal, blockrun_models, blockrun_wallet.
   TRIGGERS: blockrun, x402, use grok, use gpt, use deepseek, compare models, generate image,
   generate video, generate music, text to speech, web search, news search, prediction market,
   crypto price, on-chain data, blockchain rpc, phone call, run code remotely, pay per call
@@ -36,20 +36,29 @@ changed, because each one was a typed copy. Read prices from a live source inste
 
 The tool descriptions in the MCP server carry current prices too; they are generated, not typed.
 
+The same applies to counts. Where a number has a canonical source it is wrapped in a `br:`
+HTML-comment marker in this file, regenerated from `brand-numbers.json` by
+`scripts/sync-brand-numbers.mjs` and enforced in CI by `--check`. Add the marker rather than the
+digits — an unmarked number is invisible to that check, which is exactly how the prices drifted.
+
 ## Getting a first call working
 
-**Free, no wallet, no key.** Six open-weight chat models cost nothing. Use `blockrun_chat` with
-`routing: "free"`, or call the API directly with `api_key="not-needed-for-free-models"`. Do this
-first whenever a language model is all the task needs — it is the shortest path to something
-working, and it costs nothing if it turns out to be the wrong approach.
+**Free, no wallet, no key.** <!-- br:models.free -->8<!-- /br:models.free --> open-weight
+chat models cost nothing. Use `blockrun_chat` with `mode: "free"` — the parameter is `mode`,
+not `routing`, and an unrecognised key is silently dropped, which lands you on the paid
+`balanced` tier instead. Calling the HTTP API directly, a free model needs no wallet and no
+`X-PAYMENT` header at all; it returns `200` on the first request rather than a `402`.
+
+Do this first whenever a language model is all the task needs — it is the shortest path to
+something working, and it costs nothing if it turns out to be the wrong approach.
 
 **When you need the paid catalog**, check the balance with `blockrun_wallet`
 (`action: "status"`). If it is zero:
 
 1. `blockrun_wallet action: "setup"` prints the address and a funding QR.
-2. To fund with a card, `POST https://blockrun.ai/api/v1/onramp/token` with
-   `{"address": "0x..."}`. Free, settles nothing — the x402 signature only proves you control
-   the wallet, so the address must match the signer — and it returns a one-time Coinbase link.
+2. To fund with a card, `blockrun_wallet action: "deposit"` mints a one-time Coinbase Onramp
+   link and opens it. The call itself is free. Base only — on Solana it returns address and QR
+   guidance instead, so fund Solana by transfer.
 3. Or send USDC to the address on Base or Solana.
 
 Do not fund a wallet inside an ephemeral sandbox (Claude Cowork / Desktop / Web). The key lives
@@ -66,17 +75,19 @@ Deeper wallet, budget and x402 mechanics — including calling the HTTP API dire
 | Anything a language model can answer | `blockrun_chat` | See routing modes below |
 | Make an image | `blockrun_image` | Also `/edit` for changes to an existing image |
 | Make a video | `blockrun_video` | Async — submit, then poll |
+| Video of one *specific* real person | `blockrun_realface` | Enroll a face, then pass `real_face_asset_id` to `blockrun_video` |
 | Make music | `blockrun_music` | Full-length tracks |
 | Speak text aloud | `blockrun_speech` | Also sound effects |
 | "What just happened" — news, live web | `blockrun_search` | Freshest; priced per source |
 | Research, papers, competitors, page contents | `blockrun_exa` | Semantic, not keyword |
 | Event odds, betting markets | `blockrun_markets` | Reading only |
-| Actually place a Polymarket bet | `blockrun_polymarket` | Real money — confirm-gated |
+| Polymarket positions, open orders, order preview | `blockrun_polymarket_read` | Reads and previews only — structurally cannot sign |
+| Actually place a Polymarket bet | `blockrun_polymarket` | Real money — confirm-gated. Setup and funds-affecting actions only |
 | Token / FX / commodity price | `blockrun_price` | Crypto, FX and commodities are free |
 | DEX pairs and liquidity | `blockrun_dex` | Free |
 | DeFi TVL, yields | `blockrun_defi` | |
 | On-chain SQL, wallet labels, social mindshare | `blockrun_surf` | The deep crypto tool |
-| Raw JSON-RPC against a chain | `blockrun_rpc` | 40 chains, one gateway |
+| Raw JSON-RPC against a chain | `blockrun_rpc` | <!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains, one gateway |
 | Phone lookup, buy a number, make an AI call | `blockrun_phone` | Buy the number first |
 | Run code in a remote container / on a GPU | `blockrun_modal` | Prefer local for normal repo work |
 | Which models exist, and what they cost | `blockrun_models` | |
@@ -101,9 +112,11 @@ omitted `mode` resolves to anyway, and it is the right answer for most requests.
 | `cheap` | High volume, low stakes | Fast |
 | `free` | Anything where "good enough and free" wins | Fast |
 
-Two things to know about `free`: it routes to the open-weight tier only, and that path silently
-caps very long inputs — do not send a large document to it and trust the answer covered all of
-it. `mode` is ignored entirely when you pass an explicit `model`.
+Two things to know about `free`: it routes to the open-weight tier only, and that path caps very
+long inputs. Through the MCP the truncation is reported — the response carries a note saying
+roughly what fraction of the prompt never reached the model — but a direct HTTP call gets no
+such warning, so do not send a large document over the free tier and assume the answer covered
+all of it. `mode` is ignored entirely when you pass an explicit `model`.
 
 Name a specific model only when the user names one, or when a task genuinely needs that model's
 quirk. Otherwise a mode is both cheaper and more robust to the catalog moving.

--- a/skills/blockrun/rules/wallet-and-payment.md
+++ b/skills/blockrun/rules/wallet-and-payment.md
@@ -28,7 +28,7 @@ command to run on their own machine.
 |---|---|
 | `status` | Address, USDC balance, session spend. The default. |
 | `setup` | Address plus a funding QR — creates the wallet if there isn't one |
-| `deposit` | Deposit details for the active chain |
+| `deposit` | Card onramp — mints a one-time Coinbase link and opens it. Base only; on Solana it returns address and QR guidance instead |
 | `qr` | Funding QR on its own |
 | `chain` | Switch between `base` and `solana`; omit `chain` to read the current one |
 | `budget` | Session spend cap — `budget_action` is `set`, `check` or `clear` |
@@ -41,10 +41,12 @@ stopped rather than allowed to overspend.
 
 ## Funding
 
-1. **Card / bank.** `POST https://blockrun.ai/api/v1/onramp/token` with `{"address": "0x..."}`.
-   The endpoint is free and settles nothing — the x402 signature is used purely to prove you
-   control the wallet, which is why the funding `address` must equal the address that signed the
-   request. Returns a one-time Coinbase Onramp link. Rate-limited per IP and per wallet.
+1. **Card / bank.** Through the MCP this is `blockrun_wallet action: "deposit"` — do not
+   hand-roll it. Calling the HTTP API directly, it is
+   `POST https://blockrun.ai/api/v1/onramp/token` with `{"address": "0x..."}`. The endpoint is
+   free and settles nothing — the x402 signature is used purely to prove you control the wallet,
+   which is why the funding `address` must equal the address that signed the request. Returns a
+   one-time Coinbase Onramp link. Base only, and rate-limited per IP and per wallet.
 2. **Direct transfer.** Send USDC to the address on Base or Solana.
 3. **Neither.** The free chat tier needs no balance at all.
 

--- a/skills/blockrun/rules/wallet-and-payment.md
+++ b/skills/blockrun/rules/wallet-and-payment.md
@@ -1,0 +1,87 @@
+# Wallet and payment mechanics
+
+Read this when the wallet is misbehaving, when you need to reason about what a call will cost
+before making it, or when you are calling the HTTP API directly instead of through the MCP.
+
+## Where the key lives
+
+A wallet is auto-created on first use at `~/.blockrun/`. The private key never leaves the
+machine — it signs x402 payment headers locally, and BlockRun only ever sees a signature.
+
+The same file is read by the MCP server and by the Python, TypeScript and Go SDKs, so one funded
+wallet serves every path. That also means **anything with write access to that directory can
+spend the balance.** Keep the amount in it proportionate to what the agent is trusted to do, and
+use `blockrun_wallet action: "budget"` rather than a large balance and good intentions.
+
+### Ephemeral sandboxes lose the wallet and the money
+
+Claude Cowork, Claude Desktop and Claude Web run bash in a sandbox VM that is not the user's
+machine. A wallet created and funded there is destroyed when the sandbox resets, and the USDC
+goes with it. There is no recovery — nobody else has the key.
+
+In those environments, either use the free tier (no wallet involved) or give the user the exact
+command to run on their own machine.
+
+## `blockrun_wallet` actions
+
+| Action | What it does |
+|---|---|
+| `status` | Address, USDC balance, session spend. The default. |
+| `setup` | Address plus a funding QR — creates the wallet if there isn't one |
+| `deposit` | Deposit details for the active chain |
+| `qr` | Funding QR on its own |
+| `chain` | Switch between `base` and `solana`; omit `chain` to read the current one |
+| `budget` | Session spend cap — `budget_action` is `set`, `check` or `clear` |
+| `delegate` | Give a named `agent_id` its own allowance |
+| `revoke` | Remove a sub-agent's allowance |
+| `report` | Per-agent spending breakdown |
+
+Budgets are enforced, not advisory: an agent that exhausts its delegated allowance is hard
+stopped rather than allowed to overspend.
+
+## Funding
+
+1. **Card / bank.** `POST https://blockrun.ai/api/v1/onramp/token` with `{"address": "0x..."}`.
+   The endpoint is free and settles nothing — the x402 signature is used purely to prove you
+   control the wallet, which is why the funding `address` must equal the address that signed the
+   request. Returns a one-time Coinbase Onramp link. Rate-limited per IP and per wallet.
+2. **Direct transfer.** Send USDC to the address on Base or Solana.
+3. **Neither.** The free chat tier needs no balance at all.
+
+## What a call actually costs
+
+Do not compute a price. Two things have gone wrong historically by doing so:
+
+- **The per-transaction fee has changed more than once.** Any price written as
+  `base + fee` in a document is wrong the next time the fee moves — and every flat price in this
+  repo's skills was silently a full fee out of date for exactly that reason.
+- **Display fields in a 402 body can disagree with the signed requirements.** The authority is
+  the decoded `payment-required` header, not the human-readable JSON next to it.
+
+So: read the 402 for the real amount, `blockrun_models` for live per-token pricing, and
+<https://blockrun.ai/llms.txt> for the current catalog.
+
+## The x402 round trip, when calling HTTP directly
+
+1. `POST` the endpoint with no payment header.
+2. You get `402` with a base64 `payment-required` header. Decode it — `accepts[0]` carries
+   `scheme`, `network`, `amount`, `asset`, `payTo` and `maxTimeoutSeconds`.
+3. Sign an EIP-3009 `TransferWithAuthorization` for that amount to that recipient.
+4. Retry the same request with `X-PAYMENT` set to the base64 payload.
+
+On success the response may carry `x-payment-receipt` with the settlement transaction hash.
+
+**Failed requests are not charged.** Settlement happens on success only, so a non-2xx costs
+nothing and a retry after an upstream error is free. A signature is single-use — build a fresh
+nonce per attempt rather than replaying one.
+
+## When it goes wrong
+
+| Symptom | Cause |
+|---|---|
+| Second `402` after signing | Signature did not verify. Usually a chain mismatch, a stale nonce, or an amount that does not match the requirements. |
+| `403` from the onramp endpoint | The `address` in the body is not the address that signed. They must match. |
+| `429` from the onramp endpoint | Minting is rate-limited per IP and per wallet. Wait it out. |
+| Funded but balance still reads zero | Wait for confirmation and re-check. Also check `action: "chain"` — funds on Solana do not show against a Base balance. |
+| "Refusing to sign, per-call cap exceeded" | A client-side spending hook, not BlockRun. Raise the cap on the caller. |
+| Charged for something that failed | Should not happen — settlement is success-only. Capture the completion id and the receipt header before reporting it. |


### PR DESCRIPTION
Companion to BlockRunAI/blockrun#342, from studying AgentCash's skills repo.

## Nine of thirteen skills were not installable

`.claude-plugin/marketplace.json` listed `exa-research`, `prediction-markets`, `polymarket-trading` and `signal-to-trade-demo`. The other nine — `crypto-data`, `surf`, `rpc`, `search`, `image-prompting`, `phone`, `modal`, `gentech-blockrun` and the new core skill — sat on disk where `/plugin marketplace add` could not reach them. No decision was taken to withhold them; entries were added alongside the skill that prompted them and the rest were never backfilled.

All thirteen are now registered. Validated: 13 on disk, 13 registered, no orphans.

## New `skills/blockrun` core skill

The entry point AgentCash has and we did not: which of the twenty tools answers a given question, how the wallet works, how to get a first call working for free. Deeper wallet and x402 mechanics live in `rules/wallet-and-payment.md` so `SKILL.md` stays short enough to load on every match.

The routing-mode table was read off the zod enum in `src/tools/chat.ts`, not the marketing copy — which was wrong in three ways: the parameter is `mode` not `routing`, there is no `smart` mode, and `glm` exists and was missing.

## Found while writing it: every flat price here is one fee too high

Not a pattern-match — a single verified cause. Each published flat price equals `base + $0.002`, the per-transaction fee that was retired when it went back to `$0.001`:

| | this repo says | actually charged |
|---|---|---|
| Surf tier 1 | $0.0095 | **$0.0085** |
| RPC | $0.0040 | **$0.0030** |
| Exa search / answer / similar | $0.0120 | **$0.0110** |
| DefiLlama | $0.0070 | **$0.0060** |
| Bland call | $0.5420 | **$0.5410** |
| Phone fraud lookup | $0.0520 | **$0.0510** |
| Live Search (10 results) | $0.2645 | **$0.2635** |

Computed against `SURF_TIER_1_PRICE`, `RPC_PRICE_USD`, `EXA_ENDPOINTS`, `DEFILLAMA_ENDPOINTS`, `BLAND_CALL_PRICE_USD`, `PHONE_PRICES` and `addTransactionFee()` in the gateway repo. 19 occurrences of the dead `$0.0095` alone, across three skills — the same retired price the main repo swept in #336/#337. Agents read these to budget.

**Not fixed in this PR, on purpose.** The new skill carries no price table at all and points at `blockrun_models`, the 402 itself and `llms.txt` instead, with the reason written down. Fixing the existing eleven skills is a separate pass: several occurrences are ambiguous without checking which endpoint each row means, and a partial sweep would leave those files half-right — which is the failure mode that produced this in the first place.

Also spotted, not fixed: `skills/prediction-markets` still advertises **dFlow**, whose three paths have returned upstream 404 since 2026-08-04 and were de-registered in the gateway. Wants a live re-probe before editing.