### PR TITLE
docs(skills): say which tools do not exist on Solana, and where

### DIFF
--- a/skills/blockrun/SKILL.md
+++ b/skills/blockrun/SKILL.md
@@ -32,15 +32,33 @@ changed, because each one was a typed copy. Read prices from a live source inste
 |------|-------|
 | Per-token model pricing | `blockrun_models` |
 | What a call will actually cost | the `402` response — it carries the real amount |
-| Full endpoint catalog with prices | <https://blockrun.ai/llms.txt> |
+| Full endpoint catalog with prices | <https://blockrun.ai/llms.txt> (Base) · <https://sol.blockrun.ai/llms.txt> (Solana) |
 
 The tool descriptions in the MCP server carry current prices too; they are generated, not typed.
 
-**Every price in these skills is the Base price.** Base and Solana are separate
-gateways: Base adds a flat per-transaction fee, Solana currently adds none, so the same
-call runs about $0.001 cheaper on Solana. `blockrun_defi` and `blockrun_modal` are not
-served on Solana at all. Read the 402 on the chain you are actually on, and check
-`blockrun_wallet action: "chain"` if a figure looks off by a tenth of a cent.
+## The two chains are not the same gateway
+
+`blockrun.ai` and `sol.blockrun.ai` are separate deployments, and
+`blockrun_wallet action: "chain"` switches between them mid-session. Two consequences,
+both easy to miss because nothing announces the switch:
+
+**Prices differ.** Every figure in these skills is the **Base** price. Base adds a flat
+per-transaction fee; Solana currently adds none, so the same call runs about $0.001
+cheaper there. Each gateway's own `llms.txt` quotes its own convention — read the one for
+the chain you are on, or just read the 402.
+
+**Some tools do not exist on Solana at all.** Verified against both gateways
+2026-08-07:
+
+| Tool | On Solana | What you get |
+|---|---|---|
+| `blockrun_defi` | ✗ not served | `404` — reads like a bad path, but the path is fine |
+| `blockrun_modal` | ✗ not served | `503` on all four sandbox actions — reads like an outage |
+| everything else | ✓ | ~$0.001 cheaper than the figure printed here |
+
+Both tools now refuse before the round trip and tell you to switch, so you should never
+see the raw `404`/`503` through the MCP. If you are calling the HTTP API directly you
+will, and neither status says "wrong chain" — check the chain first.
 
 The same applies to counts. Where a number has a canonical source it is wrapped in a `br:`
 HTML-comment marker in this file, regenerated from `brand-numbers.json` by

--- a/skills/blockrun/rules/wallet-and-payment.md
+++ b/skills/blockrun/rules/wallet-and-payment.md
@@ -39,6 +39,28 @@ command to run on their own machine.
 Budgets are enforced, not advisory: an agent that exhausts its delegated allowance is hard
 stopped rather than allowed to overspend.
 
+## What `action: "chain"` actually changes
+
+It repoints every paid call at a different deployment — `blockrun.ai` becomes
+`sol.blockrun.ai` — and those two do not serve the same catalog at the same prices.
+Verified against both, 2026-08-07:
+
+- **The per-transaction fee.** Base adds a flat fee to every non-zero price; Solana adds
+  nothing. Same route, same base price, ~$0.001 apart. Nothing in the response says which
+  convention you just paid under, so a figure that looks a tenth of a cent off is usually
+  the chain, not a reprice.
+- **Coverage.** `/v1/defillama/*` is absent on Solana (`404`) and `/v1/modal/*` is present
+  but unconfigured (`503` on create, exec, status and terminate — eight probes, all four
+  actions plus the GPU tiers). `blockrun_defi` and `blockrun_modal` guard against this and
+  refuse with a message naming the chain; every other tool works on both.
+- **Onramp.** Card funding is Base-only, so `action: "deposit"` degrades to address + QR
+  guidance on Solana. Fund a Solana wallet by transfer.
+
+The budget gate reserves the **Base** figure on both chains. That over-reserves on Solana,
+which is the safe direction — it can refuse an affordable call, but it can never let one
+past the cap. `scripts/verify-prices.ts` probes both gateways and fails the build if
+Solana ever becomes the dearer one, because then the same reserve would be short.
+
 ## Funding
 
 1. **Card / bank.** Through the MCP this is `blockrun_wallet action: "deposit"` — do not

--- a/skills/crypto-data/SKILL.md
+++ b/skills/crypto-data/SKILL.md
@@ -102,7 +102,10 @@ blockrun_dex({ query: "WETH", chain: "base" })      // scope to a chain
 
 ## blockrun_defi — TVL & yields (DefiLlama)
 
-Path-based, GET only.
+Path-based, GET only. **Base only** — `sol.blockrun.ai` does not serve `/v1/defillama/*`
+and answers `404`, which reads like a bad path rather than a wrong chain. The tool checks
+the active chain and refuses with that explanation before spending the round trip; if the
+user needs DeFi data, switch back with `blockrun_wallet action:"chain" chain:"base"`.
 
 | path | cost | returns |
 |---|---|---|

--- a/skills/modal/SKILL.md
+++ b/skills/modal/SKILL.md
@@ -18,6 +18,13 @@ triggers:
 
 Disposable remote containers (with optional GPU) via Modal, paid per call in USDC. No Modal account, no GPU procurement.
 
+**Base only.** `sol.blockrun.ai` carries the `/v1/modal/*` routes but has no Modal backend
+configured, so every action — create, exec, status, terminate — answers `503`. That reads
+as "the sandbox service is down" rather than "wrong chain", which is exactly the wrong
+conclusion to act on: retrying will not help. The tool checks the active chain first and
+says so. Switch with `blockrun_wallet action:"chain" chain:"base"`. Prices below are Base
+prices and include its per-transaction fee.
+
 ## READ THIS BEFORE SETTING `timeout`
 
 **`timeout` is the BILLED lifetime, charged upfront in full, and never refunded — not an idle timeout.** Above 300s the price switches from a flat rate to **per-hour billing for the entire duration you ask for**, whether you use it or not. Terminating early refunds nothing.


### PR DESCRIPTION
Follow-up to #97. That PR proved the two gateways disagree and guarded the two affected tools in code; the skills still described one catalog.

An agent that ran `blockrun_wallet action:"chain" chain:"solana"` earlier in the session had no written way to know that two of the twenty tools had stopped existing.

## What is actually missing on Solana

Probed against both gateways 2026-08-07:

| Route family | On `sol.blockrun.ai` | Why the status misleads |
|---|---|---|
| `/v1/defillama/*` | absent → `404` | reads as a bad path, so the next move is to re-check the path, not the chain |
| `/v1/modal/*` | present but unconfigured → `503` on all four sandbox actions | reads as an outage, which invites retrying a backend that was never going to answer |

Everything else works on both, about $0.001 cheaper on Solana.

## Where it now says so

- **`crypto-data`** (defi section) and **`modal`** (opening) — at the point of use, because that is where an agent is looking when it needs the answer, not in a chain appendix.
- **`skills/blockrun`** — a short section on what `action:"chain"` actually changes: it repoints every paid call at a different deployment. Carries the coverage table and **both** `llms.txt` URLs, since each gateway's catalog quotes its own pricing convention.
- **`rules/wallet-and-payment.md`** — the mechanics: the budget gate reserves the Base figure on both chains, which over-reserves on Solana (the safe direction — it can refuse an affordable call but never let one past the cap), and `verify-prices` fails the build if Solana ever becomes the dearer one.

## Related, not in this PR

`sol.blockrun.ai/llms.txt` advertises Modal sandbox compute in two places plus its header line, with prices, while the deployment answers `503` for it. It correctly drops `defillama`, so the file is chain-aware — Modal is the one thing that was not pruned when it was not configured. That lives in `blockrun-sol`, and the fix is a product call: configure Modal there, or stop advertising it until it is. Flagged, not decided.

## Verification

`npm run typecheck`, **302/302 tests**, `sync-brand-numbers --check` all green.