### PR TITLE
0.48.0 — carry over PR #136: key from a file, and Retry-After on 429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to BlockRun MCP will be documented in this file.
 
+## 0.48.0
+
+**A key can live in a file, not just an environment variable.** Write it to
+`~/.blockrun/.api-key` and account mode picks it up — same directory the wallet
+already uses, and for the same reason that file exists: a stdio MCP server is
+launched by its client, and several clients make setting an environment variable
+awkward or impossible. `BLOCKRUN_API_KEY` still wins when both are present,
+mirroring how `BLOCKRUN_WALLET_KEY` outranks `~/.blockrun/.session` — an
+explicitly exported key is a deliberate override and must not be shadowed by
+whatever is left on disk from an earlier account. An empty or unreadable file
+falls through to wallet mode rather than taking the server down; a malformed one
+still fails loudly, and now names which source it came from.
+
+Also: a 429 from the account API surfaces its `Retry-After` instead of burying
+it in the response body. It is the one part of a rate-limit response a caller can
+act on, and an agent told only "rate limited" retries immediately and is refused
+again.
+
+Both were carried over from **@KillerQueen-Z's PR #136**, which implemented
+account-key support in parallel and had these two details the shipped
+implementation did not. That PR is closed as superseded — 0.46.0 and 0.47.0 had
+already landed the same feature, and it could no longer merge — but the ideas
+were the better ones and are here with credit.
+
+Tests 458 → 462.
+
 ## 0.47.0
 
 **Account mode stops guessing.** 0.46.0 shipped API-key billing with one honest

--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ claude mcp add blockrun -s user -e BLOCKRUN_API_KEY=brk_live_… -- npx -y @bloc
 ```
 
    Or `export BLOCKRUN_API_KEY=brk_live_…` in the environment the client launches from.
+
+   If your client makes environment variables awkward, write the key to
+   **`~/.blockrun/.api-key`** instead (`chmod 600`) — same file directory the
+   wallet uses. The environment variable wins when both are present.
 4. **[Dashboard → Activity](https://user.blockrun.ai/dashboard/activity)** — every call, priced at exact usage.
 
 Verify with `blockrun_wallet action:"status"` — it reports the account, its real
@@ -561,6 +565,7 @@ One wallet. All sources. No dashboards.
 | Variable / File | Default | Effect |
 |---|---|---|
 | `BLOCKRUN_API_KEY` | unset | A BlockRun account key (`brk_live_…`) from [user.blockrun.ai/dashboard/keys](https://user.blockrun.ai/dashboard/keys). **Set → account billing: no wallet is created, read or used, and no chain applies.** Takes priority over every wallet setting below. A malformed value is a startup error, never a silent fall back to the wallet. |
+| `~/.blockrun/.api-key` | not created | The same key on disk, for clients that make env vars awkward. Read only when `BLOCKRUN_API_KEY` is unset; an empty or unreadable file falls through to wallet mode. |
 | `BLOCKRUN_API_BASE_URL` | `https://api.blockrun.ai` | Account API base, for staging. Accepts the OpenAI-style `…/v1` form too. |
 | `~/.blockrun/.session` | auto-created on first run | EVM private key (0x…). File exists → use Base. Also the Polymarket signer (unless `BLOCKRUN_WALLET_KEY` or an agent `wallet.json` takes precedence). |
 | `BLOCKRUN_WALLET_KEY` | unset | Env override of the EVM key — takes precedence over `.session` / `wallet.json` as the Base + Polymarket signer. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/mcp",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "mcpName": "io.github.BlockRunAI/blockrun-mcp",
   "description": "BlockRun MCP Server - Give your AI agent web search, deep research, prediction markets, and crypto data. Pay per call from a USDC wallet (Solana or Base) or a BlockRun API key.",
   "type": "module",

--- a/src/utils/api-key-call.ts
+++ b/src/utils/api-key-call.ts
@@ -100,8 +100,18 @@ async function throwForStatus(response: Response, what: string): Promise<never> 
   }
   if (response.status === 401) {
     throw new Error(
-      `${what} was refused: BLOCKRUN_API_KEY was rejected. ` +
+      `${what} was refused: the BlockRun API key was rejected. ` +
         `Check the key at https://user.blockrun.ai/dashboard/keys.`,
+    );
+  }
+  // Surface Retry-After rather than burying it in the body. It is the one piece
+  // of a 429 a caller can act on, and an agent told "rate limited" with no
+  // interval will retry immediately and be refused again. (Carried over from
+  // PR #136, which surfaced it and this path did not.)
+  if (response.status === 429) {
+    const retry = response.headers.get("retry-after");
+    throw new Error(
+      `${what} was rate limited${retry ? ` — retry after ${retry}s` : ""}.`,
     );
   }
   throw new Error(`API error ${response.status}: ${JSON.stringify(body)}`);

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -3,7 +3,8 @@
 // Which credential is this process paying with — an account API key, or a
 // wallet signing x402?
 //
-// This module is deliberately DEPENDENCY-FREE. It is imported by utils/wallet.ts
+// This module imports nothing from the rest of this codebase (node builtins
+// only). It is imported by utils/wallet.ts
 // (which owns the chain and the SDK clients) and by the four tools that build
 // gateway requests by hand, so anything it imported back from wallet.ts would be
 // an import cycle across the hottest path in the server.
@@ -14,6 +15,10 @@
 // once, and the result was six `getChain() !== "base"` refusals that stayed in
 // the code for months after the Solana gateway started serving those routes.
 // One decision point, or it drifts again.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 /**
  * The shape the gateway issues and the SDK validates (`resolveApiKeyAuth` in
@@ -38,7 +43,22 @@ export type AuthMode = "api-key" | "wallet";
 let _apiKey: string | null | undefined;
 
 /**
+ * Where a key lives when it is not in the environment.
+ *
+ * Sits beside ~/.blockrun/.session for the same reason that file exists: a
+ * stdio MCP server is launched by a client, and several of those clients make
+ * setting an environment variable awkward or impossible. Carried over from
+ * @KillerQueen-Z's PR #136, which had this and the env-only implementation did
+ * not.
+ */
+const API_KEY_FILE = path.join(os.homedir(), ".blockrun", ".api-key");
+
+/**
  * The account API key, or undefined when this process pays from a wallet.
+ *
+ * Precedence is env then file, matching the wallet path (BLOCKRUN_WALLET_KEY
+ * outranks ~/.blockrun/.session): an explicitly exported key is a deliberate
+ * override and must not be shadowed by whatever is on disk.
  *
  * A MALFORMED key THROWS rather than falling back to the wallet. Falling back
  * silently is how someone who believes they are spending prepaid credit starts
@@ -49,15 +69,26 @@ let _apiKey: string | null | undefined;
 export function getApiKey(): string | undefined {
   if (_apiKey !== undefined) return _apiKey ?? undefined;
 
-  const raw = process.env.BLOCKRUN_API_KEY?.trim();
+  let raw = process.env.BLOCKRUN_API_KEY?.trim();
+  let origin = "BLOCKRUN_API_KEY";
+  if (!raw) {
+    try {
+      // An unreadable file is not a configured key: fall through to wallet mode
+      // rather than taking the whole server down over a permissions error.
+      if (fs.existsSync(API_KEY_FILE)) {
+        raw = fs.readFileSync(API_KEY_FILE, "utf-8").trim();
+        origin = API_KEY_FILE;
+      }
+    } catch { /* ignore */ }
+  }
   if (!raw) {
     _apiKey = null;
     return undefined;
   }
   if (!API_KEY_PATTERN.test(raw)) {
     throw new Error(
-      `BLOCKRUN_API_KEY is not a valid BlockRun API key (expected brk_…). ` +
-        `Create one at ${PORTAL_KEYS_URL}, or unset BLOCKRUN_API_KEY to pay from a wallet instead.`,
+      `${origin} does not contain a valid BlockRun API key (expected brk_…). ` +
+        `Create one at ${PORTAL_KEYS_URL}, or remove it to pay from a wallet instead.`,
     );
   }
   _apiKey = raw;

--- a/test/auth-mode.test.ts
+++ b/test/auth-mode.test.ts
@@ -45,7 +45,7 @@ const wallet = await import("../src/utils/wallet.js");
 const VALID_KEY = "brk_live_H4OzmQQDX09FElTg06Gv3Wh7i6C5jIozzVH0QBW5";
 
 beforeEach(() => {
-  for (const f of [".chain", ".chain-auto", ".solana-session", ".session"]) {
+  for (const f of [".chain", ".chain-auto", ".solana-session", ".session", ".api-key"]) {
     fs.rmSync(path.join(blockrunDir, f), { force: true });
   }
   delete process.env.BLOCKRUN_API_KEY;
@@ -106,8 +106,48 @@ test("a malformed key throws instead of silently falling back to the wallet", ()
   for (const bad of ["sk-not-a-blockrun-key", "brk", "brk_live_has spaces", "hello"]) {
     process.env.BLOCKRUN_API_KEY = bad;
     auth.resetAuthCache();
-    assert.throws(() => auth.getApiKey(), /not a valid BlockRun API key/, `should reject ${bad}`);
+    assert.throws(() => auth.getApiKey(), /does not contain a valid BlockRun API key/, `should reject ${bad}`);
+    assert.throws(() => auth.getApiKey(), /BLOCKRUN_API_KEY/, "the message names where the bad key came from");
   }
+});
+
+// Carried over from PR #136. A stdio MCP server is launched by its client, and
+// several clients make setting an environment variable awkward — the wallet has
+// always had ~/.blockrun/.session for exactly that reason, and the key needs the
+// same escape hatch.
+test("a key in ~/.blockrun/.api-key is used when the env var is unset", () => {
+  fs.writeFileSync(path.join(blockrunDir, ".api-key"), `${VALID_KEY}\n`);
+  auth.resetAuthCache();
+  assert.equal(auth.getApiKey(), VALID_KEY);
+  assert.equal(auth.getAuthMode(), "api-key");
+  fs.rmSync(path.join(blockrunDir, ".api-key"), { force: true });
+});
+
+// Mirrors the wallet precedence (BLOCKRUN_WALLET_KEY outranks .session): an
+// explicitly exported key is a deliberate override and must not be shadowed by
+// whatever happens to be on disk from an earlier account.
+test("the env var outranks the file", () => {
+  const other = "brk_live_ffffffffffffffffffffffffffffffff";
+  fs.writeFileSync(path.join(blockrunDir, ".api-key"), other);
+  process.env.BLOCKRUN_API_KEY = VALID_KEY;
+  auth.resetAuthCache();
+  assert.equal(auth.getApiKey(), VALID_KEY, "the exported key wins");
+  fs.rmSync(path.join(blockrunDir, ".api-key"), { force: true });
+});
+
+test("a malformed key IN THE FILE throws, naming the file rather than the env var", () => {
+  fs.writeFileSync(path.join(blockrunDir, ".api-key"), "sk-wrong-vendor");
+  auth.resetAuthCache();
+  assert.throws(() => auth.getApiKey(), /\.api-key/, "the message must name where the bad key came from");
+  fs.rmSync(path.join(blockrunDir, ".api-key"), { force: true });
+});
+
+test("an empty .api-key file is treated as unset, not as malformed", () => {
+  fs.writeFileSync(path.join(blockrunDir, ".api-key"), "  \n");
+  auth.resetAuthCache();
+  assert.equal(auth.getApiKey(), undefined);
+  assert.equal(auth.getAuthMode(), "wallet");
+  fs.rmSync(path.join(blockrunDir, ".api-key"), { force: true });
 });
 
 test("an empty key is treated as unset, not as malformed", () => {


### PR DESCRIPTION
Salvages the two good ideas from **@KillerQueen-Z's #136** that the shipped implementation did not have, and closes that PR as superseded.

## What happened

#136 implemented account-API-key support in parallel, opened 2026-09-04 and gated on `@blockrun/llm` #36 being published. That gate lifted this morning, and 0.46.0 / 0.47.0 shipped the same feature before #136 could be rebased — so it is now unmergeable against main and its CI is red on a typecheck error plus the stale `^3.8.4` pin it was explicitly waiting to replace.

Rather than close it and lose the work, this carries over the parts it got right.

## `~/.blockrun/.api-key`

The shipped implementation read `BLOCKRUN_API_KEY` and nothing else. #136 also read a file, and that is the better call: a stdio MCP server is launched by its client, and several clients make setting an environment variable awkward or impossible — which is exactly why the wallet has always had `~/.blockrun/.session`. The key needs the same escape hatch.

Precedence is **env, then file**, mirroring `BLOCKRUN_WALLET_KEY` over `.session`: an explicitly exported key is a deliberate override and must not be shadowed by whatever is left on disk from an earlier account.

- empty or unreadable file → falls through to wallet mode, rather than taking the server down over a permissions error
- malformed key → still fails loudly, and the message now **names which source it came from**, so "invalid key" does not send someone to check an env var they never set

## `Retry-After` on 429

Surfaced instead of buried in the response body. It is the one part of a rate-limit response a caller can act on; an agent told only "rate limited" retries immediately and is refused again.

## Verification

Ran the built server against a temp `HOME` holding **only** the key file, with no environment variable set anywhere:

```
Paying with: BlockRun account API key (no wallet, no chain)

  Account:  pilot (ungated)
  Spent to date: $4.5985 (invoiced account — no prepaid ceiling)
```

Four new tests cover the file path, env-outranks-file, a malformed file naming itself, and an empty file falling through. Tests 458 → 462.

## Not carried over

#136's `accountJson` helper duplicates polling and origin-pinning that `utils/api-key-call.ts` and `utils/wallet.ts:resolveGatewayUrl` already do, with tests. Its `requirements-api-preview.txt` was a temporary note for the unpublished SDK and is obsolete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116SvLAGyzJ4SYKBvAE2DTc