### PR TITLE
docs(keychain): correct two claims that live-probing did not support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,9 @@ stored key byte-for-byte before unlinking anything — a wrong answer here
 destroys the only copy of a key holding real USDC. And the secret never
 touches `argv` on either platform (`security -i` on macOS, stdin on
 `secret-tool`), because `ps` is world-readable; the `-w` stdin-prompt
-alternative was rejected for silently truncating at 128 bytes, which a base58
-Solana key comes close enough to matter.
+alternative was avoided on its own merits, and is also reported to truncate at
+128 bytes (a figure inherited from Circle's CLI, not reproduced here — nothing
+in this implementation depends on it).
 
 `getChain()` gained a matching last-resort branch. Its Solana autodetect keys
 off a non-empty `.solana-session`, which `strict` deletes — so hardening a

--- a/src/utils/keychain.ts
+++ b/src/utils/keychain.ts
@@ -67,9 +67,13 @@ export function _resetKeychainWarnings(): void {
  * we ever store a JSON blob or a passphrase here.
  *
  * A NEWLINE cannot be escaped this way at all: `security -i` reads one command
- * per line, so an embedded newline ends the command and the remainder parses
- * as the NEXT command. Callers must reject such values outright rather than
- * pretend to quote them — see the guard in keychainStore.
+ * per line, so an embedded newline ends the command mid-value. Measured on
+ * macOS 26.5: the truncated line fails to parse and `security` exits 2 without
+ * storing anything, and the remainder does NOT execute as an injected command
+ * — the quote escaping above already stops a value from closing its own quote.
+ * So this is a correctness guard, not a security boundary: callers reject such
+ * values so the failure is explicit instead of an opaque exit 2. See the guard
+ * in keychainStore.
  */
 export function escapeForSecurityInteractive(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
@@ -112,10 +116,12 @@ export function keychainStore(account: string, secret: string): boolean {
   const platform = os.platform();
 
   // No amount of quoting makes a newline safe for `security -i`, which parses
-  // one command per line: the value would be truncated at the break and the
-  // rest executed as another security(1) subcommand. Refuse and let the caller
-  // keep the file — storing a silently truncated private key would be far
-  // worse than not storing one.
+  // one command per line: the value is cut at the break. Measured on macOS
+  // 26.5 the mangled line simply fails to parse (exit 2, nothing stored) —
+  // it does NOT execute the remainder as an injected command, since the quote
+  // escaping already prevents a value from closing its own quote. Refusing up
+  // front turns that opaque exit 2 into a stated reason, and guards against a
+  // future platform being less strict about a half-parsed line.
   if (/[\r\n]/.test(secret)) {
     warnOnce("Refusing to store a key containing a line break in the OS keychain — keeping the file.");
     return false;
@@ -125,9 +131,12 @@ export function keychainStore(account: string, secret: string): boolean {
     if (platform === "darwin") {
       // `-i` (interactive) mode: the command — including the secret — arrives
       // on stdin. The alternative, a trailing bare `-w` that prompts for the
-      // password on stdin, silently TRUNCATES at 128 bytes; a base58 Solana
-      // key is up to 100 chars today, close enough to that ceiling to be a
-      // future correctness bug. `-U` updates an existing item in place.
+      // password, is reported to truncate at 128 bytes; a base58 Solana key is
+      // up to 100 chars today, close enough to that ceiling to avoid the
+      // prompt path regardless. NOTE: the 128-byte figure is inherited from
+      // Circle's CLI and has NOT been reproduced here — `-i` is preferred on
+      // its own merits (no argv exposure), so nothing depends on it being
+      // exact. `-U` updates an existing item in place.
       const command =
         `add-generic-password -s "${escapeForSecurityInteractive(KEYCHAIN_SERVICE)}" ` +
         `-a "${escapeForSecurityInteractive(account)}" ` +


### PR DESCRIPTION
Comments only, no behaviour change, no version bump — rides the next release.

I probed `/usr/bin/security` on macOS 26.5 with a throwaway keychain and a fake key (the user's own keychain was never touched — it had no `blockrun` entries). Three claims held, two did not.

## Confirmed

- A `security -i` round trip stores the value **byte-for-byte**.
- An absent item really does exit **44**, so `MACOS_ITEM_NOT_FOUND` is right.
- **A locked keychain does not exit 44 at all** — it blocks on a GUI unlock prompt until `spawnSync`'s timeout fires, leaving `status` `null`. That is the likeliest real-world path into the read failure #115 fixed, and `keychainRead` classifies `null` as `error` rather than `absent`. So that fix is load-bearing, and the 0.41.0 bug was reachable by the most ordinary failure there is.

## Wrong, corrected here

The newline guard's comments claimed the remainder of a broken line "executes as another `security(1)` subcommand." **It does not.** With escaping, the injection attempt exits 2 and stores nothing; *without* escaping it also fails, because the quote escaping already prevents a value from closing its own quote.

The guard is still worth keeping — it turns an opaque exit 2 into a stated reason, and hedges a future platform being laxer about a half-parsed line — but it is a correctness improvement, not the security boundary I described in #114.

## Unverified, now labelled

The 128-byte truncation of the bare `-w` prompt is inherited from Circle's CLI and did not reproduce here (my probe hit a usage error). `-i` is preferred for keeping the secret out of `argv` regardless, so nothing depends on the figure. It is now marked as inherited rather than stated as fact.

## Why bother

A wrong security claim in a comment is how someone later deletes the wrong guard for a right-sounding reason.

362 tests pass; typecheck clean.