### PR TITLE
docs(pricing): Solana-cheaper-than-Base is policy, not drift — close #97's open decision

### DIFF
--- a/scripts/verify-prices.ts
+++ b/scripts/verify-prices.ts
@@ -289,10 +289,14 @@ console.log(
 );
 if (solCheaper) {
   console.log(
-    "  Solana charges no transaction fee, so it is cheaper by exactly that amount.\n" +
-      "  Safe for the budget gate (we reserve the Base figure), but every flat price\n" +
-      "  published in skills/ and the tool descriptions quotes ONE number, which is\n" +
-      "  the Base one. Align the gateways or qualify the docs — do not leave both.",
+    "  Solana charges no transaction fee — DELIBERATE pricing (owner decision,\n" +
+      "  2026-08-08): Solana is meant to run ~$0.001 cheaper per call as an\n" +
+      "  incentive to settle there. Do not \"fix\" this by aligning the gateways.\n" +
+      "  Safe for the budget gate (we reserve the Base figure, the higher one).\n" +
+      "  Published flat prices are Base prices, qualified once in skills/blockrun.\n" +
+      "  The invariant this sweep enforces is direction only: Solana DEARER than\n" +
+      "  Base is a bug and fails the gate, because an agent can switch chains\n" +
+      "  mid-session while the estimators reserve the Base figure.",
   );
 }
 if (solMissing) {

--- a/skills/blockrun/SKILL.md
+++ b/skills/blockrun/SKILL.md
@@ -42,10 +42,11 @@ The tool descriptions in the MCP server carry current prices too; they are gener
 `blockrun_wallet action: "chain"` switches between them mid-session. Two consequences,
 both easy to miss because nothing announces the switch:
 
-**Prices differ.** Every figure in these skills is the **Base** price. Base adds a flat
-per-transaction fee; Solana currently adds none, so the same call runs about $0.001
-cheaper there. Each gateway's own `llms.txt` quotes its own convention — read the one for
-the chain you are on, or just read the 402.
+**Prices differ, on purpose.** Every figure in these skills is the **Base** price. Base
+adds a flat per-transaction fee; Solana deliberately adds none — the ~$0.001-per-call gap
+is pricing policy (an incentive to settle on Solana), not drift, so do not expect it to be
+"fixed". Each gateway's own `llms.txt` quotes its own convention — read the one for the
+chain you are on, or just read the 402.
 
 **Some tools do not exist on Solana at all.** Verified against both gateways
 2026-08-07:


### PR DESCRIPTION
#97 probed both gateways, found Base charges base+\$0.001 while Solana charges base+\$0.000, and left it as an open decision recommending "align the gateways or qualify the docs".

**Owner decision (2026-08-08): the gap is deliberate.** Solana is meant to run ~\$0.001 cheaper per call as an incentive to settle there.

Two prose surfaces updated so the next maintainer doesn't "fix" intentional pricing:
- `verify:prices` advisory: states the policy, and keeps the only invariant that matters — **Solana dearer than Base still fails the gate** (agents switch chains mid-session; estimators reserve the Base figure, the higher one).
- `skills/blockrun`: "Prices differ, **on purpose**" instead of "currently adds none".

No behavior changes. Typecheck + skill-frontmatter/brand tests green.