### PR TITLE
0.47.0 — account mode stops guessing: real balance, settled per-call costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to BlockRun MCP will be documented in this file.
 
+## 0.47.0
+
+**Account mode stops guessing.** 0.46.0 shipped API-key billing with one honest
+limitation: it could not tell you what a call cost or how much credit was left,
+so it printed a local estimate with a `~` and a dashboard link. The account API
+gained both signals today, and this release consumes them.
+
+`blockrun_wallet action:"status"` now reads the real balance from
+`GET /v1/credits`:
+
+```
+  Account:  acme (ungated)
+  Spent to date: $4.5239 (invoiced account — no prepaid ceiling)
+```
+
+A prepaid account shows `Credit remaining: $12.50 of $50.00 granted`; a blocked
+one says so, and why, *before* you spend a call discovering it. A read failure
+degrades to the session figure rather than failing the whole status call.
+
+**Per-call costs are now the settled amount, not an estimate**, everywhere the
+account API reports one: `search`, `exa`, `surf`, `markets`, `rpc`, `defi`,
+`phone`, `modal`, `music`, `speech`, `video`, `realface`. That is not cosmetic —
+`BLOCKRUN_BUDGET_LIMIT` and the per-agent `delegate` caps book what they are
+told, and they were booking an estimate that ran high by exactly the transaction
+fee this rail does not charge. A 19-character speech render now books $0.000998
+where it used to book $0.0031. `blockrun_chat` keeps its estimate, because chat
+settles after the response by design and holding the answer until the money
+landed would be a worse trade; anything still estimated prints a `~` and says so.
+
+Getting there meant routing account calls around the SDK. On that rail there is
+no 402 to perform — no quote, nothing to sign, no retry-after-payment — so
+`requestWithPaymentRaw` degrades to a fetch with a Bearer header, which
+`utils/api-key-call.ts` already does, and does better: it reads the response
+instead of discarding it. `utils/raw-call.ts` is now the single place that picks
+a rail, so eight path-based tools stopped choosing one for themselves. Wallet
+calls still go through the SDK, where the 402 dance is real work worth not
+reimplementing.
+
+**Two traps worth naming, because both read as success.**
+
+`Number("")` is `0`, not `NaN`. A present-but-empty cost header parsed with a
+bare `Number()` would book $0 against a genuinely billed call — the exact
+confusion the header exists to remove, reintroduced in the reader. Empty,
+malformed and negative all read as absent; an explicit `0.000000` is preserved,
+because a charge that really settled at zero is not the same as no charge
+settling at all.
+
+`remaining_usd ?? 0` would tell a paying customer in good standing that they are
+broke. An invoiced account legitimately has no prepaid ceiling, so `remaining` is
+null and the correct thing to show is spend-to-date. Two independent clients hit
+this within a day of the endpoint shipping.
+
+`blocked_reason` is a code, not a message, so it is mapped to a remedy here —
+`ACCOUNT_SUSPENDED` must not advise topping up, which would not lift it. An
+unrecognised code degrades to naming the code rather than reading as "not
+blocked", which would send an agent on to a call the proxy has already refused.
+
+Tests 449 → 458.
+
 ## 0.46.0
 
 **An API key is now a way to pay, and Solana is the chain you start on.**

--- a/README.md
+++ b/README.md
@@ -260,7 +260,19 @@ claude mcp add blockrun -s user -e BLOCKRUN_API_KEY=brk_live_… -- npx -y @bloc
    Or `export BLOCKRUN_API_KEY=brk_live_…` in the environment the client launches from.
 4. **[Dashboard → Activity](https://user.blockrun.ai/dashboard/activity)** — every call, priced at exact usage.
 
-Verify with `blockrun_wallet action:"status"` — it should report *"Paying with: BlockRun account API key"*.
+Verify with `blockrun_wallet action:"status"` — it reports the account, its real
+balance, and what this session has spent:
+
+```
+Paying with: BlockRun account API key (no wallet, no chain)
+
+  Account:  acme (ungated)
+  Spent to date: $4.5239 (invoiced account — no prepaid ceiling)
+  Top up:   https://user.blockrun.ai/dashboard/credits
+```
+
+A prepaid account shows `Credit remaining: $12.50 of $50.00 granted` instead. If
+the account is blocked, status says so and why *before* you spend a call finding out.
 
 **Option B — wallet (no account).** Run `blockrun_wallet` to see your addresses. New installs default to **Solana**; send USDC (SPL) on Solana from Coinbase (pick "Solana"), Phantom, Solflare, or Backpack. To pay on Base instead: `blockrun_wallet action:"chain" chain:"base"`, then send USDC on Base. Full instructions: [Fund your wallet](#fund-your-wallet).
 
@@ -481,6 +493,20 @@ Almost everything now settles on either chain. The exceptions:
 
 A blocked capability returns a message naming the fix, not a raw error.
 
+### What a call costs, and how sure we are
+
+| Mode | Reported cost |
+|---|---|
+| API key — most tools | **The amount actually settled**, read from the account API's per-call response |
+| API key — `blockrun_chat` | An estimate. Chat settles *after* the response by design, so no figure exists when the answer is sent |
+| API key — `blockrun_image`, paid `blockrun_price` | An estimate, until the SDK surfaces the settled figure on those paths |
+| Wallet | The amount signed and settled on-chain, from the 402 quote |
+
+Anything estimated is printed with a `~` and says so. Estimates run **high** on
+the account rail — they add a transaction fee it does not charge — so a budget
+cap trips early rather than late. The invoice is always
+[Dashboard → Activity](https://user.blockrun.ai/dashboard/activity).
+
 ---
 
 ## For agents & LLMs
@@ -544,7 +570,7 @@ One wallet. All sources. No dashboards.
 | `SOLANA_WALLET_KEY` | unset | Env override of `.solana-session`. Set → use Solana. |
 | `BLOCKRUN_KEYCHAIN` | `auto` | Key storage. `auto` — mirror the key into the OS keychain (macOS Keychain / Linux `secret-tool`) and keep the plaintext file, which stays authoritative so other BlockRun tools keep working and so replacing it still rotates your wallet. `off` — file only. `strict` — also delete `~/.blockrun/.session` once a read-back proves the keychain holds the same key; **this breaks other tools that read that file directly**. |
 | `BLOCKRUN_MCP_PROFILE` | `full` | Tool profile (`media` / `trading` / `research` / `chat`). |
-| `BLOCKRUN_BUDGET_LIMIT` | unset (unlimited) | Hard USD cap on x402 spend for this server process. In-memory; resets on restart. Per-agent caps via `blockrun_wallet action:"delegate"`. |
+| `BLOCKRUN_BUDGET_LIMIT` | unset (unlimited) | Hard USD cap on spend for this server process (both rails). In-memory; resets on restart. Per-agent caps via `blockrun_wallet action:"delegate"`. |
 | `BLOCKRUN_CONFIRM_SPEND` | off | `on` — ask before every paid call via MCP elicitation. [Details](#%EF%B8%8F-human-in-the-loop-payments). Fails open on clients without elicitation. |
 | `BLOCKRUN_CONFIRM_THRESHOLD` | `0` | Only ask for calls estimated above this many USD. Malformed values fall back to `0` (ask for everything), never to "off". |
 | `POLYMARKET_CLOB_HOST` | BlockRun Finland relay | Geoblock egress for order placement — **defaulted for you**. Override to go direct (`https://clob.polymarket.com`) or your own egress. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "mcpName": "io.github.BlockRunAI/blockrun-mcp",
   "description": "BlockRun MCP Server - Give your AI agent web search, deep research, prediction markets, and crypto data. Pay per call from a USDC wallet (Solana or Base) or a BlockRun API key.",
   "type": "module",

--- a/src/tools/defi.ts
+++ b/src/tools/defi.ts
@@ -8,17 +8,15 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
-import { reserveBudget, recordSpending } from "../utils/budget.js";
+import { reserveBudget, recordSpending, recordActualSpend } from "../utils/budget.js";
 import { confirmSpend } from "../utils/confirm-spend.js";
 import { withTxFee } from "../utils/tx-fee.js";
 import { baseOnlyMessage, getClient } from "../utils/wallet.js";
+import { type RawClient, rawGet } from "../utils/raw-call.js";
 import { formatError, extractErrorMessage } from "../utils/errors.js";
 import { hasPathTraversal } from "../utils/path-safety.js";
 import type { BudgetState } from "../types.js";
 
-type RawClient = {
-  getWithPaymentRaw: (endpoint: string, params?: Record<string, string>) => Promise<unknown>;
-};
 
 // prices/* is $0.001; protocols / protocol/{slug} / chains / yields are $0.005.
 function estimateDefiCost(path: string): number {
@@ -86,8 +84,8 @@ Use blockrun_price (free) for plain spot quotes, blockrun_dex (free) for DEX pai
           const confirm = await confirmSpend(server, { usd: estimatedCost, label: `defi · ${cleanPath}` });
           if (!confirm.ok) return { content: [{ type: "text", text: confirm.reason ?? "Charge cancelled." }] };
           const client = getClient() as unknown as RawClient;
-          const result = await client.getWithPaymentRaw(`/v1/defillama/${cleanPath}`);
-          recordSpending(budget, estimatedCost, agent_id);
+          const { data: result, paidUsd } = await rawGet(client, `/v1/defillama/${cleanPath}`);
+          recordActualSpend(budget, paidUsd, estimatedCost, agent_id);
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
             structuredContent: (typeof result === "object" && result !== null && !Array.isArray(result)

--- a/src/tools/exa.ts
+++ b/src/tools/exa.ts
@@ -7,19 +7,16 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
-import { reserveBudget, recordSpending } from "../utils/budget.js";
+import { reserveBudget, recordSpending, recordActualSpend } from "../utils/budget.js";
 import { confirmSpend } from "../utils/confirm-spend.js";
 import { withTxFee } from "../utils/tx-fee.js";
 import { asStructuredContent, coerceBody } from "../utils/body.js";
 import { getClient } from "../utils/wallet.js";
+import { type RawClient, rawPost } from "../utils/raw-call.js";
 import { formatError, extractErrorMessage } from "../utils/errors.js";
 import { hasPathTraversal, normalizeClassifyPath } from "../utils/path-safety.js";
 import type { BudgetState } from "../types.js";
 
-type RawClient = {
-  getWithPaymentRaw: (endpoint: string, params?: Record<string, string>) => Promise<unknown>;
-  requestWithPaymentRaw: (endpoint: string, body: unknown) => Promise<unknown>;
-};
 
 export function estimateExaCost(path: string, body: unknown): number {
   // normalizeClassifyPath strips the query string and fragment BEFORE matching.
@@ -85,8 +82,8 @@ Full request/response shapes + worked research workflows in the \`exa-research\`
           if (!confirm.ok) return { content: [{ type: "text", text: confirm.reason ?? "Charge cancelled." }] };
           const client = getClient() as unknown as RawClient;
           const endpoint = `/v1/exa/${cleanPath}`;
-          const result = await client.requestWithPaymentRaw(endpoint, body ?? {});
-          recordSpending(budget, estimatedCost, agent_id);
+          const { data: result, paidUsd } = await rawPost(client, endpoint, body ?? {});
+          recordActualSpend(budget, paidUsd, estimatedCost, agent_id);
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
             structuredContent: asStructuredContent(result),

--- a/src/tools/markets.ts
+++ b/src/tools/markets.ts
@@ -1,10 +1,11 @@
 // src/tools/markets.ts
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { reserveBudget, recordSpending } from "../utils/budget.js";
+import { reserveBudget, recordActualSpend } from "../utils/budget.js";
 import { confirmSpend } from "../utils/confirm-spend.js";
 import { asStructuredContent, coerceBody } from "../utils/body.js";
 import { getClient } from "../utils/wallet.js";
+import { type RawClient, rawGet, rawPost } from "../utils/raw-call.js";
 import { extractErrorMessage, formatError } from "../utils/errors.js";
 import { hasPathTraversal } from "../utils/path-safety.js";
 import type { BudgetState } from "../types.js";
@@ -122,11 +123,17 @@ Pass query params via 'params' (GET). Use 'body' only for POST endpoints (e.g. p
           // reservation. No-ops when off, sub-threshold, or unsupported by the client.
           const confirm = await confirmSpend(server, { usd: estimatedCost, label: `markets · ${path}` });
           if (!confirm.ok) return { content: [{ type: "text", text: confirm.reason ?? "Charge cancelled." }] };
-          const llm = getClient();
-          const result = body !== undefined
-            ? await llm.pmQuery(path, body)
-            : await llm.pm(path, params);
-          recordSpending(budget, estimatedCost, agent_id);
+          // rawGet/rawPost rather than the SDK's pm()/pmQuery(): those are one-line
+          // wrappers over exactly `/v1/pm/${path}` on the same raw methods
+          // (client.ts:1534, 1552), so the wallet rail is byte-identical — but the
+          // account rail then goes through utils/api-key-call.ts, which reads the
+          // settled `x-blockrun-cost-usd` instead of discarding the response.
+          const llm = getClient() as unknown as RawClient;
+          const endpoint = `/v1/pm/${path}`;
+          const { data: result, paidUsd } = body !== undefined
+            ? await rawPost(llm, endpoint, body)
+            : await rawGet(llm, endpoint, params);
+          recordActualSpend(budget, paidUsd, estimatedCost, agent_id);
 
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],

--- a/src/tools/modal.ts
+++ b/src/tools/modal.ts
@@ -7,20 +7,17 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
-import { reserveBudget, recordSpending } from "../utils/budget.js";
+import { reserveBudget, recordSpending, recordActualSpend } from "../utils/budget.js";
 import { confirmSpend } from "../utils/confirm-spend.js";
 import { withTxFee } from "../utils/tx-fee.js";
 import { asStructuredContent, coerceBody } from "../utils/body.js";
 import { baseOnlyMessage, buildClientWithTimeout } from "../utils/wallet.js";
+import { type RawClient, rawPost } from "../utils/raw-call.js";
 import { formatError, extractErrorMessage } from "../utils/errors.js";
 import { normalizeClassifyPath } from "../utils/path-safety.js";
 import { hasPathTraversal } from "../utils/path-safety.js";
 import type { BudgetState } from "../types.js";
 
-type RawClient = {
-  getWithPaymentRaw: (endpoint: string, params?: Record<string, string>) => Promise<unknown>;
-  requestWithPaymentRaw: (endpoint: string, body: unknown) => Promise<unknown>;
-};
 
 // sandbox/create is priced off the BODY, not the path. Mirrors
 // getModalCreatePricing() in the gateway's src/lib/modal.ts:
@@ -172,8 +169,8 @@ Full pricing tables + GPU details in the \`modal\` skill.`,
           // lengthening the 60s timeout the shared getClient() gives every other tool.
           const client = buildClientWithTimeout(modalTimeoutMs(body)) as unknown as RawClient;
           const endpoint = `/v1/modal/${cleanPath}`;
-          const result = await client.requestWithPaymentRaw(endpoint, body ?? {});
-          recordSpending(budget, estimatedCost, agent_id);
+          const { data: result, paidUsd } = await rawPost(client, endpoint, body ?? {});
+          recordActualSpend(budget, paidUsd, estimatedCost, agent_id);
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
             structuredContent: asStructuredContent(result),

--- a/src/tools/music.ts
+++ b/src/tools/music.ts
@@ -150,15 +150,16 @@ Returns a permanent BlockRun-hosted URL.`,
 
         // ---- Rail 1: account API key. No quote, no signature, no expiry. ----
         if (isApiKeyMode()) {
-          const { data, txHash } = await apiKeyAsyncPost("/v1/audio/generations", body, {
+          const { data, paidUsd, txHash } = await apiKeyAsyncPost("/v1/audio/generations", body, {
             pollBudgetMs: MUSIC_POLL_BUDGET_MS,
             pollIntervalMs: MUSIC_POLL_INTERVAL_MS,
             pollTimeoutMs: MUSIC_POLL_TIMEOUT_MS,
           });
-          recordActualSpend(budget, null, MUSIC_COST, agent_id);
+          recordActualSpend(budget, paidUsd, MUSIC_COST, agent_id);
           const t = (data as { data?: Array<{ url: string; duration_seconds?: number; lyrics?: string }> }).data?.[0];
           if (!t?.url) throw new Error("Completed response missing track URL");
-          return musicResult(t, (data as { model?: string }).model || model, MUSIC_COST, txHash, true);
+          // Estimated only when the rail gave us nothing to settle against.
+          return musicResult(t, (data as { model?: string }).model || model, paidUsd ?? MUSIC_COST, txHash, paidUsd === null);
         }
 
         // ---- Rail 2: Solana wallet. Same reusable helper blockrun_video uses. ----

--- a/src/tools/phone.ts
+++ b/src/tools/phone.ts
@@ -8,19 +8,16 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
-import { reserveBudget, recordSpending } from "../utils/budget.js";
+import { reserveBudget, recordSpending, recordActualSpend } from "../utils/budget.js";
 import { confirmSpend } from "../utils/confirm-spend.js";
 import { withTxFee } from "../utils/tx-fee.js";
 import { asStructuredContent, coerceBody } from "../utils/body.js";
 import { getClient } from "../utils/wallet.js";
+import { type RawClient, rawPost, rawGet } from "../utils/raw-call.js";
 import { formatError, extractErrorMessage } from "../utils/errors.js";
 import { hasPathTraversal, normalizeClassifyPath } from "../utils/path-safety.js";
 import type { BudgetState } from "../types.js";
 
-type RawClient = {
-  getWithPaymentRaw: (endpoint: string, params?: Record<string, string>) => Promise<unknown>;
-  requestWithPaymentRaw: (endpoint: string, body: unknown) => Promise<unknown>;
-};
 
 // Exported for unit tests. Normalizes the slug (drops query/trailing-slash/case)
 // before the exact-match pricing so a perturbed path can't downgrade an
@@ -107,10 +104,14 @@ Voice call flow + voice preset details + full body shapes in the \`phone\` skill
           if (!confirm.ok) return { content: [{ type: "text", text: confirm.reason ?? "Charge cancelled." }] };
           const client = getClient() as unknown as RawClient;
           const endpoint = `/v1/${cleanPath}`;
-          const result = body !== undefined
-            ? await client.requestWithPaymentRaw(endpoint, body)
-            : await client.getWithPaymentRaw(endpoint);
-          if (estimatedCost > 0) recordSpending(budget, estimatedCost, agent_id);
+          const { data: result, paidUsd } = body !== undefined
+            ? await rawPost(client, endpoint, body)
+            : await rawGet(client, endpoint);
+          // Free phone reads estimate $0 and must stay free; a settled figure
+          // from the account rail is authoritative for everything else.
+          if (estimatedCost > 0 || (paidUsd ?? 0) > 0) {
+            recordActualSpend(budget, paidUsd, estimatedCost, agent_id);
+          }
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
             structuredContent: asStructuredContent(result),

--- a/src/tools/rpc.ts
+++ b/src/tools/rpc.ts
@@ -10,18 +10,16 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
-import { reserveBudget, recordSpending } from "../utils/budget.js";
+import { reserveBudget, recordSpending, recordActualSpend } from "../utils/budget.js";
 import { confirmSpend } from "../utils/confirm-spend.js";
 import { withTxFee } from "../utils/tx-fee.js";
 import { coerceBody } from "../utils/body.js";
 import { getClient } from "../utils/wallet.js";
+import { type RawClient, rawPost } from "../utils/raw-call.js";
 import { formatError, extractErrorMessage } from "../utils/errors.js";
 import { isValidNetworkSlug } from "../utils/path-safety.js";
 import type { BudgetState } from "../types.js";
 
-type RawClient = {
-  requestWithPaymentRaw: (endpoint: string, body: unknown) => Promise<unknown>;
-};
 
 const RPC_PRICE_USD = 0.002;
 
@@ -97,8 +95,8 @@ Prefer blockrun_price (free quotes), blockrun_dex (free DEX data), or blockrun_s
           const confirm = await confirmSpend(server, { usd: estimatedCost, label: `rpc · ${cleanNetwork}` });
           if (!confirm.ok) return { content: [{ type: "text", text: confirm.reason ?? "Charge cancelled." }] };
           const client = getClient() as unknown as RawClient;
-          const result = await client.requestWithPaymentRaw(`/v1/rpc/${cleanNetwork}`, body);
-          recordSpending(budget, estimatedCost, agent_id);
+          const { data: result, paidUsd } = await rawPost(client, `/v1/rpc/${cleanNetwork}`, body);
+          recordActualSpend(budget, paidUsd, estimatedCost, agent_id);
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
             structuredContent: (typeof result === "object" && result !== null && !Array.isArray(result)

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -8,18 +8,15 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
-import { reserveBudget, recordSpending } from "../utils/budget.js";
+import { reserveBudget, recordSpending, recordActualSpend } from "../utils/budget.js";
 import { confirmSpend } from "../utils/confirm-spend.js";
 import { asStructuredContent, coerceBody } from "../utils/body.js";
 import { getClient } from "../utils/wallet.js";
+import { type RawClient, rawPost } from "../utils/raw-call.js";
 import { formatError, extractErrorMessage } from "../utils/errors.js";
 import { hasPathTraversal } from "../utils/path-safety.js";
 import type { BudgetState } from "../types.js";
 
-type RawClient = {
-  getWithPaymentRaw: (endpoint: string, params?: Record<string, string>) => Promise<unknown>;
-  requestWithPaymentRaw: (endpoint: string, body: unknown) => Promise<unknown>;
-};
 
 // Pricing scales with max_results (capped 1–50, default 10 upstream) at
 // $0.025 per returned source. Mirrors getSearchPrice() in
@@ -107,8 +104,8 @@ Full request shape + worked examples in the \`search\` skill (\`skills/search/SK
           if (!confirm.ok) return { content: [{ type: "text", text: confirm.reason ?? "Charge cancelled." }] };
           const client = getClient() as unknown as RawClient;
           const endpoint = cleanPath ? `/v1/search/${cleanPath}` : "/v1/search";
-          const result = await client.requestWithPaymentRaw(endpoint, body ?? {});
-          recordSpending(budget, estimatedCost, agent_id);
+          const { data: result, paidUsd } = await rawPost(client, endpoint, body ?? {});
+          recordActualSpend(budget, paidUsd, estimatedCost, agent_id);
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
             structuredContent: asStructuredContent(result),

--- a/src/tools/speech.ts
+++ b/src/tools/speech.ts
@@ -219,12 +219,12 @@ Returns a hosted audio URL — download immediately if you need to keep the file
         if (isApiKeyMode()) {
           const r = await apiKeyPost(path, body, { timeoutMs: SPEECH_TIMEOUT });
           data = r.data as typeof data;
-          // No per-call figure comes back on this rail, so the local estimate is
-          // both what we book and what we show — labelled as an estimate.
-          billedUsd = cost;
-          estimated = true;
+          // The settled figure when the rail reports one, the local estimate
+          // otherwise — and `estimated` says which, so the two are never mixed up.
+          billedUsd = r.paidUsd ?? cost;
+          estimated = r.paidUsd === null;
           txHash = r.txHash;
-          recordActualSpend(budget, null, cost, agent_id);
+          recordActualSpend(budget, r.paidUsd, cost, agent_id);
         } else if (getChain() === "solana") {
           // ---- Rail 2: Solana wallet, via the shared manual-x402 helper. ----
           const { solanaPaidPost } = await import("../utils/solana-402.js");

--- a/src/tools/surf.ts
+++ b/src/tools/surf.ts
@@ -13,10 +13,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { TOOL_ANNOTATIONS } from "../tool-annotations.js";
 import { z } from "zod";
-import { reserveBudget, recordSpending } from "../utils/budget.js";
+import { reserveBudget, recordSpending, recordActualSpend } from "../utils/budget.js";
 import { confirmSpend } from "../utils/confirm-spend.js";
 import { asStructuredContent, coerceBody } from "../utils/body.js";
 import { getClient } from "../utils/wallet.js";
+import { type RawClient, rawPost, rawGet } from "../utils/raw-call.js";
 import { formatError, extractErrorMessage } from "../utils/errors.js";
 import { hasPathTraversal } from "../utils/path-safety.js";
 import type { BudgetState } from "../types.js";
@@ -106,10 +107,10 @@ Each Surf endpoint pre-validates required params before settling — you get a 4
           if (!confirm.ok) return { content: [{ type: "text", text: confirm.reason ?? "Charge cancelled." }] };
           const client = getClient() as unknown as SurfClient;
           const endpoint = `/v1/surf/${cleanPath}`;
-          const result = body !== undefined
-            ? await client.requestWithPaymentRaw(endpoint, body)
-            : await client.getWithPaymentRaw(endpoint, params);
-          recordSpending(budget, estimatedCost, agent_id);
+          const { data: result, paidUsd } = body !== undefined
+            ? await rawPost(client, endpoint, body)
+            : await rawGet(client, endpoint, params);
+          recordActualSpend(budget, paidUsd, estimatedCost, agent_id);
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
             structuredContent: asStructuredContent(result),

--- a/src/tools/video.ts
+++ b/src/tools/video.ts
@@ -447,12 +447,12 @@ Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GC
 
         // ---- Rail 1: account API key. No quote, no signature, no expiry. ----
         if (isApiKeyMode()) {
-          const { data, txHash } = await apiKeyAsyncPost("/v1/videos/generations", body, {
+          const { data, paidUsd, txHash } = await apiKeyAsyncPost("/v1/videos/generations", body, {
             pollBudgetMs: VIDEO_TOTAL_BUDGET_MS,
             pollIntervalMs: POLL_INTERVAL_MS,
             pollTimeoutMs: VIDEO_POLL_TIMEOUT_MS,
           });
-          recordActualSpend(budget, null, estimatedCost, agent_id);
+          recordActualSpend(budget, paidUsd, estimatedCost, agent_id);
           const clip = (data as { data?: Array<{ url?: string; source_url?: string; duration_seconds?: number; request_id?: string; backed_up?: boolean }> }).data?.[0];
           if (!clip?.url) throw new Error("Completed video response missing video URL");
           const modelOut = (data as { model?: string }).model || selectedModel;
@@ -462,7 +462,9 @@ Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GC
             `Duration: ${clip.duration_seconds ?? billedSeconds}s`,
             `Model: ${modelOut}`,
             "Billing: BlockRun account (API key)",
-            `Cost: ~$${estimatedCost.toFixed(4)} (estimated — billed at exact usage; see https://user.blockrun.ai/dashboard/activity)`,
+            paidUsd === null
+              ? `Cost: ~$${estimatedCost.toFixed(4)} (estimated — billed at exact usage; see https://user.blockrun.ai/dashboard/activity)`
+              : `Cost: $${paidUsd.toFixed(6)}`,
             ...(clip.backed_up ? ["Backed up to BlockRun storage (URL is permanent)"] : clip.source_url ? [`Source URL: ${clip.source_url}`] : []),
             ...(clip.request_id ? [`Request ID: ${clip.request_id}`] : []),
             ...(txHash ? [`Receipt: ${txHash}`] : []),
@@ -474,8 +476,8 @@ Returns a permanent blockrun-hosted MP4 URL (the gateway mirrors the asset to GC
               ...(clip.source_url ? { source_url: clip.source_url } : {}),
               duration_seconds: clip.duration_seconds,
               model: modelOut,
-              cost_usd: estimatedCost,
-              cost_is_estimate: true,
+              cost_usd: paidUsd ?? estimatedCost,
+              cost_is_estimate: paidUsd === null,
               billing: "account",
               ...(clip.request_id ? { request_id: clip.request_id } : {}),
               ...(clip.backed_up !== undefined ? { backed_up: clip.backed_up } : {}),

--- a/src/tools/wallet.ts
+++ b/src/tools/wallet.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import type { BudgetState } from "../types.js";
 import { getWalletInfo, getUsdcBalance, getChain, setChain, ensureBothWallets, getChainBalance, getApiBase } from "../utils/wallet.js";
 import { isApiKeyMode, requireWalletMode, PORTAL_CREDITS_URL, PORTAL_ACTIVITY_URL } from "../utils/auth.js";
+import { describeBlock, formatCredit, getAccountCredit } from "../utils/account.js";
 import { generateQrPng, openQrInViewer } from "../utils/qr.js";
 import { launchTopUp } from "../utils/onramp.js";
 import { formatError } from "../utils/errors.js";
@@ -167,22 +168,40 @@ Do NOT call this for actual AI queries — use blockrun_chat for that.`,
       // ---------------------------------------------------------------------
       if (isApiKeyMode()) {
         if (action === "status") {
-          const spent = `$${budget.spent.toFixed(4)} estimated${budget.limit ? ` / $${budget.limit.toFixed(2)} local limit` : ""} — ${budget.calls} calls`;
-          const text = `Paying with: BlockRun account API key (no wallet, no chain)
-
-  Endpoint: ${getApiBase()}
-  Credit + real ledger: ${PORTAL_CREDITS_URL}
-  Per-call activity:    ${PORTAL_ACTIVITY_URL}
-
-This session (local estimate): ${spent}
-
-The figure above is this server's own ESTIMATE, computed before each call so it
-can enforce your budget limits. It is not the invoice. Actual usage is metered
-by the account API at exact token counts and is only authoritative at the
-dashboard links above.
-
-Wallet actions (setup, qr, deposit, chain) need wallet mode — unset
-BLOCKRUN_API_KEY and restart to use one.`;
+          // Read the REAL balance. This used to print only a local estimate and
+          // a link, because no key-authenticated endpoint existed; GET /v1/credits
+          // closed that on 2026-09-05. A read failure degrades to the session
+          // figure rather than failing the whole status call — knowing nothing
+          // about the account is not a reason to also refuse to say what this
+          // process has spent.
+          let credit: Awaited<ReturnType<typeof getAccountCredit>> | null = null;
+          let creditError: string | null = null;
+          try {
+            credit = await getAccountCredit();
+          } catch (err) {
+            creditError = err instanceof Error ? err.message : String(err);
+          }
+          const blockNote = credit ? describeBlock(credit.blocked ? credit.blockedReason : null) : null;
+          const session = `$${budget.spent.toFixed(4)}${budget.limit ? ` / $${budget.limit.toFixed(2)} local cap` : ""} — ${budget.calls} calls`;
+          const text = [
+            `Paying with: BlockRun account API key (no wallet, no chain)`,
+            ``,
+            credit
+              ? `  Account:  ${credit.accountId} (${credit.billingMode})\n  ${formatCredit(credit)}`
+              : `  Account credit unavailable: ${creditError}`,
+            `  Top up:   ${PORTAL_CREDITS_URL}`,
+            `  Activity: ${PORTAL_ACTIVITY_URL}`,
+            ``,
+            `This session: ${session}`,
+            ...(blockNote ? [``, `BLOCKED — ${blockNote}`] : []),
+            ``,
+            `Per-call costs are the amount the account API actually settled, where it`,
+            `reports one. Chat settles after the response by design, so chat figures`,
+            `stay estimates; the ledger above is always authoritative.`,
+            ``,
+            `Wallet actions (setup, qr, deposit, chain) need wallet mode — unset`,
+            `BLOCKRUN_API_KEY and restart to use one.`,
+          ].join("\n");
           return {
             content: [{ type: "text", text }],
             structuredContent: {
@@ -190,9 +209,19 @@ BLOCKRUN_API_KEY and restart to use one.`;
               endpoint: getApiBase(),
               creditsUrl: PORTAL_CREDITS_URL,
               activityUrl: PORTAL_ACTIVITY_URL,
-              sessionEstimatedSpend: budget.spent,
+              sessionSpend: budget.spent,
               calls: budget.calls,
-              costsAreEstimates: true,
+              ...(credit
+                ? {
+                    accountId: credit.accountId,
+                    billingMode: credit.billingMode,
+                    grantedUsd: credit.grantedUsd,
+                    spentUsd: credit.spentUsd,
+                    remainingUsd: credit.remainingUsd,
+                    blocked: credit.blocked,
+                    blockedReason: credit.blockedReason,
+                  }
+                : { creditError }),
             },
           };
         }

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -1,0 +1,99 @@
+// src/utils/account.ts
+//
+// The account rail's answer to "how much have I got left?".
+//
+// Wallet mode reads a USDC balance off-chain and prints one number. Account mode
+// could not answer the question at all until 2026-09-05 — there was no
+// key-authenticated endpoint, so `blockrun_wallet action:"status"` printed a
+// local estimate and a dashboard link. GET /v1/credits closes that.
+
+import { fetchWithTimeout } from "./http.js";
+import { apiAuthHeaders, getApiKeyBase, PORTAL_CREDITS_URL, PORTAL_KEYS_URL } from "./auth.js";
+
+/**
+ * `blocked_reason` is a CODE, not a message — confirmed with the API owner, who
+ * also committed to treating the set as append-only and announcing additions.
+ *
+ * Mapped here rather than printed because the useful half is the remedy, and the
+ * remedy differs per code; a server-side message would end up either duplicated
+ * or ignored. An UNKNOWN code must never read as "fine" — see describeBlock.
+ */
+const BLOCK_REASONS: Record<string, string> = {
+  ACCOUNT_SUSPENDED:
+    `This BlockRun account is suspended. Contact support — topping up will not lift it.`,
+  CREDIT_LIMIT_REACHED:
+    `This account has reached its credit limit. Settle the outstanding invoice or ask for a higher limit at ${PORTAL_CREDITS_URL}.`,
+  BALANCE_EXHAUSTED:
+    `This account is out of prepaid credit. Top up at ${PORTAL_CREDITS_URL}.`,
+};
+
+export function describeBlock(code: string | null | undefined): string | null {
+  if (!code) return null;
+  // An unrecognised code degrades to ugly-but-honest rather than silent. Reading
+  // an unknown block as "not blocked" is the failure mode that matters: it would
+  // send an agent on to a call the proxy has already decided to refuse.
+  return BLOCK_REASONS[code] ?? `This account is blocked (${code}). See ${PORTAL_CREDITS_URL}.`;
+}
+
+export interface AccountCredit {
+  accountId: string;
+  billingMode: string;
+  currency: string;
+  grantedUsd: number | null;
+  spentUsd: number | null;
+  /** Null on an INVOICED account, where there is no prepaid ceiling to remain of. */
+  remainingUsd: number | null;
+  blocked: boolean;
+  blockedReason: string | null;
+}
+
+function num(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+/**
+ * Read the account's credit state. Throws with an actionable message rather than
+ * returning a half-filled object, because every caller is about to render it.
+ */
+export async function getAccountCredit(timeoutMs = 15_000): Promise<AccountCredit> {
+  const response = await fetchWithTimeout(
+    `${getApiKeyBase()}/v1/credits`,
+    { method: "GET", headers: { ...apiAuthHeaders() } },
+    timeoutMs,
+  );
+  if (response.status === 401) {
+    throw new Error(`BLOCKRUN_API_KEY was rejected. Check the key at ${PORTAL_KEYS_URL}.`);
+  }
+  if (!response.ok) {
+    throw new Error(`Could not read account credit (HTTP ${response.status}). See ${PORTAL_CREDITS_URL}.`);
+  }
+  const d = (await response.json()) as Record<string, unknown>;
+  return {
+    accountId: typeof d.account_id === "string" ? d.account_id : "unknown",
+    billingMode: typeof d.billing_mode === "string" ? d.billing_mode : "unknown",
+    currency: typeof d.currency === "string" ? d.currency : "USD",
+    grantedUsd: num(d.granted_usd),
+    spentUsd: num(d.spent_usd),
+    remainingUsd: num(d.remaining_usd),
+    blocked: d.blocked === true,
+    blockedReason: typeof d.blocked_reason === "string" ? d.blocked_reason : null,
+  };
+}
+
+/**
+ * One human line for the credit state.
+ *
+ * NEVER `remaining_usd ?? 0`. An invoiced ("ungated") account legitimately has
+ * no ceiling, so remaining is null — and defaulting that to zero tells a paying
+ * customer in good standing that they are broke. Two independent clients hit
+ * this within a day of the endpoint shipping, which is why it is called out here
+ * rather than left to the next reader.
+ */
+export function formatCredit(c: AccountCredit): string {
+  if (c.remainingUsd !== null) {
+    const of = c.grantedUsd !== null ? ` of $${c.grantedUsd.toFixed(2)} granted` : "";
+    return `Credit remaining: $${c.remainingUsd.toFixed(4)}${of}`;
+  }
+  const spent = c.spentUsd !== null ? `$${c.spentUsd.toFixed(4)}` : "unavailable";
+  return `Spent to date: ${spent} (invoiced account — no prepaid ceiling)`;
+}

--- a/src/utils/api-key-call.ts
+++ b/src/utils/api-key-call.ts
@@ -23,22 +23,53 @@ import { getApiBase, resolveGatewayUrl } from "./wallet.js";
 export interface ApiKeyPostResult {
   data: Record<string, unknown>;
   /**
-   * ALWAYS NULL, and that is a fact about the account API rather than a gap here.
+   * What this call ACTUALLY cost, from the `x-blockrun-cost-usd` response header,
+   * or null when the account API did not settle a price at response time.
    *
-   * A wallet call learns its price from the 402 quote before it signs. An
-   * account call has no quote: it is metered server-side at exact upstream token
-   * counts, billed post-hoc, and the response carries no cost header (probed
-   * 2026-09-05 — the only billing-ish headers are `x-blockrun-request-id` and
-   * `x-payment-receipt: credit:<uuid>`). Callers therefore fall back to their
-   * own pre-call estimate, which recordActualSpend already does for null.
+   * Null is not "free". The header is absent for two different reasons the wire
+   * cannot tell apart: a genuinely free family (catalogue reads, job polls), and
+   * chat — where the charge settles after the response is sent, by design, so
+   * emitting it would mean holding the answer until the money landed. Callers
+   * pass null to recordActualSpend, which falls back to their pre-call estimate.
    *
-   * Returning null rather than 0 matters: recordActualSpend treats 0 as
-   * "unknown" too, but null says so on purpose instead of by accident.
+   * Until 2026-09-05 this was ALWAYS null: the header did not exist, and the
+   * estimates it replaces are high by exactly the transaction fee this rail does
+   * not charge (reconciled against the account ledger: music billed $0.157500
+   * against a $0.1595 estimate, speech $0.001050 against $0.0031).
    */
-  paidUsd: null;
+  paidUsd: number | null;
   /** The `credit:<uuid>` receipt, when the gateway returns one. */
   txHash?: string;
   jobId?: string;
+}
+
+/**
+ * Read `x-blockrun-cost-usd`, refusing anything that is not a settled amount.
+ *
+ * EMPTY, MALFORMED AND NEGATIVE ALL READ AS ABSENT, and that is the whole point
+ * of doing this by hand rather than with `Number(...)`. `Number("")` is 0, not
+ * NaN — so a header present but empty would parse as a settled zero and book $0
+ * against a call that was genuinely billed, reintroducing in the reader exactly
+ * the confusion the header exists to remove. (ClawRouter's first parser had this
+ * bug; a test caught it there.) The emitter cannot currently produce an empty
+ * value, but a reader that is only correct because of what the writer happens to
+ * do is not correct.
+ *
+ * A settled ZERO is meaningful and preserved: the gateway writes "0.000000"
+ * explicitly for a charge that really did resolve to nothing, as distinct from
+ * omitting the header.
+ */
+export function parseCostHeader(raw: string | null | undefined): number | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
+}
+
+function costFrom(response: Response): number | null {
+  return parseCostHeader(response.headers.get("x-blockrun-cost-usd"));
 }
 
 /** Statuses the gateway uses for a job that will never complete. */
@@ -92,7 +123,30 @@ export async function apiKeyPost(
     opts.timeoutMs ?? 120_000,
   );
   if (!response.ok) await throwForStatus(response, `POST ${endpoint}`);
-  return { data: await readJson(response), paidUsd: null, txHash: receiptFrom(response) };
+  return { data: await readJson(response), paidUsd: costFrom(response), txHash: receiptFrom(response) };
+}
+
+/**
+ * GET a priced endpoint. `endpoint` is rooted, e.g. "/v1/pm/polymarket/markets".
+ *
+ * Paid GETs settle inline on this rail, so the cost header is present on the
+ * response — the three families that had it missing until 0fff304 (pm, surf,
+ * defillama) are all GETs, and they were the whole reason it was worth verifying
+ * per family rather than trusting one probe.
+ */
+export async function apiKeyGet(
+  endpoint: string,
+  params?: Record<string, string>,
+  opts: { timeoutMs?: number } = {},
+): Promise<ApiKeyPostResult> {
+  const qs = params && Object.keys(params).length ? `?${new URLSearchParams(params)}` : "";
+  const response = await fetchWithTimeout(
+    `${getApiBase()}${endpoint}${qs}`,
+    { method: "GET", headers: { ...apiAuthHeaders() } },
+    opts.timeoutMs ?? 120_000,
+  );
+  if (!response.ok) await throwForStatus(response, `GET ${endpoint}`);
+  return { data: await readJson(response), paidUsd: costFrom(response), txHash: receiptFrom(response) };
 }
 
 /**
@@ -136,11 +190,12 @@ export async function apiKeyAsyncPost(
   if (!submit.ok && submit.status !== 202) await throwForStatus(submit, `POST ${endpoint}`);
 
   const submitted = await readJson(submit);
+  const submitCost = costFrom(submit);
   const pollUrl = typeof submitted.poll_url === "string" ? submitted.poll_url : undefined;
   const jobId = typeof submitted.id === "string" ? submitted.id : undefined;
 
   if (submit.status !== 202 && !pollUrl) {
-    return { data: submitted, paidUsd: null, txHash: receiptFrom(submit), jobId };
+    return { data: submitted, paidUsd: costFrom(submit), txHash: receiptFrom(submit), jobId };
   }
   if (!pollUrl) {
     throw new Error(`Async submit missing poll_url: ${JSON.stringify(submitted)}`);
@@ -179,7 +234,10 @@ export async function apiKeyAsyncPost(
       throw new Error(`Upstream generation failed: ${String(data.error ?? "unknown")}. ${billing}`);
     }
     if (poll.ok && lastStatus === "completed") {
-      return { data, paidUsd: null, txHash: receiptFrom(poll), jobId };
+      // Async media bills at SUBMIT and the polls are free, so the price rides
+      // the submit response and the completed poll carries nothing. Prefer the
+      // poll's header if one ever appears, but fall back to the submit's.
+      return { data, paidUsd: costFrom(poll) ?? submitCost, txHash: receiptFrom(poll), jobId };
     }
     // 504 is a transient upstream poll timeout on this gateway, same as the
     // wallet rails — keep polling rather than abandoning a paid job.

--- a/src/utils/raw-call.ts
+++ b/src/utils/raw-call.ts
@@ -1,0 +1,65 @@
+// src/utils/raw-call.ts
+//
+// One entry point for the path-based tools (search, exa, surf, markets, rpc,
+// defi, phone, modal), so each of them stops choosing a rail for itself.
+//
+// WHY THIS EXISTS RATHER THAN "just call the SDK". On the account rail there is
+// no x402 to perform: no quote to read, nothing to sign, no retry-after-payment.
+// The SDK's requestWithPaymentRaw degrades to a fetch with a Bearer header —
+// which utils/api-key-call.ts already does, and does better, because it reads
+// the `x-blockrun-cost-usd` response header while the SDK parses the body and
+// discards the response. Routing account calls around the SDK is therefore not
+// a workaround; it is the shorter path, and it is the only one that can tell a
+// caller what the call actually cost.
+//
+// The wallet rails keep going through the SDK unchanged, because there the 402
+// dance is real work worth not reimplementing.
+
+import { isApiKeyMode } from "./auth.js";
+import { apiKeyGet, apiKeyPost } from "./api-key-call.js";
+
+/** The two raw methods every path-based tool already depends on. */
+export type RawClient = {
+  getWithPaymentRaw: (endpoint: string, params?: Record<string, string>) => Promise<unknown>;
+  requestWithPaymentRaw: (endpoint: string, body: unknown) => Promise<unknown>;
+};
+
+export interface RawCallResult {
+  data: unknown;
+  /**
+   * Actual settled cost, or null when unknown.
+   *
+   * Null on every wallet call — the SDK does not surface the 402's settled
+   * amount through these two methods — and on account calls the gateway did not
+   * price at response time. Callers hand it to recordActualSpend, which falls
+   * back to the pre-call estimate for null, so a missing figure degrades to
+   * today's behaviour rather than to a booked zero.
+   */
+  paidUsd: number | null;
+}
+
+/** GET a rooted endpoint on whichever rail is active. */
+export async function rawGet(
+  client: RawClient,
+  endpoint: string,
+  params?: Record<string, string>,
+): Promise<RawCallResult> {
+  if (isApiKeyMode()) {
+    const { data, paidUsd } = await apiKeyGet(endpoint, params);
+    return { data, paidUsd };
+  }
+  return { data: await client.getWithPaymentRaw(endpoint, params), paidUsd: null };
+}
+
+/** POST a rooted endpoint on whichever rail is active. */
+export async function rawPost(
+  client: RawClient,
+  endpoint: string,
+  body: unknown,
+): Promise<RawCallResult> {
+  if (isApiKeyMode()) {
+    const { data, paidUsd } = await apiKeyPost(endpoint, (body ?? {}) as Record<string, unknown>);
+    return { data, paidUsd };
+  }
+  return { data: await client.requestWithPaymentRaw(endpoint, body), paidUsd: null };
+}

--- a/test/account-cost.test.ts
+++ b/test/account-cost.test.ts
@@ -1,0 +1,121 @@
+// Run with: npm test  (tsx --experimental-test-module-mocks --test)
+//
+// The account rail's two new signals: the settled per-call cost header, and the
+// credit balance. Both shipped on the server on 2026-09-05; both have a failure
+// mode that reads as success, which is what these pin.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseCostHeader } from "../src/utils/api-key-call.js";
+import { describeBlock, formatCredit, type AccountCredit } from "../src/utils/account.js";
+
+// ---------------------------------------------------------------------------
+// parseCostHeader
+// ---------------------------------------------------------------------------
+
+test("a settled amount parses, including an explicit zero", () => {
+  assert.equal(parseCostHeader("0.007500"), 0.0075);
+  assert.equal(parseCostHeader("0.010000"), 0.01);
+  assert.equal(parseCostHeader("0.157500"), 0.1575);
+  assert.equal(parseCostHeader(" 0.002000 "), 0.002);
+  // The gateway writes 0.000000 explicitly for a charge that really resolved to
+  // nothing. That is a settled price and must survive as one — it is distinct
+  // from omitting the header, which means no price settled at response time.
+  assert.equal(parseCostHeader("0.000000"), 0);
+});
+
+// THE TRAP. Number("") is 0, not NaN — so a present-but-empty header parsed with
+// a bare Number() books $0 against a call that was genuinely billed, which is
+// exactly the confusion the header exists to remove, reintroduced in the reader.
+// ClawRouter's first parser had this bug and a test caught it there.
+test("an empty header reads as ABSENT, not as a settled zero", () => {
+  assert.equal(parseCostHeader(""), null);
+  assert.equal(parseCostHeader("   "), null);
+  assert.notEqual(parseCostHeader(""), 0, "empty must not collapse to a settled zero");
+});
+
+test("missing, malformed and negative values all read as absent", () => {
+  assert.equal(parseCostHeader(null), null);
+  assert.equal(parseCostHeader(undefined), null);
+  assert.equal(parseCostHeader("free"), null);
+  assert.equal(parseCostHeader("$0.0075"), null);
+  assert.equal(parseCostHeader("NaN"), null);
+  assert.equal(parseCostHeader("Infinity"), null);
+  // A negative charge is not a refund we know how to book; treat it as unknown
+  // and fall back to the estimate rather than crediting a budget.
+  assert.equal(parseCostHeader("-0.001"), null);
+});
+
+// ---------------------------------------------------------------------------
+// formatCredit
+// ---------------------------------------------------------------------------
+
+const credit = (over: Partial<AccountCredit> = {}): AccountCredit => ({
+  accountId: "acct",
+  billingMode: "ungated",
+  currency: "USD",
+  grantedUsd: 0,
+  spentUsd: 4.238060754,
+  remainingUsd: null,
+  blocked: false,
+  blockedReason: null,
+  ...over,
+});
+
+// The bug both this client and ClawRouter nearly shipped: `remaining_usd ?? 0`
+// on an invoiced account, whose remaining is legitimately null, renders as
+// "$0.00 left" and tells a paying customer in good standing that they are broke.
+test("an invoiced account shows spend-to-date, never a zero balance", () => {
+  const line = formatCredit(credit());
+  assert.match(line, /Spent to date: \$4\.2381/);
+  assert.match(line, /no prepaid ceiling/);
+  assert.doesNotMatch(line, /remaining/i, "must not imply a ceiling that does not exist");
+  assert.doesNotMatch(line, /\$0\.00\b/, "must never render as a zero balance");
+});
+
+test("a prepaid account shows what is left, against what was granted", () => {
+  const line = formatCredit(credit({ billingMode: "gated", grantedUsd: 50, remainingUsd: 12.5 }));
+  assert.match(line, /Credit remaining: \$12\.5000/);
+  assert.match(line, /of \$50\.00 granted/);
+});
+
+test("a prepaid account genuinely at zero still says zero", () => {
+  const line = formatCredit(credit({ billingMode: "gated", grantedUsd: 50, remainingUsd: 0 }));
+  assert.match(line, /Credit remaining: \$0\.0000/);
+});
+
+// ---------------------------------------------------------------------------
+// describeBlock
+// ---------------------------------------------------------------------------
+
+test("not blocked describes nothing", () => {
+  assert.equal(describeBlock(null), null);
+  assert.equal(describeBlock(undefined), null);
+  assert.equal(describeBlock(""), null);
+});
+
+test("each known code maps to its own remedy, not a generic one", () => {
+  const suspended = describeBlock("ACCOUNT_SUSPENDED")!;
+  const limit = describeBlock("CREDIT_LIMIT_REACHED")!;
+  const exhausted = describeBlock("BALANCE_EXHAUSTED")!;
+
+  // The remedies genuinely differ — that is the whole reason these are mapped
+  // client-side instead of printed from a server message.
+  assert.match(suspended, /suspended/i);
+  assert.match(suspended, /will not lift it/, "topping up is the wrong advice here");
+  assert.match(limit, /credit limit/i);
+  assert.match(exhausted, /top up/i);
+  assert.notEqual(suspended, limit);
+  assert.notEqual(limit, exhausted);
+});
+
+// The API owner committed to the code list being append-only and to announcing
+// additions. This pins what happens if that ever slips: an unknown code must
+// surface, not vanish. Reading it as "not blocked" would send an agent on to a
+// call the proxy has already decided to refuse.
+test("an unknown code degrades to honest, never to silence", () => {
+  const out = describeBlock("SOME_FUTURE_CODE");
+  assert.ok(out, "an unknown block code must still describe a block");
+  assert.match(out, /SOME_FUTURE_CODE/, "name the code so it can be looked up");
+  assert.match(out, /user\.blockrun\.ai/, "and still point somewhere actionable");
+});


### PR DESCRIPTION
Follow-up to #137. 0.46.0 shipped API-key billing with one honest limitation: it could not say what a call cost or how much credit was left, so it printed a local estimate with a `~` and a dashboard link. The account API gained both signals today — `GET /v1/credits` and an `x-blockrun-cost-usd` header on billed responses — and this consumes them.

## Balance

`blockrun_wallet action:"status"` reads the real figure:

```
  Account:  acme (ungated)
  Spent to date: $4.5239 (invoiced account — no prepaid ceiling)
```

A prepaid account shows `Credit remaining: $12.50 of $50.00 granted`. A blocked one says so and why, *before* a call is spent discovering it. A read failure degrades to the session figure rather than failing status outright.

## Settled costs, not estimates

Everywhere the account API reports one: `search`, `exa`, `surf`, `markets`, `rpc`, `defi`, `phone`, `modal`, `music`, `speech`, `video`, `realface`.

Not cosmetic. `BLOCKRUN_BUDGET_LIMIT` and the per-agent `delegate` caps book what they are told, and they were booking an estimate that runs high by exactly the transaction fee this rail does not charge. **A 19-character speech render now books $0.000998 where it booked $0.0031.** `blockrun_chat` keeps its estimate: it settles after the response by design, and holding the answer until the money landed is the worse trade. Anything still estimated prints a `~` and says so.

## Why account calls now route around the SDK

On that rail there is no 402 to perform — no quote, nothing to sign, no retry-after-payment — so `requestWithPaymentRaw` degrades to a fetch with a Bearer header, which `utils/api-key-call.ts` already does, and does better: it reads the response instead of discarding it. `utils/raw-call.ts` is now the single place that picks a rail, so eight path-based tools stopped choosing one for themselves. Wallet calls still go through the SDK, where the 402 dance is real work worth not reimplementing.

## Two traps, both of which read as success

**`Number("")` is `0`, not `NaN`.** A present-but-empty cost header parsed with a bare `Number()` would book $0 against a genuinely billed call — the exact confusion the header exists to remove, reintroduced in the reader. Empty, malformed and negative read as absent; an explicit `0.000000` is preserved, because a charge that settled at zero is not the same as no charge settling at all.

**`remaining_usd ?? 0` tells a paying customer in good standing that they are broke.** An invoiced account legitimately has no prepaid ceiling, so `remaining` is null and the correct thing to show is spend-to-date. Two independent clients hit this within a day of the endpoint shipping.

`blocked_reason` is a code, not a message, so it maps to a remedy here — `ACCOUNT_SUSPENDED` must not advise topping up, which would not lift it. An unrecognised code names itself rather than reading as "not blocked", which would send an agent on to a call the proxy has already refused.

## Verification

Live against `api.blockrun.ai` at commit `0fff304`, gated on `/api/health` matching before spending anything:

| call | header | ledger row (by request id) |
|---|---|---|
| `GET pm/polymarket/markets` | `0.007500` | $0.007500 |
| `GET defillama/protocols` | `0.005000` | $0.005000 |
| `GET surf/exchange/price` | `0.007500` | $0.007500 |
| `POST exa/search` | `0.010000` | $0.0100 |
| `POST rpc/base` | `0.002000` | $0.002000 |
| `GET models` (free) | absent | correct |
| `POST chat/completions` | absent | correct, by design |

Then end-to-end through the built server: speech reports `Cost: $0.0010` with no `~`, and the session ledger books $0.0030 across two calls (rpc $0.002 + speech $0.000998) — settled amounts, not estimates.

Tests 449 → 458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116SvLAGyzJ4SYKBvAE2DTc