### PR TITLE
chore(brand): refresh the snapshot — the markers were rendering a stale catalog

### DIFF
--- a/brand-numbers.json
+++ b/brand-numbers.json
@@ -3,11 +3,11 @@
   "version": 1,
   "models": {
     "chatVisible": 71,
-    "totalVisible": 92,
+    "totalVisible": 93,
     "free": 6,
     "freeWithheld": 19,
     "image": 9,
-    "video": 5,
+    "video": 6,
     "music": 1,
     "speech": 5,
     "soundfx": 1,
@@ -29,6 +29,6 @@
   "savings": {
     "baselineModel": "anthropic/claude-opus-5",
     "ecoVsBaselinePct": 98,
-    "autoVsBaselinePct": 87
+    "autoVsBaselinePct": 88
   }
 }


### PR DESCRIPTION
`brand-numbers.json` in this repo was behind the published artifact, so every `br:` marker here rendered a stale number.

The markers worked correctly — they rendered the input they had. `--check` is offline by design so PR CI stays deterministic, which means it validates against this repo's **own** snapshot; only `--refresh` updates that snapshot.

Opened automatically by [`brand/fanout-brand-numbers.mjs`](https://github.com/BlockRunAI/blockrun/blob/main/brand/fanout-brand-numbers.mjs). Produced by `--refresh`, no hand-edited digits.