### PR TITLE
fix(video): clamp the last poll so the 9-min budget cannot outlive its authorization

### DIFF
--- a/src/tools/video.ts
+++ b/src/tools/video.ts
@@ -19,10 +19,38 @@ import {
 
 const BLOCKRUN_API = "https://blockrun.ai/api";
 // Overall budget for the async flow (submit + client-side polling).
-// Seedance 2.5 30s jobs can take 5-8 minutes in production. Keep this one
-// minute below the gateway's 600s payment-authorization window.
+// Seedance 2.5 30s jobs can take 5-8 minutes in production.
+//
+// These four constants are one invariant, not four independent knobs. The
+// signed EIP-3009 authorization dies at startedAt + VIDEO_PAYMENT_AUTH_SECONDS,
+// and settlement happens server-side on the poll that answers "completed" — so
+// a poll still IN FLIGHT past validBefore fails settlement for a video that
+// actually generated (see the blockrun_music entry in CHANGELOG for the same
+// bug). The loop below therefore clamps its last poll to the remaining budget,
+// which keeps worst-case wall time at exactly VIDEO_TOTAL_BUDGET_MS:
+//
+//   VIDEO_TOTAL_BUDGET_MS + 60s margin <= VIDEO_PAYMENT_AUTH_SECONDS
+//
+// Without that clamp the true worst case is budget + interval + poll timeout,
+// which at 540s/5s/90s lands 35s PAST a 600s authorization.
 export const VIDEO_TOTAL_BUDGET_MS = 540_000;
 const POLL_INTERVAL_MS = 5_000;
+export const VIDEO_POLL_TIMEOUT_MS = 90_000;
+// Lifetime of the signed payment authorization, in seconds. Exported so the
+// margin above is asserted against the value the request actually sends,
+// rather than a literal restated in the test.
+export const VIDEO_PAYMENT_AUTH_SECONDS = 600;
+
+// How long the next poll may block, given the budget that is left. Pulled out
+// of the loop so the clamp is unit-testable: inline it sits inside the handler,
+// behind a live 402 + payment + submit chain the test suite deliberately blocks
+// at the network, so its removal would otherwise go uncaught.
+// Returns 0 when the budget is spent, which the caller treats as "stop".
+export function pollTimeoutFor(deadlineMs: number, nowMs: number): number {
+  const remainingMs = deadlineMs - nowMs;
+  if (remainingMs <= 0) return 0;
+  return Math.min(VIDEO_POLL_TIMEOUT_MS, remainingMs);
+}
 
 // Video pricing mirrors the gateway's calculateVideoPrice() + addTransactionFee()
 // (blockrun/src/lib/models.ts). Two regimes:
@@ -484,7 +512,7 @@ Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GC
             resourceDescription: details.resource?.description || "BlockRun Video Generation",
             // Bump to 10 min so the signed authorization stays valid through the
             // async polling window. Default (~5 min) is tight when upstream is slow.
-            maxTimeoutSeconds: Math.max(details.maxTimeoutSeconds || 0, 600),
+            maxTimeoutSeconds: Math.max(details.maxTimeoutSeconds || 0, VIDEO_PAYMENT_AUTH_SECONDS),
             extra: details.extra,
           }
         );
@@ -538,13 +566,22 @@ Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GC
           txHash?: string;
         } | null = null;
 
-        while (Date.now() - startedAt < VIDEO_TOTAL_BUDGET_MS) {
+        const deadline = startedAt + VIDEO_TOTAL_BUDGET_MS;
+
+        while (Date.now() < deadline) {
           await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+
+          // Clamp to the budget that is actually left. Checking the deadline
+          // only at the top of the loop bounds when a poll may START, not when
+          // it finishes — an unclamped 90s poll entered just under the wire
+          // stays in flight well past validBefore.
+          const pollTimeoutMs = pollTimeoutFor(deadline, Date.now());
+          if (pollTimeoutMs === 0) break;
 
           const pollResp = await fetchWithTimeout(pollAbsoluteUrl, {
             method: "GET",
             headers: { "PAYMENT-SIGNATURE": paymentPayload },
-          }, 90_000);
+          }, pollTimeoutMs);
 
           const pollData = await pollResp.json().catch(() => ({})) as {
             status?: string;

--- a/test/video-models.test.ts
+++ b/test/video-models.test.ts
@@ -42,7 +42,15 @@ mock.module("../src/utils/wallet.js", {
   },
 });
 
-const { registerVideoTool, estimateVideoCost, SEEDANCE_RESOLUTIONS, VIDEO_TOTAL_BUDGET_MS } = await import("../src/tools/video.js");
+const {
+  registerVideoTool,
+  estimateVideoCost,
+  SEEDANCE_RESOLUTIONS,
+  VIDEO_TOTAL_BUDGET_MS,
+  VIDEO_POLL_TIMEOUT_MS,
+  VIDEO_PAYMENT_AUTH_SECONDS,
+  pollTimeoutFor,
+} = await import("../src/tools/video.js");
 
 function makeHarness() {
   let handler: ((args: Record<string, unknown>) => Promise<any>) | undefined;
@@ -320,8 +328,60 @@ test("seedance-2.5 ACCEPTS 30s — the headline capability, asserted positively"
 });
 
 test("video polling allows slow 30s jobs while staying inside payment authorization", () => {
-  assert.equal(VIDEO_TOTAL_BUDGET_MS, 9 * 60 * 1000);
-  assert.equal(10 * 60 * 1000 - VIDEO_TOTAL_BUDGET_MS, 60 * 1000);
+  // The capability this budget exists to buy: production Seedance 2.5 30s jobs
+  // measured at 479s, 400s, and 275s. The slowest must fit with room to spare.
+  const SLOWEST_OBSERVED_MS = 479_000;
+  assert.ok(
+    VIDEO_TOTAL_BUDGET_MS > SLOWEST_OBSERVED_MS,
+    `budget ${VIDEO_TOTAL_BUDGET_MS}ms must clear the slowest observed job (${SLOWEST_OBSERVED_MS}ms)`,
+  );
+
+  // The invariant on the other side. Worst-case wall time is bounded by the
+  // budget itself ONLY because the poll loop clamps its last request to the
+  // remaining budget; a poll left in flight past validBefore fails settlement
+  // for a video that actually generated. Derive the authorization window from
+  // the constant the request sends rather than restating 600 as a literal.
+  const authMs = VIDEO_PAYMENT_AUTH_SECONDS * 1000;
+  const MARGIN_MS = 60_000;
+  assert.ok(
+    VIDEO_TOTAL_BUDGET_MS + MARGIN_MS <= authMs,
+    `budget ${VIDEO_TOTAL_BUDGET_MS}ms + ${MARGIN_MS}ms margin must fit the ${authMs}ms authorization`,
+  );
+
+  // The clamp is load-bearing, not cosmetic: unclamped, the real worst case is
+  // budget + interval + poll timeout, which overruns the authorization.
+  assert.ok(
+    VIDEO_TOTAL_BUDGET_MS + VIDEO_POLL_TIMEOUT_MS > authMs,
+    "unclamped worst case would overrun the authorization — do not remove pollTimeoutFor",
+  );
+});
+
+test("the last poll is clamped to the remaining budget, never left in flight past the deadline", () => {
+  const start = 1_000_000;
+  const deadline = start + VIDEO_TOTAL_BUDGET_MS;
+
+  // Early in the window there is plenty of budget: full poll timeout.
+  assert.equal(pollTimeoutFor(deadline, start), VIDEO_POLL_TIMEOUT_MS);
+  assert.equal(pollTimeoutFor(deadline, deadline - VIDEO_POLL_TIMEOUT_MS), VIDEO_POLL_TIMEOUT_MS);
+
+  // The case that motivated this: a poll entered just under the wire. Before
+  // the clamp it got the full 90s and stayed in flight ~90s past the deadline;
+  // now it gets exactly what is left.
+  assert.equal(pollTimeoutFor(deadline, deadline - 1_000), 1_000);
+  assert.equal(pollTimeoutFor(deadline, deadline - 1), 1);
+
+  // Budget spent -> 0, which the loop treats as "stop" rather than issuing a
+  // request that cannot finish in time.
+  assert.equal(pollTimeoutFor(deadline, deadline), 0);
+  assert.equal(pollTimeoutFor(deadline, deadline + 5_000), 0);
+
+  // The property that actually matters, swept across the whole window: a poll
+  // started at any reachable instant finishes on or before the deadline.
+  for (let elapsed = 0; elapsed <= VIDEO_TOTAL_BUDGET_MS; elapsed += 4_999) {
+    const now = start + elapsed;
+    const t = pollTimeoutFor(deadline, now);
+    assert.ok(now + t <= deadline, `poll started at +${elapsed}ms would finish past the deadline`);
+  }
 });
 
 test("durations outside each model's window are refused, both ends", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #110. The 540s polling budget it introduced sits 60s inside the 600s payment authorization only at **loop entry** — the loop body then adds a 5s interval sleep and an unbounded 90s poll timeout, so a poll entered at 539.9s stays in flight until **635s, 35s past `validBefore`**.

- clamp the last poll to the remaining budget via `pollTimeoutFor()`, bounding worst-case wall time at exactly 540s
- name `VIDEO_POLL_TIMEOUT_MS` and `VIDEO_PAYMENT_AUTH_SECONDS`, and use the latter where the authorization is signed (it was a bare `600` literal)
- replace the constants-only budget assertion with the real invariant plus a swept property test

## Why

`validBefore = signingTime + maxTimeoutSeconds` (`@blockrun/llm/dist/index.js:109`), and settlement happens server-side on the poll that answers `"completed"`. A poll outliving the authorization fails settlement for a video that actually generated.

This is not hypothetical — `blockrun_music` shipped the same bug. From CHANGELOG:

> **`fix(music)` — keep the payment authorization valid through the poll window.** ... A slow MiniMax track completing after `validBefore` failed settlement server-side and surfaced as a wrong "fund your wallet" error for a track that actually generated.

That fix raised music **to** 600s to stay inside the window; #110 pushed video back **out** past it.

| | budget | +interval | +poll timeout | worst case | vs 600s auth |
|---|---|---|---|---|---|
| video (before #110) | 300s | 5s | 90s | 395s | +205s safe |
| music | 240s | 5s | 90s | 335s | +265s safe |
| video (after #110) | 540s | 5s | 90s | **635s** | **-35s expired** |
| video (this PR) | 540s | 5s | clamped | **540s** | **+60s safe** |

There's a secondary effect: `video.ts` books local spend the instant it observes `status === "completed"`, without checking settlement succeeded. Safe before, because expiry was unreachable; in the 600–635s tail it would record a ledger charge for USDC that never moved.

## Why not just lower the budget

Staying inside 600s unclamped requires `budget <= 445s`, which fails the 479s production job #110 exists to support. The budget number isn't the lever — the unbounded tail is.

## Notes

`pollTimeoutFor` is extracted rather than inlined so the clamp is testable. Inline it sits inside the handler behind a 402 + payment + submit chain that `test/video-models.test.ts` blocks at the network by design (the `NETWORK_ESCAPE` sentinel).

The tool description's "9 min hard cap" becomes accurate once this lands, so it's unchanged.

## Validation

- `npm test` — 343 passed
- `npm run typecheck`, `npm run build` — clean
- Reverted the `Math.min` to a bare `VIDEO_POLL_TIMEOUT_MS` and confirmed the new test fails (`not ok 15 - the last poll is clamped...`), so it catches the regression it guards
