### PR TITLE
perf(schema): drop the draft-07 $schema header from every tool

### DIFF
--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -26,6 +26,7 @@ import { registerDefiTool } from "./tools/defi.js";
 import { registerPolymarketReadTool, registerPolymarketTool } from "./tools/polymarket.js";
 import { resolveTools, type ToolName } from "./profiles.js";
 import { registerAppResources } from "./apps.js";
+import { stripJsonSchemaDialect } from "./utils/strip-schema-dialect.js";
 
 /**
  * Initialize the MCP server. The active tool `profile` (resolved from
@@ -39,6 +40,10 @@ export function initializeMcpServer(
   server: McpServer,
   profileArgs?: { argv?: string[]; env?: NodeJS.ProcessEnv },
 ): { profile: string; tools: ToolName[] } {
+  // Must run before any tool is registered — that is when the SDK lazily
+  // installs the tools/list handler this wraps.
+  stripJsonSchemaDialect(server);
+
   // Default global spend cap from BLOCKRUN_BUDGET_LIMIT (USD). Without it the
   // ledger starts unlimited; the cap is in-memory and resets when the (npx-spawned)
   // process restarts, so an operator who wants a hard ceiling should set the env.

--- a/src/utils/strip-schema-dialect.ts
+++ b/src/utils/strip-schema-dialect.ts
@@ -1,0 +1,42 @@
+// src/utils/strip-schema-dialect.ts
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+/**
+ * Drop the `"$schema": "http://json-schema.org/draft-07/schema#"` header the
+ * SDK's zod→JSON-Schema conversion stamps onto every tool's inputSchema.
+ *
+ * It is a dialect declaration: MCP clients validate the schema either way, and
+ * the Anthropic API ignores it outright. But it is emitted once per tool and
+ * lands in the model's context on every turn — 14 tokens x 20 tools = 280
+ * tokens of pure boilerplate in a 13.8K-token tool block.
+ *
+ * The SDK gives no option to suppress it, so we intercept the `tools/list`
+ * handler as it is installed. This uses only the public `setRequestHandler`,
+ * and if a future SDK stops routing through `ListToolsRequestSchema` the
+ * wrapper simply stops matching — the `$schema` key comes back and nothing
+ * breaks. Must run BEFORE the first tool is registered, since that is when the
+ * SDK lazily installs the handler.
+ */
+export function stripJsonSchemaDialect(server: McpServer): void {
+  // Purely an optimization: if the low-level server isn't there to wrap (a
+  // test double, a future SDK shape), skip it rather than throw. The worst
+  // case is that `$schema` stays in the payload.
+  const lowLevel = server.server;
+  if (typeof lowLevel?.setRequestHandler !== "function") return;
+  const original = lowLevel.setRequestHandler.bind(lowLevel);
+
+  lowLevel.setRequestHandler = ((requestSchema: unknown, handler: (...args: unknown[]) => unknown) => {
+    if (requestSchema !== ListToolsRequestSchema) {
+      return original(requestSchema as never, handler as never);
+    }
+    return original(requestSchema as never, (async (...args: unknown[]) => {
+      const result = await handler(...args) as { tools?: { inputSchema?: Record<string, unknown> }[] };
+      // The SDK rebuilds these objects on every call, so mutating is safe.
+      for (const tool of result?.tools ?? []) {
+        if (tool.inputSchema) delete tool.inputSchema.$schema;
+      }
+      return result;
+    }) as never);
+  }) as typeof lowLevel.setRequestHandler;
+}

--- a/test/schema-dialect.test.ts
+++ b/test/schema-dialect.test.ts
@@ -1,0 +1,56 @@
+// Run with: npm test  (tsx --test)
+//
+// The SDK's zod->JSON-Schema conversion stamps a draft-07 `$schema` header on
+// every tool's inputSchema. Clients ignore it, but it ships in the tool block
+// the model carries on every turn — 300 tokens across the full profile.
+// stripJsonSchemaDialect() removes it by wrapping the tools/list handler, so
+// the wrapper is identity-matched against the SDK's request schema: an SDK
+// upgrade that reshapes that path would silently put the header back. This
+// test is what notices.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { initializeMcpServer } from "../src/mcp-handler.js";
+
+async function listTools(argv: string[]) {
+  const server = new McpServer({ name: "test", version: "0.0.0" });
+  initializeMcpServer(server, { argv, env: {} });
+  const [clientSide, serverSide] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  await Promise.all([server.connect(serverSide), client.connect(clientSide)]);
+  const { tools } = await client.listTools();
+  await client.close();
+  return tools;
+}
+
+test("no tool advertises a $schema dialect header", async () => {
+  const tools = await listTools([]);
+  assert.equal(tools.length, 20);
+  const offenders = tools
+    .filter((t) => "$schema" in (t.inputSchema as Record<string, unknown>))
+    .map((t) => t.name);
+  assert.deepEqual(offenders, []);
+});
+
+test("stripping the dialect leaves the rest of the schema intact", async () => {
+  const tools = await listTools([]);
+  const markets = tools.find((t) => t.name === "blockrun_markets");
+  assert.ok(markets, "blockrun_markets should be in the full profile");
+
+  const schema = markets.inputSchema as {
+    type?: string;
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
+  assert.equal(schema.type, "object");
+  assert.deepEqual(schema.required, ["path"]);
+  assert.ok(schema.properties?.path, "path property survives");
+  assert.ok(schema.properties?.agent_id, "agent_id property survives");
+
+  // Annotations and MCP App metadata ride alongside inputSchema — the wrapper
+  // must not disturb them.
+  assert.ok(markets.annotations, "annotations survive");
+  assert.equal(tools.filter((t) => t._meta?.ui).length, 2);
+});


### PR DESCRIPTION
## What

Removes the `"$schema": "http://json-schema.org/draft-07/schema#"` header from every tool's `inputSchema`.

Clients validate the schema either way and the Anthropic API ignores it, but it ships in the tool block the model carries in its context on every turn.

## The number

Measured against the built server — real MCP handshake (`initialize` → `notifications/initialized` → `tools/list`), tokenizing the model-visible projection `{name, description, input_schema}` with the `mcp__blockrun__` prefix the host adds, `o200k_base`. Before and after measured the same way, not subtracted:

| Profile | Tools | Before | After | Saved |
|---|---:|---:|---:|---:|
| **full** (default) | 20 | 13,200 | **12,900** | −300 |
| trading | 9 | 5,689 | 5,554 | −135 |
| media | 7 | 5,541 | 5,436 | −105 |
| research | 6 | 3,114 | 3,024 | −90 |
| chat | 3 | 1,969 | 1,924 | −45 |

Exactly 15 tokens per tool.

This is one item from a wider tool-schema audit. The larger prize — route catalogues and per-model pricing tables living in tool descriptions, which are ~53% of the block — is a separate batch, because it changes what the model reads and needs its own review.

## Why it isn't a one-line deletion

It isn't our string. The SDK's zod→JSON-Schema conversion stamps it on, and exposes no option to suppress it — verified on `@modelcontextprotocol/sdk` 1.29.0 for **both** the zod v4 branch (`z4mini.toJSONSchema`) and the zod v3 branch (vendored `zod-to-json-schema`).

So `stripJsonSchemaDialect()` wraps the `tools/list` handler as it is installed, using only the public `setRequestHandler`. Two deliberate properties:

- **Never load-bearing.** The wrapper is identity-matched against `ListToolsRequestSchema`. If a future SDK stops routing through it, the wrapper stops matching and the header simply comes back. Nothing breaks.
- **Degrades to a no-op.** It skips when there is no low-level server to wrap — the `tool-annotations` and `apps` suites pass a minimal fake `McpServer`, and an earlier version that assumed `server.server` exists broke 8 of them.

## Tests

`test/schema-dialect.test.ts` (2 tests). Because the wrapper is identity-matched, an SDK bump could silently restore the header with nobody noticing — an optimization that reverts unobserved is worse than not having done it. These tests are what notices.

## No behaviour change

- **425/425 tests pass** (423 before, +2 new).
- `annotations` on all 20 tools and `_meta.ui` on the 2 app tools are untouched.
- Live stdio check: schema validation still rejects a missing required argument and a mistyped argument (`-32602` both), and a free tool call still succeeds. No paid tool was called.

## Note on the figures

An earlier revision of this PR quoted 13,765 → 13,465. Those numbers were 4.4% high: the measuring script used Python's `json.dumps`, which defaults to `ensure_ascii=True` and re-encodes every `—`, `→` and `·` as `\uXXXX` — six ASCII characters where the model sees one glyph. Independently reproduced with a `JSON.stringify`-based harness, which matches the wire. The **saving is unaffected at −300**, since the removed string is pure ASCII; only the totals it is measured against moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUL3ExR4Nz7uebxKaKwjDi