### PR TITLE
fix(image): read the settled cost on the account rail instead of estimating

### DIFF
--- a/src/tools/image.ts
+++ b/src/tools/image.ts
@@ -10,6 +10,7 @@ import { launchTopUp } from "../utils/onramp.js";
 import type { BudgetState } from "../types.js";
 import { getChain, getImageClient } from "../utils/wallet.js";
 import { isApiKeyMode } from "../utils/auth.js";
+import { apiKeyPost } from "../utils/api-key-call.js";
 import { solanaPaidPost } from "../utils/solana-402.js";
 import { isBlockedFetchHostResolved } from "../utils/ssrf.js";
 import { shouldInline, buildInlineImageBlock } from "../utils/inline-image.js";
@@ -399,11 +400,46 @@ Source images and masks accept a base64 data URI, an http(s) URL, or a local fil
           // (which mirrors the live price table) is the best available figure;
           // Solana returns the real 402-quoted amount.
           let billedUsd = estimatedCost;
+          // Whether `billedUsd` is still our own guess rather than a figure the
+          // rail settled. Seeded to the previous behaviour — the Base SDK rail
+          // reports the catalog price and has always been labelled exact — so
+          // this change only affects the account rail, which is the one that can
+          // now do better.
+          let costIsEstimate = isApiKeyMode();
           // isApiKeyMode() first: on the account rail getChain() can still say
           // "solana" (it is the default for a machine with no wallet), and this
           // branch would then look for a Solana key that a key-only user has
           // never had. getImageClient() below is already API-key aware.
-          if (!isApiKeyMode() && getChain() === "solana") {
+          if (isApiKeyMode()) {
+            // ---- Account rail: one POST, exact cost from the response. ----
+            //
+            // This used to go through getImageClient(), which parses the body
+            // and drops the Response — so `x-blockrun-cost-usd` was unreadable
+            // and the tool reported its own estimate. That estimate is high by
+            // construction: estimateCost adds the $0.001 transaction fee the
+            // account rail does not charge. Verified against the gateway on
+            // 2026-09-05 — a nano-banana image settles at $0.052500 and returns
+            // both the header and `price.amount`, against a $0.0535 estimate.
+            //
+            // apiKeyPost is the same helper music, speech, video and realface
+            // already use; image was the odd one out only because an SDK client
+            // existed for it.
+            const { endpoint, body } = buildSolanaImageRequest(action, {
+              model: selectedModel,
+              prompt,
+              size,
+              quality,
+              image: normalizedImage,
+              mask: normalizedMask,
+            });
+            const r = await apiKeyPost(endpoint, body, { timeoutMs: SOLANA_IMAGE_TIMEOUT_MS });
+            // paidUsd null is "the rail settled nothing at response time", NOT
+            // "free" — fall back to the estimate and say so, never book $0.
+            billedUsd = r.paidUsd ?? estimatedCost;
+            costIsEstimate = r.paidUsd === null;
+            recordActualSpend(budget, r.paidUsd, estimatedCost, agent_id);
+            imageUrl = (r.data as { data?: Array<{ url?: string }> }).data?.[0]?.url;
+          } else if (getChain() === "solana") {
             // Solana: manual x402 against the sol.blockrun.ai gateway (the SDK's
             // ImageClient signs Base/EVM payments only). Record the ACTUAL cost
             // from the 402 quote — the Solana gateway prices carry a markup over
@@ -430,6 +466,7 @@ Source images and masks accept a base64 data URI, an http(s) URL, or a local fil
             });
             recordActualSpend(budget, paidUsd, estimatedCost, agent_id);
             billedUsd = paidUsd ?? estimatedCost;
+            costIsEstimate = paidUsd === null;
             imageUrl = (data as { data?: Array<{ url?: string }> }).data?.[0]?.url;
           } else {
             const response = action === "edit"
@@ -458,8 +495,11 @@ Source images and masks accept a base64 data URI, an http(s) URL, or a local fil
           // estimateCost adds the $0.001 transaction fee that account billing
           // does not charge. Printing that unlabelled invites someone to
           // reconcile an invoice against a number we invented.
-          const costLine = isApiKeyMode()
-            ? `Cost: ~$${billedUsd.toFixed(4)} (estimated — billed to your BlockRun account at exact usage; see https://user.blockrun.ai/dashboard/activity)`
+          // Label what the number IS, not which rail produced it. Calling a
+          // settled amount "estimated" is as misleading as the reverse, and it
+          // invites someone to discount a figure that reconciles exactly.
+          const costLine = costIsEstimate
+            ? `Cost: ~$${billedUsd.toFixed(4)} (estimated${isApiKeyMode() ? " — billed to your BlockRun account at exact usage; see https://user.blockrun.ai/dashboard/activity" : ""})`
             : `Cost: $${billedUsd.toFixed(4)}`;
           const textBlock = {
             type: "text" as const,
@@ -471,7 +511,7 @@ Source images and masks accept a base64 data URI, an http(s) URL, or a local fil
 
           return {
             content: previewBlock ? [previewBlock, textBlock] : [textBlock],
-            structuredContent: { url: delivered, prompt, model: selectedModel, cost_usd: billedUsd, cost_is_estimate: isApiKeyMode(), inlined: Boolean(previewBlock) },
+            structuredContent: { url: delivered, prompt, model: selectedModel, cost_usd: billedUsd, cost_is_estimate: costIsEstimate, inlined: Boolean(previewBlock) },
           };
         } finally {
           gate.release();

--- a/test/image-account-cost.test.ts
+++ b/test/image-account-cost.test.ts
@@ -1,0 +1,114 @@
+// Run with: npm test  (tsx --test)
+//
+// The account rail reports what the gateway SETTLED, not what we guessed.
+//
+// blockrun_image used to route the account rail through the SDK's ImageClient,
+// which parses the body and drops the Response — so `x-blockrun-cost-usd` was
+// unreadable and the tool fell back to `estimateCost`. That estimate is high by
+// construction: it adds the $0.001 transaction fee the account rail does not
+// charge. Measured against the gateway on 2026-09-05, a nano-banana image
+// settles at $0.052500 against a $0.0535 estimate.
+//
+// Two properties are pinned here, and they are the same two that make the cost
+// header safe to read at all:
+//
+//   header present → use it, and stop calling the number an estimate
+//   header ABSENT  → fall back to the estimate and keep saying so. Absent is
+//                    "nothing settled at response time", never "free": booking
+//                    $0 against a call that was genuinely billed is the failure
+//                    this whole mechanism exists to prevent.
+import { test, mock } from "node:test";
+import assert from "node:assert/strict";
+import type { BudgetState } from "../src/types.js";
+
+let lastPostedEndpoint: string | undefined;
+let settledCost: number | null = 0.0525;
+
+// Drive account mode through the env var rather than mocking auth.js: the mode
+// is derived from BLOCKRUN_API_KEY, and replacing that module wholesale drops
+// exports other modules import (onramp.ts wants PORTAL_CREDITS_URL).
+process.env.BLOCKRUN_API_KEY = "brk_live_testkeyfortestsonly0000";
+
+// The account rail helper the four hand-built tools already use. Standing in
+// for it keeps this test off the network while exercising the same seam.
+mock.module("../src/utils/api-key-call.js", {
+  namedExports: {
+    apiKeyPost: async (endpoint: string) => {
+      lastPostedEndpoint = endpoint;
+      return {
+        data: { data: [{ url: "https://blockrun.ai/media/fake.png" }] },
+        paidUsd: settledCost,
+        txHash: "credit:test",
+      };
+    },
+  },
+});
+
+mock.module("../src/utils/wallet.js", {
+  namedExports: {
+    getApiBase: () => "https://api.blockrun.ai",
+    resolveGatewayUrl: (u: string) => (u.startsWith("http") ? u : `https://api.blockrun.ai${u}`),
+    getChain: () => "solana", // account rail must win over this, not read a key
+    getImageClient: () => {
+      throw new Error("account rail must NOT go through the SDK ImageClient");
+    },
+    getOrCreateWalletKey: () => {
+      throw new Error("account rail must not touch a wallet key");
+    },
+    getWalletInfo: async () => ({ address: "0xTEST" }),
+    resolveSolanaKey: () => undefined,
+  },
+});
+
+const { registerImageTool } = await import("../src/tools/image.js");
+
+function makeHarness() {
+  let handler: ((args: Record<string, unknown>) => Promise<any>) | undefined;
+  const server = {
+    registerTool: (_name: string, _cfg: unknown, h: any) => {
+      handler = h;
+    },
+    server: { getClientCapabilities: () => ({}) },
+  } as any;
+  const budget: BudgetState = { limit: null, spent: 0, calls: 0, agents: new Map() };
+  registerImageTool(server, budget);
+  return { call: (args: Record<string, unknown>) => handler!(args), budget };
+}
+
+test("account rail reports the SETTLED cost, not the estimate", async () => {
+  settledCost = 0.0525;
+  const { call } = makeHarness();
+  const res = await call({ prompt: "a red cube", model: "google/nano-banana" });
+  const text = res.content.map((c: any) => c.text).join("\n");
+
+  // The settled figure, and NOT flagged as an estimate — calling a number that
+  // reconciles exactly "estimated" invites someone to discount it.
+  assert.match(text, /Cost: \$0\.0525/);
+  assert.doesNotMatch(text, /estimated/);
+  assert.equal(res.structuredContent.cost_usd, 0.0525);
+  assert.equal(res.structuredContent.cost_is_estimate, false);
+});
+
+test("account rail does not go through the SDK or touch a wallet", async () => {
+  // getImageClient and getOrCreateWalletKey both throw in this harness, so
+  // reaching either fails the test rather than silently working.
+  settledCost = 0.0525;
+  const { call } = makeHarness();
+  const res = await call({ prompt: "a red cube", model: "google/nano-banana" });
+  assert.equal(res.isError, undefined);
+  assert.ok(lastPostedEndpoint, "expected the account rail to POST directly");
+});
+
+test("an absent settled cost falls back to the estimate and still says so", async () => {
+  // paidUsd null means the rail settled nothing at response time. It must not
+  // be booked as $0.
+  settledCost = null;
+  const { call, budget } = makeHarness();
+  const res = await call({ prompt: "a red cube", model: "google/nano-banana" });
+  const text = res.content.map((c: any) => c.text).join("\n");
+
+  assert.match(text, /estimated/);
+  assert.equal(res.structuredContent.cost_is_estimate, true);
+  assert.ok(res.structuredContent.cost_usd > 0, "must not book a null as $0");
+  assert.ok(budget.spent > 0, "the ledger must not record zero for a billed call");
+});


### PR DESCRIPTION
`blockrun_image` was the last paid tool still routing the account rail through an SDK client. `@blockrun/llm`'s `ImageClient` parses the body and drops the `Response`, so `x-blockrun-cost-usd` was unreadable and the tool fell back to `estimateCost` — which is **high by construction**, because it adds the $0.001 transaction fee the account rail does not charge.

Music, speech, video and realface already read the settled figure via `apiKeyPost`. Image was the odd one out only because an SDK client happened to exist for it.

## Measured, not assumed

Against the live gateway on 2026-09-05:

```
POST /v1/images/generations   model=google/nano-banana
  x-blockrun-cost-usd: 0.052500
  body price: {"amount": "0.052500", "currency": "USD"}
  payment:    {"status": "settled", "network": "credit"}

  estimateCost(...) = $0.0535     ← what the tool reported before
  settled           = $0.0525     ← what the account was actually charged
```

So the header is available on this endpoint; nothing was blocking this but the SDK swallowing the response.

## What changed

- **Account rail uses `apiKeyPost`**, the same helper the other four hand-built tools use, so there is one account rail rather than two. The request body comes from the existing `buildSolanaImageRequest`, which already builds the gateway's own shape.
- **`cost_is_estimate` now reports what the number IS, not which rail produced it.** It was hardcoded to `isApiKeyMode()`, so an exact settled figure was still printed as `~$X (estimated)`. Calling a figure that reconciles to the cent an estimate invites someone to discount it.
- **`paidUsd: null` still means "nothing settled at response time", never "free"** — it falls back to the estimate and keeps saying so, rather than booking $0 against a call that was genuinely billed.

**The Base SDK rail is deliberately untouched.** It still reports the catalog price and is still labelled exactly as before. An earlier cut of this changed that label too and broke four existing tests in `image-cost.test.ts`; those tests are right that nothing about the Base path has changed, so the fix was narrowed to the rail that can actually do better.

## Tests

Three new ones in `test/image-account-cost.test.ts`: the settled case, the `null` fallback, and a harness where `getImageClient` and `getOrCreateWalletKey` both **throw** — so a regression back onto the SDK, or into a wallet key on a key-only machine, fails loudly instead of quietly working.

465 tests pass, `tsc --noEmit` clean.

## Context

Found while fixing the same class of bug in ClawRouter, which shipped in v0.12.272: media calls there were journaled at **$0** on the account rail because `amountUsd ?? estimate` does not catch a legitimate `0`. Different mechanism, same outcome — an invoice nobody can re-derive. This repo's `parseCostHeader` is already correct on that point (and credits ClawRouter's `Number("")` bug); this PR just gets image onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iCMppEJ7GHFWV7hm2RgiH