### PR TITLE
fix: the price sweep only ever saw one of two gateways

### DIFF
--- a/scripts/verify-prices.ts
+++ b/scripts/verify-prices.ts
@@ -32,7 +32,23 @@ import { estimateVideoCost } from "../src/tools/video.js";
 import { MARKETS_PRICE_USD } from "../src/tools/markets.js";
 import { withTxFee } from "../src/utils/tx-fee.js";
 
+// TWO gateways, and they do not agree. Base and Solana are separate deployments
+// with separate env, and TRANSACTION_FEE_USD is env-overridable in the gateway —
+// so the fee can move on one chain and not the other, silently.
+//
+// It already has. Probed 2026-08-07, every comparable route: Base charges
+// base + $0.001, Solana charges base + $0.000. Solana adds no transaction fee at
+// all. `blockrun_wallet action:"chain"` lets one agent switch chains mid-session,
+// so "the price" is not a single number until those two agree.
+//
+// This script probed ONLY Base until now, which means the divergence was
+// invisible to the one tool whose entire job is catching price drift — the same
+// shape of gap as a marketplace check that never looked at the skills directory.
+// Direction matters for severity: Solana cheaper means we over-reserve there
+// (safe). Solana DEARER would mean every estimator under-reserves for Solana
+// users, which is a release blocker exactly like a Base shortfall.
 const BASE = "https://blockrun.ai/api/v1/";
+const SOL = "https://sol.blockrun.ai/api/v1/";
 
 type Probe = {
   label: string;
@@ -45,8 +61,8 @@ type Probe = {
   allowOver?: boolean;
 };
 
-async function quote(path: string, body?: unknown): Promise<number | string> {
-  const res = await fetch(BASE + path, {
+async function quote(host: string, path: string, body?: unknown): Promise<number | string> {
+  const res = await fetch(host + path, {
     method: body === undefined ? "GET" : "POST",
     ...(body === undefined ? {} : { headers: { "content-type": "application/json" }, body: JSON.stringify(body) }),
   });
@@ -190,25 +206,57 @@ const EPSILON = 1e-9;
 let short = 0;
 let over = 0;
 let unreachable = 0;
+// Cross-chain accounting, kept separate from the estimator verdict above: these
+// say the two GATEWAYS disagree, not that a local estimator is wrong.
+let solShort = 0; // Solana charges MORE than we reserve -> release blocker
+let solCheaper = 0; // Solana charges LESS than Base -> safe, but the docs quote one number
+let solMissing = 0; // route not served on Solana at all
+const solNotes: string[] = [];
 
-console.log(`Verifying ${PROBES.length} routes against live 402 quotes (free — no payment attached)\n`);
+console.log(`Verifying ${PROBES.length} routes against live 402 quotes on BOTH gateways (free — no payment attached)\n`);
 
 for (const probe of PROBES) {
-  const live = await quote(probe.path, probe.body);
+  // Both chains at once so adding the second gateway costs no wall-clock.
+  const [live, solLive] = await Promise.all([
+    quote(BASE, probe.path, probe.body),
+    quote(SOL, probe.path, probe.body),
+  ]);
+
+  // Compare the chains before judging the estimator, so a Solana-only problem is
+  // still reported when the Base probe itself is unreachable.
+  let solTag = "";
+  if (typeof solLive === "string") {
+    solMissing++;
+    solTag = "  [sol: not served]";
+    solNotes.push(`${probe.label}: Solana ${solLive}`);
+  } else if (typeof live === "number") {
+    const chainDelta = solLive - live;
+    if (chainDelta > EPSILON) {
+      // Solana dearer than Base. Every estimator is built off Base, so this is
+      // an under-reserve for anyone on Solana — same severity as `✗`.
+      solShort++;
+      solTag = `  [sol: $${solLive.toFixed(6)} DEARER by $${chainDelta.toFixed(6)}]`;
+      solNotes.push(`${probe.label}: Solana charges $${solLive.toFixed(6)} vs Base $${live.toFixed(6)}`);
+    } else if (chainDelta < -EPSILON) {
+      solCheaper++;
+      solTag = `  [sol: $${solLive.toFixed(6)}, -$${(-chainDelta).toFixed(6)}]`;
+    }
+  }
+
   if (typeof live === "string") {
-    console.log(`  ?  ${probe.label.padEnd(26)} ${live}`);
+    console.log(`  ?  ${probe.label.padEnd(26)} ${live}${solTag}`);
     unreachable++;
     continue;
   }
   const delta = probe.expected - live;
   if (delta < -EPSILON) {
     // The only genuinely dangerous direction: we reserve less than we pay.
-    console.log(`  ✗  ${probe.label.padEnd(26)} reserve $${probe.expected} < charge $${live}  UNDER-RESERVES by $${(-delta).toFixed(6)}`);
+    console.log(`  ✗  ${probe.label.padEnd(26)} reserve $${probe.expected} < charge $${live}  UNDER-RESERVES by $${(-delta).toFixed(6)}${solTag}`);
     short++;
   } else if (probe.allowOver && delta >= -EPSILON) {
-    console.log(`  ✓  ${probe.label.padEnd(26)} $${live}  (reserve $${probe.expected.toFixed(6)}, intentionally conservative)`);
+    console.log(`  ✓  ${probe.label.padEnd(26)} $${live}  (reserve $${probe.expected.toFixed(6)}, intentionally conservative)${solTag}`);
   } else if (delta > 0.001) {
-    console.log(`  !  ${probe.label.padEnd(26)} reserve $${probe.expected} > charge $${live}  over-reserves by $${delta.toFixed(6)}`);
+    console.log(`  !  ${probe.label.padEnd(26)} reserve $${probe.expected} > charge $${live}  over-reserves by $${delta.toFixed(6)}${solTag}`);
     over++;
   } else {
     // Print the cushion even when it is inside tolerance. Every route currently
@@ -216,7 +264,7 @@ for (const probe of PROBES) {
     // gateway's 0.001), and that gap IS the safety margin — a `✓ exact` that
     // hides it means the day the fee moves again, the sweep goes from silently
     // fine to silently short with no visible change in between.
-    console.log(`  ✓  ${probe.label.padEnd(26)} $${live}${delta > 1e-9 ? `  (+$${delta.toFixed(6)} cushion)` : ""}`);
+    console.log(`  ✓  ${probe.label.padEnd(26)} $${live}${delta > 1e-9 ? `  (+$${delta.toFixed(6)} cushion)` : ""}${solTag}`);
   }
 }
 
@@ -225,9 +273,29 @@ console.log(
     `${PROBES.length - short - over - unreachable} exact`,
 );
 if (unreachable) console.log("Unreachable routes were NOT verified — treat them as unknown, not as passing.");
-// Under-reserving is a release blocker: it means the budget cap is a lie.
+
+console.log(
+  `Solana: ${solShort} dearer than Base, ${solCheaper} cheaper, ${solMissing} not served`,
+);
+if (solCheaper) {
+  console.log(
+    "  Solana charges no transaction fee, so it is cheaper by exactly that amount.\n" +
+      "  Safe for the budget gate (we reserve the Base figure), but every flat price\n" +
+      "  published in skills/ and the tool descriptions quotes ONE number, which is\n" +
+      "  the Base one. Align the gateways or qualify the docs — do not leave both.",
+  );
+}
+if (solMissing) {
+  console.log("  Not served on Solana — an agent that switched chains gets a 404/503, not a cheaper call:");
+  for (const n of solNotes) console.log(`    ${n}`);
+}
+// Under-reserving is a release blocker: it means the budget cap is a lie. That is
+// true per CHAIN — an estimator built off Base is a lie on Solana the moment
+// Solana costs more, and nothing else in the repo would notice.
 // Over-reserving only blocks affordable calls, so it warns without failing.
-if (short) {
-  console.log("\nFAIL: an estimator reserves less than the gateway charges. Fix it before publishing.");
+if (short || solShort) {
+  console.log(
+    `\nFAIL: an estimator reserves less than the gateway charges${solShort ? " (on Solana)" : ""}. Fix it before publishing.`,
+  );
   process.exit(1);
 }

--- a/skills/blockrun/SKILL.md
+++ b/skills/blockrun/SKILL.md
@@ -36,6 +36,12 @@ changed, because each one was a typed copy. Read prices from a live source inste
 
 The tool descriptions in the MCP server carry current prices too; they are generated, not typed.
 
+**Every price in these skills is the Base price.** Base and Solana are separate
+gateways: Base adds a flat per-transaction fee, Solana currently adds none, so the same
+call runs about $0.001 cheaper on Solana. `blockrun_defi` and `blockrun_modal` are not
+served on Solana at all. Read the 402 on the chain you are actually on, and check
+`blockrun_wallet action: "chain"` if a figure looks off by a tenth of a cent.
+
 The same applies to counts. Where a number has a canonical source it is wrapped in a `br:`
 HTML-comment marker in this file, regenerated from `brand-numbers.json` by
 `scripts/sync-brand-numbers.mjs` and enforced in CI by `--check`. Add the marker rather than the

--- a/skills/crypto-data/SKILL.md
+++ b/skills/crypto-data/SKILL.md
@@ -60,22 +60,22 @@ Five tools cover crypto data and they overlap. **Pick by cost first** — two of
 | **FX rate / commodity (gold, oil)** | `blockrun_price` category:"fx" or `"commodity"` | **FREE** |
 | **Which symbols exist?** | `blockrun_price` action:"list" | **FREE** |
 | **DEX pair, liquidity, volume, contract** | `blockrun_dex` | **FREE** |
-| Stock quote / history (12 markets) | `blockrun_price` category:"stocks" | $0.0030 |
-| Token price by contract address | `blockrun_defi` path:"prices/{coins}" | $0.0030 |
-| Raw JSON-RPC on <!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains | `blockrun_rpc` | $0.0040 |
-| Protocol TVL, chain TVL, yields/APY | `blockrun_defi` | $0.0070 |
-| **Everything below** (on-chain SQL, wallet labels, social, news, unlocks, liquidations, ETF flows) | `blockrun_surf` | $0.0095 |
-| Raw SQL over 80+ ClickHouse tables | `blockrun_surf` path:"onchain/sql" | $0.0095 |
+| Stock quote / history (12 markets) | `blockrun_price` category:"stocks" | $0.0020 |
+| Token price by contract address | `blockrun_defi` path:"prices/{coins}" | $0.0020 |
+| Raw JSON-RPC on <!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains | `blockrun_rpc` | $0.0030 |
+| Protocol TVL, chain TVL, yields/APY | `blockrun_defi` | $0.0060 |
+| **Everything below** (on-chain SQL, wallet labels, social, news, unlocks, liquidations, ETF flows) | `blockrun_surf` | $0.0085 |
+| Raw SQL over 80+ ClickHouse tables | `blockrun_surf` path:"onchain/sql" | $0.0085 |
 
-Every price below is what x402 actually **charges** (the base plus the gateway's $0.002 flat fee), verified against live `payment-required` headers — not the base you may see in a 402 body.
+Every price below is what x402 actually **charges** (the base plus the gateway's $0.001 flat fee), verified against live `payment-required` headers — not the base you may see in a 402 body.
 
 **The rule:** a plain crypto price or a DEX pair is free. Only reach for `blockrun_surf` when you need something the free tools genuinely do not have — labels, SQL, social, news, unlocks.
 
-**Prediction markets are never a Surf question.** Surf carries `prediction-market/*` endpoints, but Predexon (`blockrun_markets`) serves the same Polymarket/Kalshi data at the **same $0.0095** — and adds wallet clustering, smart money, sports, UMA, and five more venues that Surf does not have at all. Price is no longer the argument (it was 7.5× cheaper before 2026-07-15); coverage is, and it is decisive. Route odds, positions and market history to [`skills/prediction-markets/SKILL.md`](../prediction-markets/SKILL.md).
+**Prediction markets are never a Surf question.** Surf carries `prediction-market/*` endpoints, but Predexon (`blockrun_markets`) serves the same Polymarket/Kalshi data at the **same $0.0085** — and adds wallet clustering, smart money, sports, UMA, and five more venues that Surf does not have at all. Price is no longer the argument (it was 7.5× cheaper before 2026-07-15); coverage is, and it is decisive. Route odds, positions and market history to [`skills/prediction-markets/SKILL.md`](../prediction-markets/SKILL.md).
 
 ## blockrun_price — quotes & history (Pyth-backed)
 
-Free for crypto, FX and commodities. $0.0030 only for stocks.
+Free for crypto, FX and commodities. $0.0020 only for stocks.
 
 ```ts
 blockrun_price({ action: "price",   category: "crypto",    symbol: "BTC-USD" })            // FREE
@@ -84,7 +84,7 @@ blockrun_price({ action: "history", category: "crypto",    symbol: "ETH-USD",
 blockrun_price({ action: "price",   category: "fx",        symbol: "EUR-USD" })            // FREE
 blockrun_price({ action: "price",   category: "commodity", symbol: "XAU-USD" })            // FREE — gold
 blockrun_price({ action: "list",    category: "crypto" })                                  // FREE — discovery
-blockrun_price({ action: "price",   category: "stocks",    symbol: "AAPL", market: "us" }) // $0.0030
+blockrun_price({ action: "price",   category: "stocks",    symbol: "AAPL", market: "us" }) // $0.0020
 ```
 
 Stock markets: `us`, `hk`, `jp`, `kr`, `gb`, `de`, `fr`, `nl`, `ie`, `lu`, `cn`, `ca` — `market` is required when `category:"stocks"`.
@@ -106,11 +106,11 @@ Path-based, GET only.
 
 | path | cost | returns |
 |---|---|---|
-| `protocols` | $0.0070 | every DeFi protocol ranked by TVL |
-| `protocol/{slug}` | $0.0070 | one protocol's TVL history + chain breakdown |
-| `chains` | $0.0070 | TVL by chain |
-| `yields` | $0.0070 | yield pools with APY + TVL (large — filter client-side) |
-| `prices/{coins}` | $0.0030 | token prices by contract, e.g. `base:0x8335…,coingecko:ethereum` |
+| `protocols` | $0.0060 | every DeFi protocol ranked by TVL |
+| `protocol/{slug}` | $0.0060 | one protocol's TVL history + chain breakdown |
+| `chains` | $0.0060 | TVL by chain |
+| `yields` | $0.0060 | yield pools with APY + TVL (large — filter client-side) |
+| `prices/{coins}` | $0.0020 | token prices by contract, e.g. `base:0x8335…,coingecko:ethereum` |
 
 ```ts
 blockrun_defi({ path: "protocol/aave-v3" })
@@ -131,12 +131,12 @@ blockrun_surf({ path: "market/etf",          params: { symbol: "BTC" } })       
 blockrun_surf({ path: "social/mindshare",    params: { project: "base" } })
 blockrun_surf({ path: "onchain/sql", body: {
   sql: "SELECT token_address, count() FROM ethereum.dex_trades WHERE block_time > now() - INTERVAL 1 DAY GROUP BY 1 ORDER BY 2 DESC LIMIT 10"
-}})                                                                                   // $0.0095
+}})                                                                                   // $0.0085
 ```
 
 ## blockrun_rpc — raw chain access
 
-<!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains, one endpoint, no node, no key. $0.0040/call (batches charge per element, plus one flat fee per request). See [`skills/rpc/SKILL.md`](../rpc/SKILL.md).
+<!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains, one endpoint, no node, no key. $0.0030/call (batches charge per element, plus one flat fee per request). See [`skills/rpc/SKILL.md`](../rpc/SKILL.md).
 
 ```ts
 blockrun_rpc({ network: "base", method: "eth_blockNumber", params: [] })
@@ -150,7 +150,7 @@ blockrun_rpc({ network: "base", method: "eth_blockNumber", params: [] })
 blockrun_price({ action: "price", category: "crypto", symbol: "BTC-USD" })   // FREE
 ```
 
-Not `blockrun_surf({ path: "market/price" })` — that is $0.0095 for an answer you can get free.
+Not `blockrun_surf({ path: "market/price" })` — that is $0.0085 for an answer you can get free.
 
 ### 2. "Is this token legit?" ← compound, mostly free
 

--- a/skills/exa-research/SKILL.md
+++ b/skills/exa-research/SKILL.md
@@ -33,22 +33,22 @@ blockrun_exa({ path: "find-similar", body: { url: "https://arxiv.org/abs/2401.12
 
 ## Quick Decision Table
 
-Costs below are what you are actually CHARGED — the $0.002 transaction fee is
+Costs below are what you are actually CHARGED — the $0.001 transaction fee is
 already included (it applies once per call, not per result).
 
 | User wants... | Path | Body | Cost |
 |--------------|------|------|------|
-| Relevant URLs on a topic | `search` | `{ query, numResults?, category? }` | $0.0120/call |
-| Cited answer to a question | `answer` | `{ query }` | $0.0120/call |
-| Full text of URLs | `contents` | `{ urls: [...] }` | $0.002/URL + $0.002 → 1 URL $0.0040, 3 URLs $0.0080 |
-| Pages like a given URL | `find-similar` | `{ url, numResults? }` | $0.0120/call |
-| Recent news | `search` + `category: "news"` | – | $0.0120/call |
-| Academic papers | `search` + `category: "research paper"` | – | $0.0120/call |
-| Company info | `search` + `category: "company"` | – | $0.0120/call |
+| Relevant URLs on a topic | `search` | `{ query, numResults?, category? }` | $0.0110/call |
+| Cited answer to a question | `answer` | `{ query }` | $0.0110/call |
+| Full text of URLs | `contents` | `{ urls: [...] }` | $0.002/URL + $0.001 → 1 URL $0.0030, 3 URLs $0.0070 |
+| Pages like a given URL | `find-similar` | `{ url, numResults? }` | $0.0110/call |
+| Recent news | `search` + `category: "news"` | – | $0.0110/call |
+| Academic papers | `search` + `category: "research paper"` | – | $0.0110/call |
+| Company info | `search` + `category: "company"` | – | $0.0110/call |
 
 `contents` bills per URL, so batching URLs into ONE call is markedly cheaper than
-one call each: 3 URLs together cost $0.0080, but three separate calls cost
-$0.0120 — you pay the flat fee three times instead of once.
+one call each: 3 URLs together cost $0.0070, but three separate calls cost
+$0.0090 — you pay the flat fee three times instead of once.
 
 Valid `category` values for `search`: `"news"`, `"research paper"`, `"company"`, `"tweet"`, `"github"`, `"pdf"`.
 

--- a/skills/gentech-blockrun/SKILL.md
+++ b/skills/gentech-blockrun/SKILL.md
@@ -66,8 +66,8 @@ blockrun_wallet(action="status")
 ### Pattern 1: Regular Price Checks (FREE)
 
 Crypto, FX and commodity quotes cost **nothing** — `blockrun_price` is free for those
-categories (only `stocks`/`usstock` is paid, at $0.0030). Use them liberally, and do
-not pay $0.0095 to `blockrun_surf` for a quote you can get for $0.
+categories (only `stocks`/`usstock` is paid, at $0.0020). Use them liberally, and do
+not pay $0.0085 to `blockrun_surf` for a quote you can get for $0.
 
 ```python
 # Single price
@@ -81,9 +81,9 @@ blockrun_price(action="price", category="crypto", symbol="SOL-USD")
 blockrun_price(action="list", category="crypto", query="sol")
 ```
 
-**Cost:** $0 — crypto/FX/commodity price *and* list calls are both free. Only `category:"stocks"` is paid ($0.0030).
+**Cost:** $0 — crypto/FX/commodity price *and* list calls are both free. Only `category:"stocks"` is paid ($0.0020).
 
-### Pattern 2: Token Research Pipeline (~$0.021)
+### Pattern 2: Token Research Pipeline (~$0.018)
 
 Start with the free tools, then pay only for what they cannot answer.
 
@@ -94,22 +94,22 @@ blockrun_dex({ query: "SOL" })
 # 2. FREE — CEX price (crypto category is free)
 blockrun_price(action="price", category="crypto", symbol="SOL-USD")
 
-# 3. $0.0070 each — Protocol TVL
+# 3. $0.0060 each — Protocol TVL
 blockrun_defi({ path: "protocols" })
 blockrun_defi({ path: "protocol/jupiter" })
 
-# 4. $0.0070 — Chain TVL
+# 4. $0.0060 — Chain TVL
 blockrun_defi({ path: "chains" })
 ```
 
-**Total: ~$0.021 per full token analysis** (2 free calls + 3 x $0.0070 DefiLlama). Replace CoinGecko/CMC tabs entirely.
+**Total: ~$0.018 per full token analysis** (2 free calls + 3 x $0.0060 DefiLlama). Replace CoinGecko/CMC tabs entirely.
 
-### Pattern 3: Research + Synthesis (~$0.012 + chat)
+### Pattern 3: Research + Synthesis (~$0.011 + chat)
 
 Use Exa (neural search) + BlockRun Chat (second opinion) for thorough research.
 
 ```python
-# 1. $0.0120 — Neural web search with Exa
+# 1. $0.0110 — Neural web search with Exa
 blockrun_exa({ path: "search", body: {
   query: "latest AI agent infrastructure developments 2026",
   numResults: 10,
@@ -146,10 +146,10 @@ blockrun_wallet(action="report")
 ### DeFi Intelligence Pipeline
 
 ```python
-# 1. TVL & protocol health ($0.0070)
+# 1. TVL & protocol health ($0.0060)
 blockrun_defi({ path: "protocol/aave-v3" })
 
-# 2. Yield pools ($0.0070)
+# 2. Yield pools ($0.0060)
 blockrun_defi({ path: "yields" })
 
 # 3. Token price (FREE — crypto category)
@@ -169,26 +169,26 @@ blockrun_rpc({ network: "base", method: "eth_getBalance", params: ["0xabc...", "
 blockrun_price(action="price", category="crypto", symbol="ETH-USD")
 blockrun_price(action="price", category="crypto", symbol="USDC-USD")
 
-# 3. Prediction market positions ($0.0095)
+# 3. Prediction market positions ($0.0085)
 blockrun_markets({ path: "polymarket/positions" })
 ```
 
 ### Content Generation Pipeline
 
 ```python
-# 1. Research ($0.0120)
+# 1. Research ($0.0110)
 blockrun_exa({ path: "search", body: { query: "agentic commerce trends", numResults: 5 }})
 
-# 2. Image generation for post ($0.0178 cheapest to $0.1070 quality)
+# 2. Image generation for post ($0.01675 cheapest to $0.106 quality)
 blockrun_image({ prompt: "AI agent futuristic dashboard with neon grids" })
 
-# 3. Voiceover for video ($0.0545/1k chars)
+# 3. Voiceover for video ($0.0535/1k chars)
 blockrun_speech({ input: "Your narration text here...", voice: "sarah" })
 
-# 4. Music track ($0.1595)
+# 4. Music track ($0.1585)
 blockrun_music({ prompt: "upbeat synthwave background" })
 
-# 5. Short video clip ($0.402)
+# 5. Short video clip ($0.421)
 blockrun_video({ prompt: "animated data visualization", duration_seconds: 8 })
 ```
 
@@ -202,21 +202,21 @@ blockrun_video({ prompt: "animated data visualization", duration_seconds: 8 })
 |-----------|-------|-----------|
 | `blockrun_price` (list) | FREE | daily discovery |
 | `blockrun_dex` | FREE | unlimited |
-| `blockrun_rpc` | $0.0040 | on-chain reads (batch: $0.002/element + $0.002) |
+| `blockrun_rpc` | $0.0030 | on-chain reads (batch: $0.002/element + $0.001) |
 | `blockrun_wallet` (status/report) | FREE | before every session |
-| `blockrun_price` (quote) | **FREE** | crypto/FX/commodity; stocks $0.0030 |
-| `blockrun_defi` | $0.0070 | protocol/chain analysis ($0.0030 for prices/*) |
+| `blockrun_price` (quote) | **FREE** | crypto/FX/commodity; stocks $0.0020 |
+| `blockrun_defi` | $0.0060 | protocol/chain analysis ($0.0020 for prices/*) |
 | `blockrun_chat` (free mode) | $0 | NVIDIA-backed chat |
 | `blockrun_chat` (glm mode) | per-token | Zhipu GLM-5 coding — billed on tokens used, not a flat rate |
-| `blockrun_exa` (search) | $0.0120 | deep research (`contents`: $0.002/URL + $0.002) |
-| `blockrun_surf` | $0.0095 | crypto data, wallets/candles/search, on-chain SQL (flat) |
-| `blockrun_speech` | $0.0545/1k chars | TTS |
-| `blockrun_image` | $0.0178–0.1070 | image generation |
-| `blockrun_music` | $0.1595 | music tracks |
-| `blockrun_video` | $0.402+ | short video clips (per-second × duration) |
-| `blockrun_markets` | $0.0095 | prediction market data, wallet analytics (flat) |
-| `blockrun_modal` | $0.0030–$192 | remote sandbox execution — `timeout` drives the price, see the modal skill |
-| `blockrun_phone` | $0.0120–$5.002 | lookups; number buy/renew is $5.002 |
+| `blockrun_exa` (search) | $0.0110 | deep research (`contents`: $0.002/URL + $0.001) |
+| `blockrun_surf` | $0.0085 | crypto data, wallets/candles/search, on-chain SQL (flat) |
+| `blockrun_speech` | $0.0535/1k chars | TTS |
+| `blockrun_image` | $0.01675–0.106 | image generation |
+| `blockrun_music` | $0.1585 | music tracks |
+| `blockrun_video` | $0.421+ | short video clips (per-second × duration) |
+| `blockrun_markets` | $0.0085 | prediction market data, wallet analytics (flat) |
+| `blockrun_modal` | $0.0020–$192 | remote sandbox execution — `timeout` drives the price, see the modal skill |
+| `blockrun_phone` | $0.0110–$5.001 | lookups; number buy/renew is $5.001 |
 
 ### Daily Budget Formula (GenTech's Setup)
 
@@ -224,7 +224,7 @@ blockrun_video({ prompt: "animated data visualization", duration_seconds: 8 })
 # ~$0.30/day typical
 Daily budget:
   Free tools:     unlimited (price quotes, dex, list, wallet status)
-  Crypto data:   ~$0.10 (surf + markets, flat $0.0095 each; defi $0.0070)
+  Crypto data:   ~$0.10 (surf + markets, flat $0.0085 each; defi $0.0060)
   AI calls:      ~$0.10 (chat free mode, occasional glm)
   Media:         ~$0.10 (occasional image/speech)
   Total:         ~$0.30/day

--- a/skills/image-prompting/SKILL.md
+++ b/skills/image-prompting/SKILL.md
@@ -24,19 +24,19 @@ Most image failures are prompt failures. This skill gives the MCP agent a repeat
 
 Costs are what you are actually CHARGED, verified live. **Size is the biggest
 lever:** any dimension above 1024 moves GPT Image 2 to the large tier and roughly
-doubles the price ($0.065 → $0.128). Ask for `1536x1024` only when you need it.
+doubles the price ($0.064 → $0.127). Ask for `1536x1024` only when you need it.
 
 | User wants... | Model | Mode | Size | Cost |
 |---|---|---|---|---|
-| Poster / typography-heavy asset | `openai/gpt-image-2` | generate | `1536x1024` or `1024x1536` | $0.128 |
-| Clean product / UI mockup | `openai/gpt-image-2` | generate | `1024x1024` | $0.065 |
-| Photoreal / fashion / editorial | `openai/gpt-image-2` or `google/nano-banana-pro` | generate | `1024x1024` | $0.065–0.107 |
-| Pro-level photoreal at Flash speed | `google/nano-banana-2` | generate | `1024x1024` (only size) | $0.0965 |
-| Artistic / stylized / fast | `google/nano-banana` | generate | `1024x1024` | $0.0545 |
-| Cheapest usable draft | `zai/cogview-4` | generate | `1024x1024` | $0.0178 |
-| Widescreen / banner on a budget | `bytedance/seedream-5-pro` | generate | `2048x1024` or `1280x720` | $0.0493 ($0.0965 when both sides >1024) |
-| Edit an existing image (localized change) | `openai/gpt-image-2` | edit | match source | $0.065 at 1024x1024, $0.128 above |
-| Composite from multiple refs | `openai/gpt-image-2` | edit (multi-ref) | match target | $0.065 at 1024x1024, $0.128 above |
+| Poster / typography-heavy asset | `openai/gpt-image-2` | generate | `1536x1024` or `1024x1536` | $0.127 |
+| Clean product / UI mockup | `openai/gpt-image-2` | generate | `1024x1024` | $0.064 |
+| Photoreal / fashion / editorial | `openai/gpt-image-2` or `google/nano-banana-pro` | generate | `1024x1024` | $0.064–0.106 |
+| Pro-level photoreal at Flash speed | `google/nano-banana-2` | generate | `1024x1024` (only size) | $0.0955 |
+| Artistic / stylized / fast | `google/nano-banana` | generate | `1024x1024` | $0.0535 |
+| Cheapest usable draft | `zai/cogview-4` | generate | `1024x1024` | $0.01675 |
+| Widescreen / banner on a budget | `bytedance/seedream-5-pro` | generate | `2048x1024` or `1280x720` | $0.04825 ($0.0955 when both sides >1024) |
+| Edit an existing image (localized change) | `openai/gpt-image-2` | edit | match source | $0.064 at 1024x1024, $0.127 above |
+| Composite from multiple refs | `openai/gpt-image-2` | edit (multi-ref) | match target | $0.064 at 1024x1024, $0.127 above |
 
 **Valid GPT Image 2 sizes:** `1024x1024` (square), `1536x1024` (landscape ~3:2), `1024x1536` (portrait ~2:3).
 

--- a/skills/modal/SKILL.md
+++ b/skills/modal/SKILL.md
@@ -26,10 +26,10 @@ That makes `timeout` the single most expensive field in this MCP:
 
 | what you ask for | what you pay |
 |---|---|
-| `{ timeout: 300 }` | **$0.0120** |
-| `{ timeout: 300, gpu: "A100" }` | **$0.2020** |
-| `{ timeout: 600, gpu: "A100" }` | **$0.6687** |
-| `{ timeout: 86400, gpu: "H100" }` | **$192.0020** |
+| `{ timeout: 300 }` | **$0.0110** |
+| `{ timeout: 300, gpu: "A100" }` | **$0.2010** |
+| `{ timeout: 600, gpu: "A100" }` | **$0.6677** |
+| `{ timeout: 86400, gpu: "H100" }` | **$192.0010** |
 
 All four are live-verified quotes. A 24h H100 sandbox costs **$192 upfront, non-refundable**, even if your job finishes in a minute.
 
@@ -38,7 +38,7 @@ All four are live-verified quotes. A 24h H100 sandbox costs **$192 upfront, non-
 ## How to Call from MCP
 
 ```ts
-// 1. Create — timeout: 300 keeps you on the FLAT rate ($0.0120, or $0.2020 with A100).
+// 1. Create — timeout: 300 keeps you on the FLAT rate ($0.0110, or $0.2010 with A100).
 //    Anything above 300 bills hourly for the full requested lifetime, no refund.
 blockrun_modal({ path: "sandbox/create", body: {
   image: "python:3.11",
@@ -63,9 +63,9 @@ blockrun_modal({ path: "sandbox/terminate", body: { sandbox_id: "sb_abc..." } })
 | Path | Method | Body | Price |
 |---|---|---|---|
 | `sandbox/create` | POST | `{ image?, timeout?, cpu?, memory?, gpu?, setup_commands? }` | **depends on `timeout` + `gpu` — see below** |
-| `sandbox/exec` | POST | `{ sandbox_id, command: ["python","-c","..."], timeout? }` | $0.0030 |
-| `sandbox/status` | POST | `{ sandbox_id }` | $0.0030 |
-| `sandbox/terminate` | POST | `{ sandbox_id }` | $0.0030 |
+| `sandbox/exec` | POST | `{ sandbox_id, command: ["python","-c","..."], timeout? }` | $0.0020 |
+| `sandbox/status` | POST | `{ sandbox_id }` | $0.0020 |
+| `sandbox/terminate` | POST | `{ sandbox_id }` | $0.0020 |
 
 ### `sandbox/create` pricing is bimodal
 
@@ -73,27 +73,27 @@ blockrun_modal({ path: "sandbox/terminate", body: { sandbox_id: "sb_abc..." } })
 
 | gpu | price |
 |---|---|
-| *(none, CPU)* | $0.0120 |
-| `T4` | $0.0520 |
-| `L4` | $0.0820 |
-| `A10G` | $0.1020 |
-| `A100` | $0.2020 |
-| `H100` | $0.4020 |
+| *(none, CPU)* | $0.0110 |
+| `T4` | $0.0510 |
+| `L4` | $0.0810 |
+| `A10G` | $0.1010 |
+| `A100` | $0.2010 |
+| `H100` | $0.4010 |
 
 **`timeout > 300s` — per-hour × the full requested lifetime, upfront, no refund:**
 
 | gpu | per hour | 1h | 24h (max) |
 |---|---|---|---|
-| *(none, CPU)* | $0.10 | $0.1020 | $2.4020 |
-| `T4` | $1.50 | $1.5020 | $36.0020 |
-| `L4` | $2.00 | $2.0020 | $48.0020 |
-| `A10G` | $2.50 | $2.5020 | $60.0020 |
-| `A100` | $4.00 | $4.0020 | $96.0020 |
-| `H100` | $8.00 | $8.0020 | **$192.0020** |
+| *(none, CPU)* | $0.10 | $0.1010 | $2.4010 |
+| `T4` | $1.50 | $1.5010 | $36.0010 |
+| `L4` | $2.00 | $2.0010 | $48.0010 |
+| `A10G` | $2.50 | $2.5010 | $60.0010 |
+| `A100` | $4.00 | $4.0010 | $96.0010 |
+| `H100` | $8.00 | $8.0010 | **$192.0010** |
 
-Hours are exact, not rounded up — `timeout: 1800` on `A100` is 0.5h = $2.0020. Every figure above includes the $0.002 flat transaction fee. Max `timeout` is 86400 (24h).
+Hours are exact, not rounded up — `timeout: 1800` on `A100` is 0.5h = $2.0010. Every figure above includes the $0.001 flat transaction fee. Max `timeout` is 86400 (24h).
 
-One quirk worth knowing: `timeout: 300` costs $0.0120 (flat) but `timeout: 301` costs $0.0104 (CPU-hourly) — just past the cliff is briefly *cheaper* on CPU. It stops being cheaper around 432s.
+One quirk worth knowing: `timeout: 300` costs $0.0110 (flat) but `timeout: 301` costs $0.0094 (CPU-hourly) — just past the cliff is briefly *cheaper* on CPU. It stops being cheaper at 360s.
 
 ## Field Reference
 
@@ -119,7 +119,7 @@ await blockrun_modal({ path: "sandbox/exec", body: {
 }})
 await blockrun_modal({ path: "sandbox/terminate", body: { sandbox_id: sb.sandbox_id } })
 ```
-**Cost: $0.0180** — create $0.0120 + exec $0.0030 + terminate $0.0030. Every call carries the $0.002 transaction fee, so three calls pay it three times; batch your work into one `exec` rather than several.
+**Cost: $0.0150** — create $0.0110 + exec $0.0020 + terminate $0.0020. Every call carries the $0.001 transaction fee, so three calls pay it three times; batch your work into one `exec` rather than several.
 
 ### 2. GPU inference, A100, with deps pre-installed
 
@@ -134,7 +134,7 @@ blockrun_modal({ path: "sandbox/create", body: {
 ```
 Then `sandbox/exec` with your inference command.
 
-**Cost: $1.3413** — create $1.3353 + exec $0.0030 + terminate $0.0030. `timeout: 1200` is above the 300s flat tier, so the A100 bills hourly for the full 20 minutes you asked for: $4.00/h × (1200/3600) = $1.3333, + the $0.002 fee. It is **charged upfront and never refunded** — it does NOT auto-evict when idle, and terminating after 30 seconds still costs the full $1.3353. Ask for the time you actually need.
+**Cost: $1.3383** — create $1.3343 + exec $0.0020 + terminate $0.0020. `timeout: 1200` is above the 300s flat tier, so the A100 bills hourly for the full 20 minutes you asked for: $4.00/h × (1200/3600) = $1.3333, + the $0.001 fee. It is **charged upfront and never refunded** — it does NOT auto-evict when idle, and terminating after 30 seconds still costs the full $1.3343. Ask for the time you actually need.
 
 ### 3. Test untrusted code Claude generated
 

--- a/skills/phone/SKILL.md
+++ b/skills/phone/SKILL.md
@@ -52,18 +52,18 @@ blockrun_phone({ path: `voice/call/${r.call_id}` })
 
 | Path | Body | Price | Effect |
 |---|---|---|---|
-| `phone/lookup` | `{ phoneNumber }` | $0.0120 | Carrier, line type (mobile/landline/VoIP) |
-| `phone/lookup/fraud` | `{ phoneNumber }` | $0.0520 | + SIM-swap signals, call-forwarding detection |
-| `phone/numbers/buy` | `{ country?: "US"\|"CA", areaCode? }` | $5.00 | 30-day lease, US or CA |
-| `phone/numbers/renew` | `{ phoneNumber }` | $5.00 | Extend lease 30 days |
-| `phone/numbers/list` | `{}` | $0.0030 | Your wallet-owned numbers |
+| `phone/lookup` | `{ phoneNumber }` | $0.0110 | Carrier, line type (mobile/landline/VoIP) |
+| `phone/lookup/fraud` | `{ phoneNumber }` | $0.0510 | + SIM-swap signals, call-forwarding detection |
+| `phone/numbers/buy` | `{ country?: "US"\|"CA", areaCode? }` | $5.001 | 30-day lease, US or CA |
+| `phone/numbers/renew` | `{ phoneNumber }` | $5.001 | Extend lease 30 days |
+| `phone/numbers/list` | `{}` | $0.0020 | Your wallet-owned numbers |
 | `phone/numbers/release` | `{ phoneNumber }` | free | Return to pool |
 
 ### Outbound AI calls (`/v1/voice/*`)
 
 | Path | Method | Body | Price |
 |---|---|---|---|
-| `voice/call` | POST | `{ to, task, from, voice?, max_duration?, language?, first_sentence?, wait_for_greeting? }` | $0.5420 flat |
+| `voice/call` | POST | `{ to, task, from, voice?, max_duration?, language?, first_sentence?, wait_for_greeting? }` | $0.5410 flat |
 | `voice/call/{call_id}` | GET (no body) | – | free poll |
 
 > **`from` is REQUIRED and must be a number your wallet owns.** Provision one first with `phone/numbers/buy` ($5, 30-day lease). 400 errors from `voice/call` are almost always missing `from`.
@@ -100,7 +100,7 @@ blockrun_phone({ path: `voice/call/${r.call_id}` })
 ```ts
 blockrun_phone({ path: "phone/lookup/fraud", body: { phoneNumber: "+14155550150" } })
 ```
-Returns carrier, line type, SIM-swap indicator, call-forwarding state. **Cost: $0.0520.**
+Returns carrier, line type, SIM-swap indicator, call-forwarding state. **Cost: $0.0510.**
 
 ### 2. Spin up a US number with a 415 area code
 
@@ -108,7 +108,7 @@ Returns carrier, line type, SIM-swap indicator, call-forwarding state. **Cost: $
 blockrun_phone({ path: "phone/numbers/buy", body: { country: "US", areaCode: "415" } })
 // returns { phoneNumber: "+14155550199", expires_at: "..." }
 ```
-Best-effort area code match. **Cost: $5.00 for 30 days.**
+Best-effort area code match. **Cost: $5.001 for 30 days.**
 
 ### 3. Confirm an appointment via AI voice call
 
@@ -116,7 +116,7 @@ Best-effort area code match. **Cost: $5.00 for 30 days.**
 // Step 0 (one-time): provision a number you'll use as caller ID
 const { phoneNumber: myNumber } = await blockrun_phone({
   path: "phone/numbers/buy", body: { country: "US", areaCode: "415" }
-})  // $5.00, 30-day lease
+})  // $5.001, 30-day lease
 
 // Step 1: place the call (from is REQUIRED)
 const r = await blockrun_phone({ path: "voice/call", body: {
@@ -139,7 +139,7 @@ while (true) {
   await new Promise(r => setTimeout(r, 5000))
 }
 ```
-**Cost: $0.5420 flat for the call.** Status polling is free.
+**Cost: $0.5410 flat for the call.** Status polling is free.
 
 ### 4. List your wallet's leased numbers + release one
 
@@ -158,7 +158,7 @@ await blockrun_phone({ path: "phone/numbers/release", body: { phoneNumber: numbe
 
 ## When NOT to Use
 
-- **High-volume autodialer / robocall workloads** — pricing is per-call ($0.5420 each) which doesn't amortize like wholesale telephony
+- **High-volume autodialer / robocall workloads** — pricing is per-call ($0.5410 each) which doesn't amortize like wholesale telephony
 - **Receiving inbound calls** — `numbers/buy` provisions a number but inbound routing is not exposed via MCP; use Bland directly
 - **Two-way human-to-human calls** — this is for AI-driven outbound; for real-time human bridging, use a SIP provider
 
@@ -167,7 +167,7 @@ await blockrun_phone({ path: "phone/numbers/release", body: { phoneNumber: numbe
 - `phone/lookup` is cheap reconnaissance; `phone/lookup/fraud` is 5× the price but adds SIM-swap + call-forwarding signals you can't get from a basic carrier lookup
 - Voice calls return immediately with a `call_id`; the call runs in the background. Always poll `voice/call/{call_id}` to get the transcript
 - The poll endpoint is free — poll as often as you want, but every 5s is plenty
-- Calls that fail upstream (recipient hangs up, no answer) still charge the flat $0.5420 — Bland's pricing model
+- Calls that fail upstream (recipient hangs up, no answer) still charge the flat $0.5410 — Bland's pricing model
 
 ## Reference
 

--- a/skills/prediction-markets/SKILL.md
+++ b/skills/prediction-markets/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: prediction-markets
-description: "Use when the user asks about event probabilities, prediction market odds, what people are betting on, Polymarket/Kalshi prices, sports markets — or about the things you CANNOT get from a public API: historical price/volume/orderbook time series, smart-money positioning, whale leaderboards, wallet P&L, wallet identity and on-chain clustering, and canonical IDs matching the same question across venues. 58 endpoints over Polymarket, Kalshi, Limitless, Opinion, Predict.Fun, dFlow, Binance Futures, sports, and the UMA oracle. Pay-per-call in USDC via x402 — no Predexon account, no API key."
+description: "Use when the user asks about event probabilities, prediction market odds, what people are betting on, Polymarket/Kalshi prices, sports markets — or about the things you CANNOT get from a public API: historical price/volume/orderbook time series, smart-money positioning, whale leaderboards, wallet P&L, wallet identity and on-chain clustering, and canonical IDs matching the same question across venues. 55 endpoints over Polymarket, Kalshi, Limitless, Opinion, Predict.Fun, Binance Futures, sports, and the UMA oracle. Pay-per-call in USDC via x402 — no Predexon account, no API key."
 triggers:
   - "polymarket"
   - "kalshi"
-  - "dflow"
   - "limitless"
   - "predict.fun"
   - "predexon"
@@ -48,7 +47,7 @@ triggers:
 
 # Prediction Markets (Predexon)
 
-58 endpoints across Polymarket, Kalshi, Limitless, Opinion, Predict.Fun, dFlow, Binance Futures, sports, and the UMA oracle — one x402 gateway, no Predexon account or API key.
+55 endpoints across Polymarket, Kalshi, Limitless, Opinion, Predict.Fun, Binance Futures, sports, and the UMA oracle — one x402 gateway, no Predexon account or API key.
 
 **What is worth paying for.** Current market lists are free from public APIs. These are not, and cannot be backfilled after the fact:
 
@@ -103,7 +102,7 @@ Current parameter contracts that prevent paid 4xx responses:
 
 | Tier | Price | What |
 |---|---|---|
-| **All endpoints** | $0.0095 | Market data, events, history, candles, orderbooks, trades, leaderboard, sports, UMA, wallet analytics, smart money, identity + clustering, cross-venue matching, Binance |
+| **All endpoints** | $0.0085 | Market data, events, history, candles, orderbooks, trades, leaderboard, sports, UMA, wallet analytics, smart money, identity + clustering, cross-venue matching, Binance |
 
 Pass-through pricing, 0% BlockRun margin — settles straight to Predexon's Base treasury.
 
@@ -157,8 +156,6 @@ Pass-through pricing, 0% BlockRun margin — settles straight to Predexon's Base
 | Equivalent sports outcomes | `sports/outcomes/{predexon_id}` | 1 |
 | Limitless / Opinion / Predict.Fun markets | `limitless/markets`, `opinion/markets`, `predictfun/markets` | 1 |
 | Their historical orderbook snapshots | `limitless/orderbooks`, `opinion/orderbooks`, `predictfun/orderbooks` | 1 |
-| dFlow trades | `dflow/trades` | 1 |
-| dFlow wallet positions / P&L | `dflow/wallet/positions/{w}`, `dflow/wallet/pnl/{w}` | 2 |
 | Binance candles / ticks | `binance/candles/{symbol}`, `binance/ticks/{symbol}` | 2 |
 
 ## Worked Examples

--- a/skills/rpc/SKILL.md
+++ b/skills/rpc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rpc
-description: Use when the user needs raw blockchain JSON-RPC access — contract reads (eth_call), native balances, blocks, transactions, logs, gas estimates, or any chain-native RPC method across 40 chains. One endpoint per chain via BlockRun's Tatum-backed gateway, $0.0040 per call, no node, no API key. Prefer blockrun_price / blockrun_dex / blockrun_surf when they already cover the question.
+description: Use when the user needs raw blockchain JSON-RPC access — contract reads (eth_call), native balances, blocks, transactions, logs, gas estimates, or any chain-native RPC method across 40 chains. One endpoint per chain via BlockRun's Tatum-backed gateway, $0.0030 per call, no node, no API key. Prefer blockrun_price / blockrun_dex / blockrun_surf when they already cover the question.
 triggers:
   - "rpc"
   - "json-rpc"
@@ -18,7 +18,7 @@ triggers:
 
 # Multi-chain RPC — every supported chain, one tool
 
-`blockrun_rpc` POSTs a standard JSON-RPC 2.0 body to `/v1/rpc/{network}`. Flat **$0.0040 per call** ($0.002 base + the $0.002 transaction fee). A JSON-RPC **batch array charges per element but pays the flat fee only once** — $0.002 × n + $0.002, so a batch of 3 costs $0.0080 where three separate calls cost $0.0120. Batch whenever you can. Settlement in USDC via x402. Responses are cached briefly server-side for identical read calls (`X-Cache: HIT` is free of upstream latency but still billed).
+`blockrun_rpc` POSTs a standard JSON-RPC 2.0 body to `/v1/rpc/{network}`. Flat **$0.0030 per call** ($0.002 base + the $0.001 transaction fee). A JSON-RPC **batch array charges per element but pays the flat fee only once** — $0.002 × n + $0.001, so a batch of 3 costs $0.0070 where three separate calls cost $0.0090. Batch whenever you can. Settlement in USDC via x402. Responses are cached briefly server-side for identical read calls (`X-Cache: HIT` is free of upstream latency but still billed).
 
 ## When to use which tool
 
@@ -89,7 +89,7 @@ Gas: `method: "eth_gasPrice"` / `eth_estimateGas`
 
 Solana token account: `network: "solana", method: "getTokenAccountsByOwner", params: ["<owner>", {"mint": "<mint>"}, {"encoding": "jsonParsed"}]`
 
-Batch (charged per element, flat fee paid once — 3 calls = $0.0080, vs $0.0120 sent separately):
+Batch (charged per element, flat fee paid once — 3 calls = $0.0070, vs $0.0090 sent separately):
 
 ```
 blockrun_rpc({ network: "ethereum", body: [

--- a/skills/search/SKILL.md
+++ b/skills/search/SKILL.md
@@ -15,7 +15,7 @@ triggers:
 
 # Live Search (Grok)
 
-Real-time web + news search with AI-summarized results and citations. **PRICED PER SOURCE and expensive by default: $0.025 × `max_results`, +5% +$0.002 → default 10 settles $0.2645 per call.** Best for *fresh* queries; for semantic / neural research use `blockrun_exa` instead.
+Real-time web + news search with AI-summarized results and citations. **PRICED PER SOURCE and expensive by default: $0.025 × `max_results`, +5% +$0.001 → default 10 settles $0.2635 per call.** Best for *fresh* queries; for semantic / neural research use `blockrun_exa` instead.
 
 ## How to Call from MCP
 
@@ -53,14 +53,14 @@ blockrun_search({ body: {
 ```ts
 blockrun_search({ body: { query: "Ethereum ETF approval SEC", sources: ["news","web"], max_results: 8 } })
 ```
-**Cost: ~$0.2120** (8 sources: $0.025 × 8 × 1.05 + $0.002).
+**Cost: ~$0.2110** (8 sources: $0.025 × 8 × 1.05 + $0.001).
 
 ### 2. "What is X saying about Solana's latest outage?"
 
 ```ts
 blockrun_search({ body: { query: "Solana outage today", sources: ["x"], max_results: 15 } })
 ```
-**Cost: ~$0.3958** (15 sources: $0.025 × 15 × 1.05 + $0.002).
+**Cost: ~$0.3948** (15 sources: $0.025 × 15 × 1.05 + $0.001).
 
 ### 3. "Background on Pectra upgrade, last 90 days only"
 
@@ -71,7 +71,7 @@ blockrun_search({ body: {
   from_date: "2026-02-17"
 }})
 ```
-**Cost: $0.2645** (10 sources, the default — verified live).
+**Cost: $0.2635** (10 sources, the default — verified live).
 
 ## search vs exa — Pick the Right Tool
 
@@ -85,7 +85,7 @@ blockrun_search({ body: {
 ## Notes
 
 - Returns AI-summarized text + a list of sources with URLs. The summary is one paragraph; sources let you drill in.
-- **Price is per result, not per source.** `max_results: 20` with one source or three sources both charge **$0.527** ($0.025 × 20 × 1.05 + $0.002 — verified live). Pass a smaller `max_results` to cap spend.
+- **Price is per result, not per source.** `max_results: 20` with one source or three sources both charge **$0.526** ($0.025 × 20 × 1.05 + $0.001 — verified live). Pass a smaller `max_results` to cap spend.
 - Date filters are strict — results outside the window are dropped, not down-ranked.
 
 ## Reference

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: surf
-description: Use when the user wants crypto data — token prices, on-chain SQL, prediction-market positions, CEX order books, wallet labels/net-worth, social mindshare, news, or unified search. 83 endpoints across exchange, on-chain, wallet, social, prediction, news and search — one API, flat $0.0095/call in USDC via x402. Settles directly to Surf's Base treasury; no Surf account needed.
+description: Use when the user wants crypto data — token prices, on-chain SQL, prediction-market positions, CEX order books, wallet labels/net-worth, social mindshare, news, or unified search. 83 endpoints across exchange, on-chain, wallet, social, prediction, news and search — one API, flat $0.0085/call in USDC via x402. Settles directly to Surf's Base treasury; no Surf account needed.
 triggers:
   - "surf"
   - "asksurf"
@@ -53,9 +53,9 @@ blockrun_surf({ path: "wallet/labels/batch", params: { addresses: "0xabc,0xdef" 
 
 ## Pricing — one flat rate
 
-**$0.0095 per call. Every endpoint, no tiers, including raw on-chain SQL.**
+**$0.0085 per call. Every endpoint, no tiers, including raw on-chain SQL.**
 
-Verified against the gateway's own `payment-required` header, which is free to request — send any call with no payment header and it quotes the exact charge. All of `market/price`, `wallet/labels/batch`, `social/mindshare`, `news/feed`, `exchange/klines`, `search/web` **and `onchain/sql`** return the same $0.0095 (`SURF_TIER_1/2/3_PRICE` are all identical upstream).
+Verified against the gateway's own `payment-required` header, which is free to request — send any call with no payment header and it quotes the exact charge. All of `market/price`, `wallet/labels/batch`, `social/mindshare`, `news/feed`, `exchange/klines`, `search/web` **and `onchain/sql`** return the same $0.0085 (`SURF_TIER_1/2/3_PRICE` are all identical upstream).
 
 Ignore any "premium tier" pricing you may have seen — SQL used to cost more and no longer does.
 
@@ -69,9 +69,9 @@ Predexon used to be 7.5× cheaper; since 2026-07-15 both bill the same flat rate
 
 | | Predexon (`blockrun_markets`) | Surf |
 |---|---|---|
-| Polymarket / Kalshi markets | $0.0095 | $0.0095 (same) |
+| Polymarket / Kalshi markets | $0.0085 | $0.0085 (same) |
 | Wallet clustering, smart money, leaderboards | ✅ | ❌ none |
-| Limitless, Opinion, Predict.Fun, dFlow, sports, UMA | ✅ | ❌ Polymarket + Kalshi only |
+| Limitless, Opinion, Predict.Fun, sports, UMA | ✅ | ❌ Polymarket + Kalshi only |
 
 The only Surf prediction-market endpoint with no Predexon equivalent is `prediction-market/category-metrics`. Everything else is a strictly worse buy. See [`skills/prediction-markets/SKILL.md`](../prediction-markets/SKILL.md).
 
@@ -139,7 +139,7 @@ The only Surf prediction-market endpoint with no Predexon equivalent is `predict
 ```ts
 blockrun_surf({ path: "market/price", params: { symbol: "BTC" } })
 ```
-**Cost: $0.0095.** Returns price history; latest point = current price.
+**Cost: $0.0085.** Returns price history; latest point = current price.
 
 ### 2. "Top 10 tokens by DEX volume on Ethereum in the last 24h"
 
@@ -158,7 +158,7 @@ blockrun_surf({
   }
 })
 ```
-**Cost: $0.0095.** Raw ClickHouse — same query language Surf's own UI uses, at the same flat rate as any other Surf read.
+**Cost: $0.0085.** Raw ClickHouse — same query language Surf's own UI uses, at the same flat rate as any other Surf read.
 
 ### 3. "Is this whale wallet labeled? What does it hold?"
 
@@ -173,7 +173,7 @@ blockrun_surf({ path: "wallet/protocols", params: { address: "0xabc..." } })
 // Step 3 — net-worth time series
 blockrun_surf({ path: "wallet/net-worth", params: { address: "0xabc..." } })
 ```
-**Cost: 4 × $0.0095 = $0.038.** Replaces a Nansen subscription for one-off lookups.
+**Cost: 4 × $0.0085 = $0.034.** Replaces a Nansen subscription for one-off lookups.
 
 ### 4. "What's the market saying about the 2028 election?"
 
@@ -203,7 +203,7 @@ blockrun_surf({ path: "market/fear-greed" })
 blockrun_surf({ path: "exchange/funding-history",  params: { pair: "BTC-USDT" } })
 blockrun_surf({ path: "exchange/long-short-ratio", params: { pair: "BTC-USDT" } })
 ```
-**Cost: 4 × $0.0095 = $0.038.**
+**Cost: 4 × $0.0085 = $0.034.**
 
 ## Method Routing — When to Use `body`
 

--- a/src/tools/defi.ts
+++ b/src/tools/defi.ts
@@ -10,7 +10,7 @@ import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
 import { reserveBudget, recordSpending } from "../utils/budget.js";
 import { withTxFee } from "../utils/tx-fee.js";
-import { getClient } from "../utils/wallet.js";
+import { getClient, getChain } from "../utils/wallet.js";
 import { formatError, extractErrorMessage } from "../utils/errors.js";
 import { hasPathTraversal } from "../utils/path-safety.js";
 import type { BudgetState } from "../types.js";
@@ -54,6 +54,16 @@ Use blockrun_price (free) for plain spot quotes, blockrun_dex (free) for DEX pai
     },
     async ({ path, agent_id }) => {
       try {
+        // sol.blockrun.ai does not serve /v1/defillama/* at all — it 404s, which
+        // reaches the agent as a bare "Not Found" with nothing to act on. Probed
+        // 2026-08-07 by the dual-chain sweep in scripts/verify-prices.ts. Fail
+        // fast and name the fix, the way music/video/image/speech already do.
+        if (getChain() !== "base") {
+          return {
+            content: [{ type: "text", text: formatError("blockrun_defi is served on Base only. Switch BlockRun to Base (run blockrun_wallet with action:chain chain:base) and fund the Base wallet with USDC.") }],
+            isError: true,
+          };
+        }
         const cleanPath = path.replace(/^\/+/, "").replace(/^v1\/defillama\//, "").replace(/^api\/v1\/defillama\//, "");
         if (hasPathTraversal(cleanPath)) {
           return { content: [{ type: "text", text: formatError(`Invalid path '${path}'.`) }], isError: true };

--- a/src/tools/markets.ts
+++ b/src/tools/markets.ts
@@ -73,7 +73,6 @@ SPORTS (Tier 1):
 
 KALSHI: kalshi/markets, kalshi/trades, kalshi/orderbooks
 LIMITLESS / OPINION / PREDICT.FUN: {platform}/markets, {platform}/orderbooks
-DFLOW: dflow/trades, dflow/wallet/positions/:wallet, dflow/wallet/pnl/:wallet
 BINANCE FUTURES: binance/candles/:symbol, binance/ticks/:symbol
 
 CROSS-PLATFORM:

--- a/src/tools/modal.ts
+++ b/src/tools/modal.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 import { reserveBudget, recordSpending } from "../utils/budget.js";
 import { withTxFee } from "../utils/tx-fee.js";
 import { asStructuredContent, coerceBody } from "../utils/body.js";
-import { buildClientWithTimeout } from "../utils/wallet.js";
+import { buildClientWithTimeout, getChain } from "../utils/wallet.js";
 import { formatError, extractErrorMessage } from "../utils/errors.js";
 import { hasPathTraversal } from "../utils/path-safety.js";
 import type { BudgetState } from "../types.js";
@@ -125,6 +125,17 @@ Full pricing tables + GPU details in the \`modal\` skill.`,
     },
     async ({ path, body, agent_id }) => {
       try {
+        // sol.blockrun.ai returns 503 for every /v1/modal/* route — the sandbox
+        // backend is Base-only. Probed 2026-08-07 by the dual-chain sweep in
+        // scripts/verify-prices.ts (all six modal probes, create and exec). A
+        // raw 503 reads as "the service is down" rather than "wrong chain", so
+        // say which it is before spending the round trip.
+        if (getChain() !== "base") {
+          return {
+            content: [{ type: "text", text: formatError("blockrun_modal is served on Base only. Switch BlockRun to Base (run blockrun_wallet with action:chain chain:base) and fund the Base wallet with USDC.") }],
+            isError: true,
+          };
+        }
         body = coerceBody(body);
         const cleanPath = path.replace(/^\/+/, "").replace(/^v1\/modal\//, "");
         if (hasPathTraversal(cleanPath)) {


### PR DESCRIPTION
Started as the price sweep #91 deferred. Became three things, because probing the second gateway changed what the first two should say.

## 1. `verify:prices` was blind to half the surface

`BASE` was hardcoded to `blockrun.ai`. Every "verified live" claim this repo has made was a claim about **one of two gateways** — and they do not agree:

| | Base | Solana |
|---|---|---|
| every route | base + **$0.001** | base + **$0.000** |

Solana adds no transaction fee at all. Probed 2026-08-07 across 45 routes: **37 cheaper on Solana, 0 dearer, 8 not served there at all** (all six `modal` routes 503, `defillama` 404, `seedance-2.5@1080p` 400 — that last is the already-tracked gateway defect).

They can diverge because they are separate deployments and `TRANSACTION_FEE_USD` is env-overridable in the gateway: the fee can move on one chain and not the other with nothing here noticing. Same shape as a marketplace check that never reads the skills directory — the tool whose whole job is this bug class could not see the case.

Direction decides severity, so they are counted separately:

- **Solana cheaper** → safe. Estimators reserve the Base figure, so we over-reserve there. Reported, not fatal.
- **Solana dearer** → every estimator under-reserves for that chain, exactly as fatal as a Base shortfall, since `blockrun_wallet action:"chain"` lets one agent switch mid-session. **Exits 1.**
- **Not served** → reported per route; a chain switch turns those into a 404/503, not a cheaper call.

Both chains probe concurrently, so the second gateway costs no wall-clock.

## 2. `blockrun_defi` and `blockrun_modal` had no chain guard

Six other tools do. On Solana, modal 503s and defi 404s — the 503 reads as "sandbox is down" (plausible, wrong, invites a retry loop) and the 404 reads as a bad path, so the next move is to re-check the path rather than the chain. Both now fail fast and name the fix.

## 3. The price sweep itself

Every flat figure across eleven skills was `base + $0.002` — the fee that has since gone back to $0.001. Corrected **route by route against the live 402**, not by subtracting $0.001, because several rows share a printed value while meaning different endpoints. That trap fired mid-sweep: crypto-data's RPC rows went `$0.0040 → $0.0030 → $0.0020` when a later rule re-matched an earlier rule's output. Only a per-route audit caught it.

Two figures were wrong for reasons unrelated to the fee, and only probing found them:

- The modal CPU billing cliff stops being cheaper at **360s**, not the 432s claimed (probed: 300s `$0.011000`, 360s `$0.011001`, 361s `$0.011028`).
- An 8s video clip is **$0.421**, not $0.402 — its base is $0.42, not the `$0.05/sec × 8` the per-second table implies.

**dFlow** is removed: all three paths return `Unknown Predexon endpoint` 404 from the gateway itself — de-registered, not an upstream timeout. Gone from the description, triggers and route table (58 → 55 endpoints), from surf's coverage comparison, and from `src/tools/markets.ts`, which was advertising the same three dead routes to the model on every call.

## On the one number the docs print

Prices in `skills/` are **Base** prices. Rather than caveat eleven files with something we intend to delete once the gateways agree, that is stated once in `skills/blockrun` — the entry point every agent loads first. The open decision is whether to align the gateways (my recommendation: one number, since an agent can switch chains mid-session and a per-chain table doubles the drift surface this PR exists to shrink) or to keep them apart and qualify everywhere.

## Verification

- `npm run typecheck`, `npm run build`, **302/302 tests**, `sync-brand-numbers --check` all green.
- `npm run verify:prices` → `0 under-reserving, 0 Solana dearer`, exits 0.