### PR TITLE
fix(pricing): sync Grok rates to xAI's published rate (blockrun#503)

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -68,8 +68,8 @@ export const BASE_RPC_URLS = [
 // ZAI (4): glm-5.2 ($1.4/$4.4, 1M), glm-5.1 ($1.4/$4.4), glm-5 ($1/$3.2 —
 //   Z.AI RAISED the list rate; still the cheapest ZAI, but no longer a
 //   cheap-tier pick), glm-5-turbo ($1.2/$4)
-// xAI (3): grok-4.5 ($2.5/$9, 500K, native search), grok-4.3 ($1.5/$4, 1M),
-//   grok-build-0.1 ($1.5/$3, coding)
+// xAI (3): grok-4.5 ($2/$6, 500K, native search), grok-4.3 ($1.25/$2.5, 1M),
+//   grok-build-0.1 ($1/$2, coding)
 // MiniMax (2): minimax-m3 ($0.3/$1.2, 1M), minimax-m2.7 ($0.3/$1.2, 200K)
 // Qwen (3): qwen3.7-max ($1.475/$4.425, 1M), qwen3.7-plus ($0.32/$1.28, 1M),
 //   qwen3.7-flash ($0.03/$0.13, 1M — the cheapest PAID model in the catalogue;
@@ -204,9 +204,9 @@ export const CHAT_PRICE_PER_MTOKEN: Record<string, { input: number; output: numb
   "google/gemini-2.5-flash": { input: 0.3, output: 2.5 },
   "google/gemini-3.5-flash-lite": { input: 0.3, output: 2.5 },
   "moonshot/kimi-k3": { input: 3, output: 15 },
-  "xai/grok-4.5": { input: 2.5, output: 9 },
-  "xai/grok-4.3": { input: 1.5, output: 4 },
-  "xai/grok-build-0.1": { input: 1.5, output: 3 },
+  "xai/grok-4.5": { input: 2, output: 6 },
+  "xai/grok-4.3": { input: 1.25, output: 2.5 },
+  "xai/grok-build-0.1": { input: 1, output: 2 },
   "qwen/qwen3.7-max": { input: 1.475, output: 4.425 },
   "qwen/qwen3.7-flash": { input: 0.03, output: 0.13 },
   "zai/glm-5.2": { input: 1.4, output: 4.4 },


### PR DESCRIPTION
Follow-on to blockrun#503 (live in production since 2026-09-04).

**This one is not a docs fix.** The values changed here are the executable price table this client uses to estimate and display cost, so stale entries here mis-state what a call will cost — not just what a README says.

Six Grok SKUs on the gateway carried a resale spread over xAI's published rate — up to +140% on output — while the site claimed "provider list price on chat tokens, no markup". The prices were moved rather than the claim:

| SKU | was | now |
|---|---|---|
| `xai/grok-4.3` | $1.50 / $4.00 | **$1.25 / $2.50** |
| `xai/grok-4.5` | $2.50 / $9.00 | **$2.00 / $6.00** |
| `xai/grok-build-0.1` | $1.50 / $3.00 | **$1.00 / $2.00** |

Verified against `docs.x.ai/docs/models`; the blockrun-sol agent independently re-checked all 24 numbers (both axes, both tiers) against OpenRouter's live endpoint list.

No price guard reaches this repo — `brand/consumers.json` lists 15 repos and the gateway's drift sweep covers its own sheets only. Found by grep, not by CI.

**CHANGELOG entries are deliberately unchanged.** A dated entry records what the price was on that day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChUparsmmkz1GJrvzqmuvL