### PR TITLE
feat(video): support Solana payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to BlockRun MCP will be documented in this file.
 
+## Unreleased
+
+**`blockrun_video` now pays on Solana as well as Base.** The Solana route uses
+the gateway's payment-on-completion async flow: the job POST is never retried,
+idempotent poll GETs tolerate transient disconnects, and their SVM transaction
+is refreshed before its recent blockhash expires. A reactive re-challenge is
+pinned to the original amount and recipient, so a slow Seedance 2.5 render can
+finish inside a 15-minute polling budget without silently repricing or sending
+a payment signature to another origin. Image-to-video also rejects the
+Solana-incompatible `image_url` + `aspect_ratio` combination before payment.
+
 ## 0.41.1
 
 **`BLOCKRUN_KEYCHAIN=strict` could mint a new wallet and orphan your funded

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ blockrun_wallet action:"setup"                  # shows the Solana address + fun
 
 Then send USDC (SPL) on the **Solana** network — from Coinbase (pick "Solana"), Phantom, Solflare, or Backpack. Switch back with `blockrun_wallet action:"chain" chain:"base"`. The server keeps both wallets; switching just changes which one pays.
 
-**Base-only** — these fall back to Base regardless of active chain: `blockrun_music`, `blockrun_speech`, `blockrun_video`, `blockrun_modal`, `blockrun_defi`, paid `blockrun_realface`, paid stock `blockrun_price`, and native Anthropic (`claude-*`) passthrough. In Solana mode they return a "switch to Base" message instead of charging. `blockrun_image` pays on either chain.
+**Base-only** — these fall back to Base regardless of active chain: `blockrun_music`, `blockrun_speech`, `blockrun_modal`, `blockrun_defi`, paid `blockrun_realface`, paid stock `blockrun_price`, and native Anthropic (`claude-*`) passthrough. In Solana mode they return a "switch to Base" message instead of charging. `blockrun_image` and `blockrun_video` pay on either chain.
 
 ---
 

--- a/src/tools/video.ts
+++ b/src/tools/video.ts
@@ -269,9 +269,9 @@ export function registerVideoTool(server: McpServer, budget: BudgetState): void 
   server.registerTool(
     "blockrun_video",
     {
-      description: `Generate short AI videos via BlockRun x402 (async, client-polled).
+      description: `Generate short AI videos via BlockRun x402 on the active Base or Solana chain (async, client-polled).
 
-Turns a text prompt (and optional seed image) into a short MP4 clip. The tool submits the job, then polls until the video is ready (typical total wall-time 60-180s; 9 min hard cap). Payment is settled only when upstream returns a finished video — if the job fails or we give up, you are not charged.
+Turns a text prompt (and optional seed image) into a short MP4 clip. The tool submits the job, then polls until the video is ready (typical total wall-time 60-180s; 9 min Base / 15 min Solana hard cap). Payment is settled only when upstream returns a finished video — if the job fails or we give up, you are not charged.
 
 Models. Every rate below is what you are CHARGED (margin and transaction fee included), at the 720p baseline Seedance renders by default with synced audio:
 - azure/sora-2 (~$0.105/sec, 720p + synced audio, text-to-video) — OpenAI Sora 2 via Azure AI Foundry. duration_seconds must be 4, 8, or 12 (4s default -> ~$0.42/clip). No image_url / RealFace.
@@ -306,13 +306,6 @@ Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GC
       // stale budget; release in finally once the call settles or fails.
       let gate: ReturnType<typeof reserveBudget> | undefined;
       try {
-        if (getChain() !== "base") {
-          return {
-            content: [{ type: "text", text: formatError("blockrun_video currently settles on Base only. Switch BlockRun to Base (for example: run blockrun_wallet with action:chain chain:base) and fund the Base wallet with USDC.") }],
-            isError: true,
-          };
-        }
-
         const selectedModel = model || "xai/grok-imagine-video";
 
         // RealFace guardrails — fail fast client-side instead of round-tripping a 400.
@@ -425,10 +418,6 @@ Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GC
           };
         }
 
-        const privateKey = getOrCreateWalletKey();
-        const account = privateKeyToAccount(privateKey);
-        const submitUrl = `${BLOCKRUN_API}/v1/videos/generations`;
-
         const body: Record<string, unknown> = { model: selectedModel, prompt };
         if (image_url) body.image_url = image_url;
         if (real_face_asset_id) body.real_face_asset_id = real_face_asset_id;
@@ -441,6 +430,72 @@ Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GC
         if (resolution !== undefined && seedanceRes) body.resolution = resolution;
         if (aspect_ratio !== undefined) body.aspect_ratio = aspect_ratio;
         if (last_frame_url) body.last_frame_url = last_frame_url;
+
+        if (getChain() === "solana") {
+          // Loaded only on the Solana branch so Base-only test harnesses and
+          // installations never need to initialize SVM payment dependencies.
+          const { solanaPaidAsyncPost } = await import("../utils/solana-402.js");
+          // The Solana gateway derives image-to-video geometry from the seed
+          // image. Supplying aspect_ratio as well is rejected before quoting;
+          // fail locally so a caller gets the actionable form of that error.
+          if (image_url && aspect_ratio) {
+            return {
+              content: [{ type: "text", text: formatError("Solana image-to-video derives its frame shape from image_url; do not also pass aspect_ratio.") }],
+              isError: true,
+            };
+          }
+
+          const { data, paidUsd, txHash } = await solanaPaidAsyncPost(
+            "/v1/videos/generations",
+            body,
+            300_000,
+            {
+              pollBudgetMs: 900_000,
+              onQuote: (quotedUsd) => {
+                if (quotedUsd === null || quotedUsd <= estimatedCost) return;
+                gate?.release();
+                gate = reserveBudget(budget, agent_id, quotedUsd);
+                if (!gate.allowed) throw new Error(`${gate.reason}. No payment was signed.`);
+              },
+            },
+          );
+          // A terminal response means the gateway has already settled. Book it
+          // before validating the payload so a malformed completed body cannot
+          // make a real Solana charge disappear from the local ledger.
+          recordActualSpend(budget, paidUsd, estimatedCost, agent_id);
+          const clip = (data as { data?: Array<{ url?: string; source_url?: string; duration_seconds?: number; request_id?: string; backed_up?: boolean }>; model?: string }).data?.[0];
+          if (!clip?.url) throw new Error("Completed Solana video response missing video URL");
+          const billedUsd = paidUsd ?? estimatedCost;
+          const lines = [
+            "🎬 Video ready!",
+            `URL: ${clip.url}`,
+            `Duration: ${clip.duration_seconds ?? billedSeconds}s`,
+            `Model: ${(data as { model?: string }).model || selectedModel}`,
+            "Chain: Solana",
+            `Cost: $${billedUsd.toFixed(4)}`,
+            ...(clip.backed_up ? ["Backed up to BlockRun storage (URL is permanent)"] : clip.source_url ? [`Source URL: ${clip.source_url}`] : []),
+            ...(clip.request_id ? [`Request ID: ${clip.request_id}`] : []),
+            ...(txHash ? [`Tx: ${txHash}`] : []),
+          ];
+          return {
+            content: [{ type: "text", text: lines.join("\n") }],
+            structuredContent: {
+              url: clip.url,
+              ...(clip.source_url ? { source_url: clip.source_url } : {}),
+              duration_seconds: clip.duration_seconds,
+              model: (data as { model?: string }).model || selectedModel,
+              cost_usd: billedUsd,
+              chain: "solana",
+              ...(clip.request_id ? { request_id: clip.request_id } : {}),
+              ...(clip.backed_up !== undefined ? { backed_up: clip.backed_up } : {}),
+              ...(txHash ? { txHash } : {}),
+            },
+          };
+        }
+
+        const privateKey = getOrCreateWalletKey();
+        const account = privateKeyToAccount(privateKey);
+        const submitUrl = `${BLOCKRUN_API}/v1/videos/generations`;
 
         // Step 1: get 402 with price + requirements
         const resp402 = await fetchWithTimeout(submitUrl, {

--- a/src/utils/solana-402.ts
+++ b/src/utils/solana-402.ts
@@ -25,6 +25,79 @@ export interface SolanaPaidPostResult {
   data: Record<string, unknown>;
   /** Actual USD charged, from the 402 quote. Null when unparseable — callers fall back to their estimate. */
   paidUsd: number | null;
+  /** Settlement receipt from the terminal response, when the gateway returns one. */
+  txHash?: string;
+}
+
+export interface SolanaPaidAsyncPostOptions {
+  /** Total time allowed for submit + polling. Defaults to 15 minutes. */
+  pollBudgetMs?: number;
+  /** Delay between idempotent poll GETs. Defaults to 5 seconds. */
+  pollIntervalMs?: number;
+  /** Refresh the SVM transaction before its recent blockhash goes stale. */
+  resignIntervalMs?: number;
+  /** Maximum reactive re-signs after a completed poll rejects a stale signature. */
+  maxReactiveResigns?: number;
+  /** Called after the authoritative quote is parsed and before anything is signed. */
+  onQuote?: (quotedUsd: number | null) => void;
+}
+
+type SolanaPaymentContext = {
+  paymentRequired: ReturnType<typeof parsePaymentRequired>;
+  details: ReturnType<typeof extractPaymentDetails>;
+  paidUsd: number | null;
+};
+
+async function readPaymentRequired(response: Response): Promise<string> {
+  let header = response.headers.get("payment-required") || response.headers.get("PAYMENT-REQUIRED");
+  if (!header) {
+    const body = await response.json().catch(() => null) as Record<string, unknown> | null;
+    if (body && (body.accepts || body.x402Version)) {
+      header = Buffer.from(JSON.stringify(body)).toString("base64");
+    }
+  }
+  if (!header) throw new PaymentError("402 response but no payment requirements found");
+  return header;
+}
+
+function parseSolanaChallenge(paymentHeader: string): SolanaPaymentContext {
+  const paymentRequired = parsePaymentRequired(paymentHeader);
+  const details = extractPaymentDetails(paymentRequired, SOLANA_NETWORK);
+  if (!details.network?.startsWith("solana:")) {
+    throw new PaymentError(`Expected a Solana payment quote, got network: ${details.network}. The endpoint may not support Solana settlement yet.`);
+  }
+  const feePayer = (details.extra as { feePayer?: string } | undefined)?.feePayer;
+  if (!feePayer) throw new PaymentError("Missing feePayer in the 402 quote's extra field");
+  return { paymentRequired, details, paidUsd: amountToUsd(details.amount) };
+}
+
+async function signSolanaChallenge(
+  context: SolanaPaymentContext,
+  url: string,
+  privateKey: string,
+): Promise<string> {
+  const apiUrl = SolanaLLMClient.SOLANA_API_URL;
+  const { paymentRequired, details } = context;
+  const feePayer = (details.extra as { feePayer: string }).feePayer;
+  const quotedResource = details.resource?.url;
+  const resourceUrl = quotedResource && quotedResource.startsWith(apiUrl) ? quotedResource : url;
+  const fromAddress = await solanaPublicKey(privateKey);
+  const secretKey = await solanaKeyToBytes(privateKey);
+  const extensions = (paymentRequired as unknown as Record<string, unknown>).extensions as Record<string, unknown> | undefined;
+  return createSolanaPaymentPayload(
+    secretKey,
+    fromAddress,
+    details.recipient,
+    details.amount,
+    feePayer,
+    {
+      resourceUrl,
+      resourceDescription: details.resource?.description || "BlockRun Solana API call",
+      maxTimeoutSeconds: details.maxTimeoutSeconds || 300,
+      extra: details.extra as Record<string, unknown>,
+      ...(extensions ? { extensions } : {}),
+    },
+  );
 }
 
 /**
@@ -70,51 +143,14 @@ export async function solanaPaidPost(
   // The gateway sends the requirements both as a PAYMENT-REQUIRED header and
   // as the JSON body — fall back to the body (base64-wrapped, the shape
   // parsePaymentRequired expects) when a proxy strips the header.
-  let prHeader = quoteResp.headers.get("payment-required") || quoteResp.headers.get("PAYMENT-REQUIRED");
-  if (!prHeader) {
-    const respBody = await quoteResp.json().catch(() => null) as Record<string, unknown> | null;
-    if (respBody && (respBody.accepts || respBody.x402Version)) {
-      prHeader = Buffer.from(JSON.stringify(respBody)).toString("base64");
-    }
-  }
-  if (!prHeader) throw new PaymentError("402 response but no payment requirements found");
-
-  const paymentRequired = parsePaymentRequired(prHeader);
-  const details = extractPaymentDetails(paymentRequired, SOLANA_NETWORK);
-  if (!details.network?.startsWith("solana:")) {
-    throw new PaymentError(`Expected a Solana payment quote, got network: ${details.network}. The endpoint may not support Solana settlement yet.`);
-  }
-  const feePayer = (details.extra as { feePayer?: string } | undefined)?.feePayer;
-  if (!feePayer) throw new PaymentError("Missing feePayer in the 402 quote's extra field");
+  const prHeader = await readPaymentRequired(quoteResp);
+  const context = parseSolanaChallenge(prHeader);
 
   // Hand the caller the REAL quoted price before we sign/pay, so it can re-check
   // the marked-up Solana amount against its budget cap and abort (by throwing)
   // if it would overshoot — the amount is only known now, after the quote.
-  opts?.onQuote?.(amountToUsd(details.amount));
-
-  // Only sign for a resource on the gateway's own origin — a spoofed quote must
-  // not relabel the payment as authorizing some other resource.
-  const quotedResource = details.resource?.url;
-  const resourceUrl = quotedResource && quotedResource.startsWith(apiUrl) ? quotedResource : url;
-
-  const fromAddress = await solanaPublicKey(privateKey);
-  const secretKey = await solanaKeyToBytes(privateKey);
-  const extensions = (paymentRequired as unknown as Record<string, unknown>).extensions as Record<string, unknown> | undefined;
-
-  const paymentPayload = await createSolanaPaymentPayload(
-    secretKey,
-    fromAddress,
-    details.recipient,
-    details.amount,
-    feePayer,
-    {
-      resourceUrl,
-      resourceDescription: details.resource?.description || "BlockRun Solana API call",
-      maxTimeoutSeconds: details.maxTimeoutSeconds || 300,
-      extra: details.extra as Record<string, unknown>,
-      ...(extensions ? { extensions } : {}),
-    },
-  );
+  opts?.onQuote?.(context.paidUsd);
+  const paymentPayload = await signSolanaChallenge(context, url, privateKey);
 
   // Step 2: paid request. The signed SPL transaction embeds a recent blockhash
   // (~60-90s validity); the gateway settles optimistically in parallel with
@@ -134,5 +170,141 @@ export async function solanaPaidPost(
   }
 
   const data = await resp.json() as Record<string, unknown>;
-  return { data, paidUsd: amountToUsd(details.amount) };
+  return { data, paidUsd: context.paidUsd };
+}
+
+/**
+ * Solana x402 flow for payment-on-completion media endpoints such as video.
+ * The paid POST is issued exactly once. Only idempotent poll GETs are retried;
+ * their SVM transaction is periodically refreshed because a recent blockhash
+ * expires long before a slow Seedance 2.5 job can finish.
+ */
+export async function solanaPaidAsyncPost(
+  endpoint: string,
+  body: Record<string, unknown>,
+  requestTimeoutMs: number,
+  opts: SolanaPaidAsyncPostOptions = {},
+): Promise<SolanaPaidPostResult> {
+  const privateKey = process.env.SOLANA_WALLET_KEY || loadSolanaWallet();
+  if (!privateKey) {
+    throw new PaymentError('No Solana wallet found. Run blockrun_wallet with action:"setup" to provision one.');
+  }
+
+  const apiUrl = SolanaLLMClient.SOLANA_API_URL;
+  const url = `${apiUrl}${endpoint}`;
+  const quoteResp = await fetchWithTimeout(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }, QUOTE_TIMEOUT_MS);
+  if (quoteResp.status !== 402) {
+    const data = await quoteResp.json().catch(() => ({})) as Record<string, unknown>;
+    if (quoteResp.ok) return { data, paidUsd: 0 };
+    throw new Error(`Unexpected status ${quoteResp.status} (the endpoint did not return a quote): ${JSON.stringify(data)}`);
+  }
+
+  const paymentHeader = await readPaymentRequired(quoteResp);
+  const original = parseSolanaChallenge(paymentHeader);
+  if (original.paidUsd === null) {
+    throw new PaymentError(`The gateway's Solana quote carried an unreadable amount (${JSON.stringify(original.details.amount)}); refusing to sign it.`);
+  }
+  opts.onQuote?.(original.paidUsd);
+  let paymentPayload = await signSolanaChallenge(original, url, privateKey);
+
+  const submitResp = await fetchWithTimeout(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "PAYMENT-SIGNATURE": paymentPayload },
+    body: JSON.stringify(body),
+  }, requestTimeoutMs);
+  if (submitResp.status === 402) throw new PaymentError("Payment was rejected. Check your Solana USDC balance.");
+
+  const submitData = await submitResp.json().catch(() => ({})) as Record<string, unknown>;
+  if (submitResp.status === 200) {
+    return {
+      data: submitData,
+      paidUsd: original.paidUsd,
+      txHash: submitResp.headers.get("x-payment-receipt") || undefined,
+    };
+  }
+  if (submitResp.status !== 202) {
+    throw new Error(`API error ${submitResp.status}: ${JSON.stringify(submitData)}`);
+  }
+
+  const pollPath = typeof submitData.poll_url === "string" ? submitData.poll_url : "";
+  if (!pollPath) throw new Error(`Submit response missing id/poll_url: ${JSON.stringify(submitData)}`);
+  const pollUrl = new URL(pollPath, apiUrl);
+  if (pollUrl.origin !== new URL(apiUrl).origin) {
+    throw new PaymentError(`Refusing to send a payment signature to an off-gateway poll URL: ${pollUrl.origin}`);
+  }
+
+  const pollBudgetMs = opts.pollBudgetMs ?? 900_000;
+  const pollIntervalMs = opts.pollIntervalMs ?? 5_000;
+  const resignIntervalMs = opts.resignIntervalMs ?? 45_000;
+  let resignsLeft = opts.maxReactiveResigns ?? 3;
+  const deadline = Date.now() + pollBudgetMs;
+  let lastStatus = typeof submitData.status === "string" ? submitData.status : "queued";
+  let lastSignedAt = Date.now();
+
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+
+    // Proactively refresh only the transaction/blockhash. The authorized
+    // amount and recipient remain pinned to the original 402 challenge.
+    if (Date.now() - lastSignedAt >= resignIntervalMs) {
+      try {
+        paymentPayload = await signSolanaChallenge(original, url, privateKey);
+        lastSignedAt = Date.now();
+      } catch {
+        // Best effort: keep polling with the previous signature. A terminal
+        // 402 below obtains a fresh challenge and reports a precise failure.
+      }
+    }
+
+    let pollResp: Response;
+    try {
+      pollResp = await fetchWithTimeout(pollUrl.toString(), {
+        method: "GET",
+        headers: { "PAYMENT-SIGNATURE": paymentPayload },
+      }, Math.min(requestTimeoutMs, remaining));
+    } catch {
+      // Polling is idempotent and settlement has not been observed. A transient
+      // disconnect is safe to retry inside the existing deadline.
+      continue;
+    }
+
+    if (pollResp.status === 402 && resignsLeft > 0) {
+      resignsLeft--;
+      const challenge = await fetchWithTimeout(pollUrl.toString(), { method: "GET" }, Math.min(requestTimeoutMs, remaining));
+      if (challenge.status === 402) {
+        const freshHeader = await readPaymentRequired(challenge);
+        const fresh = parseSolanaChallenge(freshHeader);
+        if (fresh.details.amount !== original.details.amount || fresh.details.recipient !== original.details.recipient) {
+          throw new PaymentError("The refreshed poll challenge changed the payment amount or recipient; refusing to re-authorize it.");
+        }
+        paymentPayload = await signSolanaChallenge(fresh, pollUrl.toString(), privateKey);
+        lastSignedAt = Date.now();
+        continue;
+      }
+    }
+    if (pollResp.status === 402) throw new PaymentError("Payment was rejected while settling the completed Solana video.");
+
+    const pollData = await pollResp.json().catch(() => ({})) as Record<string, unknown>;
+    if (typeof pollData.status === "string") lastStatus = pollData.status;
+    if (lastStatus === "failed") {
+      throw new Error(`Video generation failed upstream: ${String(pollData.error || "unknown")}. No payment was taken.`);
+    }
+    if (lastStatus === "completed") {
+      return {
+        data: pollData,
+        paidUsd: original.paidUsd,
+        txHash: pollResp.headers.get("x-payment-receipt") || undefined,
+      };
+    }
+    if (pollResp.status === 202 || pollResp.status === 504 || pollResp.ok) continue;
+    throw new Error(`Video poll error ${pollResp.status}: ${JSON.stringify(pollData)}`);
+  }
+
+  throw new Error(`Video generation did not complete within ${Math.round(pollBudgetMs / 1000)}s (last status: ${lastStatus}). Settlement only happens on completion, so no payment was taken.`);
 }

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -218,11 +218,11 @@ export async function ensureBothWallets(): Promise<{
 
 /**
  * Guard for capabilities the Solana SDK path doesn't cover yet (price data,
- * video, music, speech, RealFace). Returns an actionable message when the
+ * music, speech, RealFace). Returns an actionable message when the
  * active chain is Solana, otherwise null. Tools call this before paying so
  * they never silently drain the Base wallet while the user believes they're
- * on Solana. Image generation is NOT on this list — it pays on either chain
- * via utils/solana-402.ts.
+ * on Solana. Image and video generation are NOT on this list — they pay on
+ * either chain via utils/solana-402.ts.
  */
 export function baseOnlyMessage(capability: string): string | null {
   if (getChain() === "solana") {

--- a/test/solana-402-async.test.ts
+++ b/test/solana-402-async.test.ts
@@ -1,0 +1,94 @@
+// Run with: npm test  (tsx --experimental-test-module-mocks --test)
+import { test, mock } from "node:test";
+import assert from "node:assert/strict";
+
+function headers(map: Record<string, string> = {}) {
+  const lower = Object.fromEntries(Object.entries(map).map(([key, value]) => [key.toLowerCase(), value]));
+  return { get: (name: string) => lower[name.toLowerCase()] ?? null };
+}
+
+let script: Array<() => unknown> = [];
+let requests: Array<{ url: string; method: string }> = [];
+let signaturesCreated = 0;
+mock.module("../src/utils/http.js", {
+  namedExports: {
+    fetchWithTimeout: async (url: string, init: { method?: string }) => {
+      requests.push({ url, method: init.method || "GET" });
+      const next = script.shift();
+      if (!next) throw new Error("UNEXPECTED_NETWORK_CALL");
+      return next();
+    },
+  },
+});
+
+mock.module("@blockrun/llm", {
+  namedExports: {
+    SolanaLLMClient: { SOLANA_API_URL: "https://sol.blockrun.ai/api" },
+    PaymentError: class PaymentError extends Error {},
+    SOLANA_NETWORK: "solana:mainnet",
+    loadSolanaWallet: () => "test-solana-key",
+    solanaPublicKey: async () => "payer",
+    solanaKeyToBytes: async () => new Uint8Array(64),
+    createSolanaPaymentPayload: async () => { signaturesCreated++; return "signed-svm-payment"; },
+    parsePaymentRequired: () => ({}),
+    extractPaymentDetails: () => ({
+      network: "solana:mainnet",
+      recipient: "recipient",
+      amount: "500000",
+      extra: { feePayer: "fee-payer" },
+      resource: { url: "https://sol.blockrun.ai/api/v1/videos/generations" },
+    }),
+  },
+});
+
+const { solanaPaidAsyncPost } = await import("../src/utils/solana-402.js");
+const quote = () => ({ status: 402, ok: false, headers: headers({ "payment-required": "quote" }), json: async () => ({}) });
+const submit = (pollUrl: string) => ({ status: 202, ok: true, headers: headers(), json: async () => ({ id: "vid_1", status: "queued", poll_url: pollUrl }) });
+const poll = (status: string, extra: Record<string, unknown> = {}) => ({ status: status === "completed" ? 200 : 202, ok: true, headers: headers({ "x-payment-receipt": "solana-tx" }), json: async () => ({ status, ...extra }) });
+
+test("async Solana flow submits once, retries only idempotent polls, and returns the receipt", async () => {
+  requests = [];
+  signaturesCreated = 0;
+  script = [
+    quote,
+    () => submit("/api/v1/videos/poll/vid_1"),
+    () => { throw new TypeError("transient disconnect"); },
+    () => poll("in_progress"),
+    () => poll("completed", { data: [{ url: "https://blockrun.ai/media/vid_1.mp4" }] }),
+  ];
+  const result = await solanaPaidAsyncPost("/v1/videos/generations", { prompt: "test" }, 100, {
+    pollBudgetMs: 100,
+    pollIntervalMs: 1,
+    resignIntervalMs: 10_000,
+  });
+  assert.equal(result.paidUsd, 0.5);
+  assert.equal(result.txHash, "solana-tx");
+  assert.equal((result.data.data as Array<{ url: string }>)[0].url, "https://blockrun.ai/media/vid_1.mp4");
+  assert.equal(requests.filter((request) => request.method === "POST").length, 2, "probe + one paid submit only");
+  assert.equal(requests.filter((request) => request.method === "GET").length, 3);
+  assert.equal(signaturesCreated, 1);
+});
+
+test("a gateway cannot redirect the payment-bearing poll to another origin", async () => {
+  requests = [];
+  script = [quote, () => submit("https://evil.example/poll/vid_1")];
+  await assert.rejects(
+    solanaPaidAsyncPost("/v1/videos/generations", { prompt: "test" }, 100, { pollBudgetMs: 10, pollIntervalMs: 1 }),
+    /off-gateway poll URL/,
+  );
+  assert.equal(requests.some((request) => request.url.includes("evil.example")), false);
+});
+
+test("the authoritative quote hook runs before any Solana payment is signed", async () => {
+  requests = [];
+  signaturesCreated = 0;
+  script = [quote];
+  await assert.rejects(
+    solanaPaidAsyncPost("/v1/videos/generations", { prompt: "test" }, 100, {
+      onQuote: () => { throw new Error("budget exceeded"); },
+    }),
+    /budget exceeded/,
+  );
+  assert.equal(signaturesCreated, 0);
+  assert.equal(requests.length, 1);
+});

--- a/test/video-solana.test.ts
+++ b/test/video-solana.test.ts
@@ -1,0 +1,108 @@
+// Run with: npm test  (tsx --experimental-test-module-mocks --test)
+import { test, mock } from "node:test";
+import assert from "node:assert/strict";
+import type { BudgetState } from "../src/types.js";
+
+let solanaCalls = 0;
+let quoteUsd = 0.5;
+let completedHasUrl = true;
+
+mock.module("../src/utils/wallet.js", {
+  namedExports: {
+    getChain: () => "solana",
+    getOrCreateWalletKey: () => { throw new Error("Base wallet must not be touched on the Solana route"); },
+    getWalletInfo: async () => ({ address: "So1anaTest" }),
+  },
+});
+mock.module("../src/utils/solana-402.js", {
+  namedExports: {
+    solanaPaidAsyncPost: async (_endpoint: string, _body: unknown, _timeout: number, opts: { onQuote?: (usd: number) => void }) => {
+      solanaCalls++;
+      opts.onQuote?.(quoteUsd);
+      return {
+        paidUsd: quoteUsd,
+        txHash: "solana-tx",
+        data: {
+          model: "bytedance/seedance-2.5",
+          status: "completed",
+          data: completedHasUrl ? [{ url: "https://blockrun.ai/media/solana.mp4", duration_seconds: 15, backed_up: true }] : [],
+        },
+      };
+    },
+  },
+});
+mock.module("../src/utils/http.js", {
+  namedExports: { fetchWithTimeout: async () => { throw new Error("Base HTTP route reached"); }, isTimeoutError: () => false },
+});
+mock.module("../src/utils/ssrf.js", {
+  namedExports: { isBlockedFetchHostResolved: async () => false, isBlockedFetchHost: () => false },
+});
+mock.module("@blockrun/llm", {
+  namedExports: {
+    createPaymentPayload: async () => "unused",
+    parsePaymentRequired: () => ({}),
+    extractPaymentDetails: () => ({}),
+  },
+});
+
+const { registerVideoTool } = await import("../src/tools/video.js");
+
+function makeHarness(limit: number | null = null) {
+  let handler: ((args: Record<string, unknown>) => Promise<any>) | undefined;
+  const server = { registerTool: (_n: string, _c: unknown, h: any) => { handler = h; } } as any;
+  const budget: BudgetState = { limit, spent: 0, calls: 0, agents: new Map() };
+  registerVideoTool(server, budget);
+  return { call: (args: Record<string, unknown>) => handler!(args), budget };
+}
+
+test("Solana video uses the async SVM route and reports the settled result", async () => {
+  solanaCalls = 0;
+  quoteUsd = 0.5;
+  completedHasUrl = true;
+  const { call, budget } = makeHarness();
+  const res = await call({ prompt: "a rainy alley", model: "bytedance/seedance-2.5", duration_seconds: 15 });
+  assert.notEqual(res.isError, true, res.content?.[0]?.text);
+  assert.equal(solanaCalls, 1);
+  assert.equal(res.structuredContent.chain, "solana");
+  assert.equal(res.structuredContent.url, "https://blockrun.ai/media/solana.mp4");
+  assert.equal(res.structuredContent.txHash, "solana-tx");
+  assert.equal(res.structuredContent.cost_usd, 0.5);
+  assert.equal(budget.spent, 0.5);
+});
+
+test("Solana image-to-video rejects image_url plus aspect_ratio before payment", async () => {
+  solanaCalls = 0;
+  const { call, budget } = makeHarness();
+  const res = await call({
+    prompt: "a rainy alley",
+    model: "bytedance/seedance-2.5",
+    duration_seconds: 15,
+    image_url: "https://example.com/keyframe.png",
+    aspect_ratio: "16:9",
+  });
+  assert.equal(res.isError, true);
+  assert.match(res.content[0].text, /do not also pass aspect_ratio/);
+  assert.equal(solanaCalls, 0);
+  assert.equal(budget.spent, 0);
+});
+
+test("the authoritative Solana quote is re-checked against the budget before signing", async () => {
+  solanaCalls = 0;
+  quoteUsd = 5;
+  const { call, budget } = makeHarness(1);
+  const res = await call({ prompt: "a rainy alley", model: "bytedance/seedance-2.5", duration_seconds: 4 });
+  assert.equal(res.isError, true);
+  assert.match(res.content[0].text, /budget|limit/i);
+  assert.equal(budget.spent, 0);
+});
+
+test("a malformed completed Solana payload still books the settled charge", async () => {
+  quoteUsd = 0.5;
+  completedHasUrl = false;
+  const { call, budget } = makeHarness();
+  const res = await call({ prompt: "a rainy alley", model: "bytedance/seedance-2.5", duration_seconds: 15 });
+  assert.equal(res.isError, true);
+  assert.match(res.content[0].text, /missing video URL/);
+  assert.equal(budget.spent, 0.5);
+  completedHasUrl = true;
+});


### PR DESCRIPTION
## Summary
- route blockrun_video through the active Solana wallet as well as Base
- add payment-on-completion polling with transient GET retries and fresh SVM signatures for long Seedance jobs
- pin reactive re-challenges to the original amount/recipient and reject off-origin poll URLs
- re-check the authoritative quote before signing and preserve settled spend on malformed terminal payloads
- reject Solana image-to-video image_url + aspect_ratio conflicts before payment

## Tests
- full suite: 367 passed, 0 failed
- production tsup build passed
- added focused Solana async-payment and video-handler regression tests