### PR TITLE
test(skills): fail the build when a skill is not installable

### DIFF
--- a/test/marketplace.test.ts
+++ b/test/marketplace.test.ts
@@ -1,0 +1,106 @@
+// Run with: npm test  (tsx --test)
+//
+// A skill that is not listed in .claude-plugin/marketplace.json is unreachable.
+// `/plugin marketplace add BlockRunAI/blockrun-mcp` shows the user exactly the
+// entries in that file, so an unlisted SKILL.md is shipped, published to npm,
+// and installable by nobody.
+//
+// That is not hypothetical either. Nine of thirteen skills sat unreachable —
+// `crypto-data`, `surf`, `rpc`, `search`, `image-prompting`, `phone`, `modal`,
+// `gentech-blockrun` and `blockrun` — until 0.37.1. No decision was ever taken
+// to withhold them: an entry got added alongside whichever skill prompted it,
+// and the rest were never backfilled. Nothing failed, because nothing looked.
+//
+// The failure mode is silence in BOTH directions, which is why this checks
+// both: an unregistered directory is invisible to users, and an entry pointing
+// at a directory that moved or was renamed is a broken install rather than a
+// missing one.
+//
+// Sibling guard: skill-frontmatter.test.ts proves each SKILL.md can LOAD.
+// This file proves it can be REACHED. A skill needs both, and neither implies
+// the other.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, existsSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SKILLS_DIR = join(ROOT, "skills");
+const MARKETPLACE = join(ROOT, ".claude-plugin", "marketplace.json");
+
+type Entry = { name?: unknown; source?: unknown; description?: unknown };
+
+const marketplace = JSON.parse(readFileSync(MARKETPLACE, "utf8")) as { plugins?: Entry[] };
+const entries = marketplace.plugins ?? [];
+
+// A directory is a shippable skill exactly when it carries a SKILL.md at its
+// root — that root file is what makes the plugin register a skill (verified on
+// 0.37.1 with `claude plugin details`, which reports `Skills (1)` for this
+// layout despite there being no .claude-plugin/plugin.json). Same definition
+// skill-frontmatter.test.ts uses, deliberately: the two tests must agree on
+// what counts as a skill or one of them can pass vacuously.
+const skillDirs = readdirSync(SKILLS_DIR).filter((d) => existsSync(join(SKILLS_DIR, d, "SKILL.md")));
+
+test("marketplace.json parses and lists plugins", () => {
+  assert.ok(Array.isArray(marketplace.plugins), ".claude-plugin/marketplace.json has no `plugins` array");
+  assert.ok(entries.length > 0, "marketplace lists no plugins at all");
+});
+
+test("every skill on disk is registered in the marketplace", () => {
+  const registered = new Set(entries.map((e) => e.name));
+  const missing = skillDirs.filter((d) => !registered.has(d));
+  assert.deepEqual(
+    missing,
+    [],
+    `these skills exist on disk but are NOT installable — nobody can reach them:\n` +
+      missing.map((d) => `  skills/${d}/`).join("\n") +
+      `\n  Add an entry to .claude-plugin/marketplace.json:\n` +
+      missing
+        .map((d) => `    { "name": "${d}", "source": "./skills/${d}", "description": "Use when …" }`)
+        .join("\n"),
+  );
+});
+
+test("every marketplace entry points at a skill that exists", () => {
+  const orphans = entries
+    .map((e) => String(e.name))
+    .filter((n) => !skillDirs.includes(n));
+  assert.deepEqual(
+    orphans,
+    [],
+    `these marketplace entries have no skills/<name>/SKILL.md, so installing them yields an empty plugin:\n` +
+      orphans.map((n) => `  ${n}`).join("\n"),
+  );
+});
+
+test("every entry's source path matches its name", () => {
+  // The install resolves `source` relative to the repo root. A name/source
+  // mismatch installs the wrong skill under the right label, which is worse
+  // than a missing entry because it looks like it worked.
+  for (const e of entries) {
+    assert.equal(
+      e.source,
+      `./skills/${String(e.name)}`,
+      `marketplace entry "${String(e.name)}" has source ${JSON.stringify(e.source)}; expected "./skills/${String(e.name)}"`,
+    );
+  }
+});
+
+test("every entry has a non-empty description", () => {
+  // This is the only text a user sees in the marketplace list before
+  // installing; an entry without it is registered but unchosen.
+  for (const e of entries) {
+    assert.equal(typeof e.description, "string", `marketplace entry "${String(e.name)}" has no description`);
+    assert.ok(
+      (e.description as string).trim().length > 0,
+      `marketplace entry "${String(e.name)}" has an empty description`,
+    );
+  }
+});
+
+test("no duplicate entry names", () => {
+  const names = entries.map((e) => String(e.name));
+  const dupes = [...new Set(names.filter((n, i) => names.indexOf(n) !== i))];
+  assert.deepEqual(dupes, [], `duplicate marketplace entries: ${dupes.join(", ")}`);
+});


### PR DESCRIPTION
Closes the recurrence risk left open by #91.

## The gap

Nine of thirteen skills were unreachable until 0.37.1 — on disk, shipped inside the npm package, and installable by nobody, because `/plugin marketplace add` shows exactly the entries in `.claude-plugin/marketplace.json`. #91 backfilled all thirteen but nothing stops the fourteenth from drifting the same way. The original cause was not a decision: an entry got added alongside whichever skill prompted it, and the rest were never backfilled. Nothing failed, because nothing looked.

## What this checks

Both directions, because both are silent:

| Invariant | What it catches |
|---|---|
| every `skills/<name>/SKILL.md` has an entry | the actual bug — shipped but unreachable |
| every entry has a `skills/<name>/SKILL.md` | a renamed or moved directory: a *broken* install, not a missing one |
| `source == ./skills/<name>` | the wrong skill installed under the right label, which looks like it worked |
| non-empty `description` | registered but unchosen — it's the only text shown before install |
| unique names | — |

## Why a test and not a script

`npm test` already gates PRs and `publish.yml`, so this needs no new CI step. `brand-numbers.test.ts` established the pattern in this repo: assert the invariant against the real files, in the repo that can fix it. And nothing here is usefully auto-fixable — a marketplace description is hand-written prose, so generating one from the frontmatter would produce worse text than the omission it replaces.

It is the sibling of `skill-frontmatter.test.ts`, which proves a `SKILL.md` can **load**. This proves it can be **reached**. Neither implies the other. Both take "a directory with `SKILL.md` at its root" as the definition of a skill — the same definition on purpose, or one of them can pass vacuously.

## Verification

Green at 288/288, and confirmed it can actually fail — each invariant broken in turn, each producing the matching failure and nothing else:

```
### drop the 'rpc' entry        -> not ok 2 - every skill on disk is registered
### entry naming a ghost skill  -> not ok 2, not ok 3
### wrong source path           -> not ok 4 - source path matches its name
### empty description           -> not ok 5
### duplicate entry             -> not ok 6
```

The unregistered-skill failure names the directories and prints the JSON to paste:

```
these skills exist on disk but are NOT installable — nobody can reach them:
  skills/modal/
  skills/rpc/
  Add an entry to .claude-plugin/marketplace.json:
    { "name": "modal", "source": "./skills/modal", "description": "Use when …" }
```

Test-only — `skills/` and `dist` ship to npm, `test/` does not, so this needs no version bump or release.